### PR TITLE
feat(ci): no clean coverage dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,6 @@ jobs:
         run: |
           cargo fmt --all -- --check
           cargo clippy -- -D warnings
-        shell: bash
 
   coverage:
     # The type of runner that the job will run on
@@ -53,8 +52,7 @@ jobs:
           cargo install cargo-tarpaulin
       - uses: Swatinem/rust-cache@v2
       - name: Coverage
-        run: cargo tarpaulin --workspace
-        shell: bash
+        run: cargo tarpaulin --workspace --skip-clean
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
Use `cargo tarpaulin` `--skip-clean` flag to use the cached dependencies from `Swatinem/rust-cache@v2` in coverage ci

# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

`cargo tarpaulin --workspace` defaults to clean the directory
https://github.com/keep-starknet-strange/madara/actions/runs/4556469374/jobs/8036859662#step:6:12

Issue Number: N/A

# What is the new behavior?

- tarpaulin uses cache

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
