### PR TITLE
Verify tx version on execute

### DIFF
--- a/crates/pallets/starknet/src/message.rs
+++ b/crates/pallets/starknet/src/message.rs
@@ -88,7 +88,7 @@ impl Message {
             caller_address: ContractAddressWrapper::default(),
         };
         Ok(Transaction {
-            version: U256::default(),
+            version: 1_u8,
             hash: H256::default(),
             signature: BoundedVec::default(),
             events: BoundedVec::default(),
@@ -133,7 +133,7 @@ mod test {
         let test_message: Message =
             Message { topics: vec![hex.clone(), hex.clone(), hex.clone(), hex.clone()], data: hex.clone() };
         let expected_tx = Transaction {
-            version: U256::default(),
+            version: 1_u8,
             hash: H256::default(),
             signature: BoundedVec::default(),
             events: BoundedVec::default(),

--- a/crates/pallets/starknet/src/tests.rs
+++ b/crates/pallets/starknet/src/tests.rs
@@ -76,6 +76,51 @@ fn given_hardcoded_contract_run_invoke_tx_fails_sender_not_deployed() {
 }
 
 #[test]
+fn given_hardcoded_contract_run_invoke_tx_fails_invalid_tx_version() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(0);
+        run_to_block(2);
+
+        let none_origin = RuntimeOrigin::none();
+
+        let contract_address_str = "02356b628D108863BAf8644c945d97bAD70190AF5957031f4852d00D0F690a77";
+        let contract_address_bytes = <[u8; 32]>::from_hex(contract_address_str).unwrap();
+
+        let class_hash_str = "025ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918";
+        let class_hash_bytes = <[u8; 32]>::from_hex(class_hash_str).unwrap();
+
+        // Example tx : https://testnet.starkscan.co/tx/0x6fc3466f58b5c6aaa6633d48702e1f2048fb96b7de25f2bde0bce64dca1d212
+        let transaction = Transaction::new(
+            0_u8,
+            H256::from_str("0x06fc3466f58b5c6aaa6633d48702e1f2048fb96b7de25f2bde0bce64dca1d212").unwrap(),
+            bounded_vec![
+                H256::from_str("0x00f513fe663ffefb9ad30058bb2d2f7477022b149a0c02fb63072468d3406168").unwrap(),
+                H256::from_str("0x02e29e92544d31c03e89ecb2005941c88c28b4803a3647a7834afda12c77f096").unwrap()
+            ],
+            bounded_vec!(),
+            contract_address_bytes,
+            U256::from(0),
+            CallEntryPointWrapper::new(
+                Some(class_hash_bytes),
+                EntryPointTypeWrapper::External,
+                None,
+                bounded_vec![
+                    H256::from_str("0x024d1e355f6b9d27a5a420c8f4b50cea9154a8e34ad30fc39d7c98d3c177d0d7").unwrap(), // Contract address
+                    H256::from_str("0x00e7def693d16806ca2a2f398d8de5951344663ba77f340ed7a958da731872fc").unwrap(), // Selector
+                    H256::from_str("0x0000000000000000000000000000000000000000000000000000000000000001").unwrap(), // Length
+                    H256::from_str("0x0000000000000000000000000000000000000000000000000000000000000019").unwrap(), // Value
+                ],
+                contract_address_bytes,
+                contract_address_bytes
+            ),
+            None,
+        );
+
+        assert_err!(Starknet::add_invoke_transaction(none_origin, transaction), Error::<Test>::TransactionExecutionFailed);
+    });
+}
+
+#[test]
 fn given_hardcoded_contract_run_invoke_tx_then_it_works() {
     new_test_ext().execute_with(|| {
         System::set_block_number(0);

--- a/crates/pallets/starknet/src/tests.rs
+++ b/crates/pallets/starknet/src/tests.rs
@@ -69,7 +69,7 @@ fn given_hardcoded_contract_run_invoke_tx_fails_sender_not_deployed() {
         let contract_address_bytes = <[u8; 32]>::from_hex(contract_address_str).unwrap();
 
         let transaction =
-            Transaction { version: U256::from(1), sender_address: contract_address_bytes, ..Transaction::default() };
+            Transaction { version: 1_u8, sender_address: contract_address_bytes, ..Transaction::default() };
 
         assert_err!(Starknet::add_invoke_transaction(none_origin, transaction), Error::<Test>::AccountNotDeployed);
     })
@@ -91,7 +91,7 @@ fn given_hardcoded_contract_run_invoke_tx_then_it_works() {
 
         // Example tx : https://testnet.starkscan.co/tx/0x6fc3466f58b5c6aaa6633d48702e1f2048fb96b7de25f2bde0bce64dca1d212
         let transaction = Transaction::new(
-            U256::from(1),
+            1_u8,
             H256::from_str("0x06fc3466f58b5c6aaa6633d48702e1f2048fb96b7de25f2bde0bce64dca1d212").unwrap(),
             bounded_vec![
                 H256::from_str("0x00f513fe663ffefb9ad30058bb2d2f7477022b149a0c02fb63072468d3406168").unwrap(),
@@ -142,7 +142,7 @@ fn given_hardcoded_contract_run_invoke_tx_then_event_is_emitted() {
 
         // Example tx : https://testnet.starkscan.co/tx/0x6fc3466f58b5c6aaa6633d48702e1f2048fb96b7de25f2bde0bce64dca1d212
         let transaction = Transaction::new(
-            U256::from(1),
+            1_u8,
             H256::from_str("0x06fc3466f58b5c6aaa6633d48702e1f2048fb96b7de25f2bde0bce64dca1d212").unwrap(),
             bounded_vec![
                 H256::from_str("0x00f513fe663ffefb9ad30058bb2d2f7477022b149a0c02fb63072468d3406168").unwrap(),
@@ -200,7 +200,7 @@ fn given_hardcoded_contract_run_deploy_account_tx_then_it_works() {
 
         // Example tx : https://testnet.starkscan.co/tx/0x6fc3466f58b5c6aaa6633d48702e1f2048fb96b7de25f2bde0bce64dca1d212
         let transaction = Transaction::new(
-            U256::from(1),
+            1_u8,
             H256::default(),
             bounded_vec!(),
             bounded_vec!(),
@@ -243,7 +243,7 @@ fn given_hardcoded_contract_run_deploy_account_tx_twice_then_it_fails() {
 
         // Example tx : https://testnet.starkscan.co/tx/0x6fc3466f58b5c6aaa6633d48702e1f2048fb96b7de25f2bde0bce64dca1d212
         let transaction = Transaction::new(
-            U256::from(1),
+            1_u8,
             H256::default(),
             bounded_vec!(),
             bounded_vec!(),
@@ -291,7 +291,7 @@ fn given_hardcoded_contract_run_deploy_account_tx_undeclared_then_it_fails() {
 
         // Example tx : https://testnet.starkscan.co/tx/0x6fc3466f58b5c6aaa6633d48702e1f2048fb96b7de25f2bde0bce64dca1d212
         let transaction = Transaction::new(
-            U256::from(1),
+            1_u8,
             H256::default(),
             bounded_vec!(),
             bounded_vec!(),
@@ -335,7 +335,7 @@ fn given_hardcoded_contract_run_declare_tx_then_it_works() {
 
         // Example tx : https://testnet.starkscan.co/tx/0x6fc3466f58b5c6aaa6633d48702e1f2048fb96b7de25f2bde0bce64dca1d212
         let transaction = Transaction::new(
-            U256::from(1),
+            1_u8,
             H256::default(),
             bounded_vec!(),
             bounded_vec!(),
@@ -378,7 +378,7 @@ fn given_hardcoded_contract_run_declare_twice_then_it_fails() {
 
         // Example tx : https://testnet.starkscan.co/tx/0x6fc3466f58b5c6aaa6633d48702e1f2048fb96b7de25f2bde0bce64dca1d212
         let transaction = Transaction::new(
-            U256::from(1),
+            1_u8,
             H256::default(),
             bounded_vec!(),
             bounded_vec!(),
@@ -425,7 +425,7 @@ fn given_hardcoded_contract_run_declare_none_then_it_fails() {
 
         // Example tx : https://testnet.starkscan.co/tx/0x6fc3466f58b5c6aaa6633d48702e1f2048fb96b7de25f2bde0bce64dca1d212
         let transaction = Transaction::new(
-            U256::from(1),
+            1_u8,
             H256::default(),
             bounded_vec!(),
             bounded_vec!(),
@@ -474,7 +474,7 @@ fn given_hardcoded_contract_run_storage_read_and_write_it_works() {
             H256::from_str("0x0000000000000000000000000000000000000000000000000000000000000001").unwrap();
 
         let transaction = Transaction::new(
-            U256::from(1),
+            1_u8,
             H256::default(),
             bounded_vec!(),
             bounded_vec!(),

--- a/crates/primitives/starknet/src/transaction/mod.rs
+++ b/crates/primitives/starknet/src/transaction/mod.rs
@@ -9,6 +9,7 @@ use blockifier::execution::contract_class::ContractClass;
 use blockifier::execution::entry_point::{CallInfo, ExecutionResources};
 use blockifier::state::cached_state::CachedState;
 use blockifier::state::state_api::StateReader;
+use blockifier::transaction::errors::TransactionExecutionError;
 use blockifier::transaction::objects::AccountTransactionContext;
 use blockifier::transaction::transactions::Executable;
 use frame_support::BoundedVec;
@@ -148,7 +149,7 @@ impl TryInto<DeployAccountTransaction> for &Transaction {
         Ok(DeployAccountTransaction {
             transaction_hash: TransactionHash(StarkFelt::new(self.hash.0)?),
             max_fee: Fee(2),
-            version: TransactionVersion(StarkFelt::new(self.version.into())?),
+            version: TransactionVersion(StarkFelt::new(U256::from(self.version).into())?),
             signature: TransactionSignature(
                 self.signature.clone().into_inner().iter().map(|x| StarkFelt::new(x.0).unwrap()).collect(),
             ),
@@ -169,7 +170,7 @@ impl TryInto<L1HandlerTransaction> for &Transaction {
     fn try_into(self) -> Result<L1HandlerTransaction, Self::Error> {
         Ok(L1HandlerTransaction {
             transaction_hash: TransactionHash(StarkFelt::new(self.hash.0)?),
-            version: TransactionVersion(StarkFelt::new(self.version.into())?),
+            version: TransactionVersion(StarkFelt::new(U256::from(self.version).into())?),
             nonce: Nonce(StarkFelt::new(self.nonce.into())?),
             contract_address: StarknetContractAddress::try_from(StarkFelt::new(self.sender_address)?)?,
             calldata: self.call_entrypoint.to_starknet_call_entry_point().calldata,
@@ -214,9 +215,9 @@ impl TryInto<DeclareTransaction> for &Transaction {
             class_hash: self.call_entrypoint.to_starknet_call_entry_point().class_hash.unwrap_or_default(),
         };
 
-        Ok(if self.version == U256::zero() {
+        Ok(if self.version == 0_u8 {
             DeclareTransaction::V0(tx)
-        } else if self.version == U256::one() {
+        } else if self.version == 1_u8 {
             DeclareTransaction::V1(tx)
         } else {
             unimplemented!("DeclareTransactionV2 required the compiled class hash. I don't know how to get it");
@@ -228,7 +229,7 @@ impl Transaction {
     /// Creates a new instance of a transaction.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        version: U256,
+        version: u8,
         hash: H256,
         signature: BoundedVec<H256, MaxArraySize>,
         events: BoundedVec<EventWrapper, MaxArraySize>,
@@ -243,6 +244,32 @@ impl Transaction {
     /// Creates a new instance of a transaction without signature.
     pub fn from_tx_hash(hash: H256) -> Self {
         Self { hash, ..Self::default() }
+    }
+
+    /// Verifies if a transaction has the correct version
+    pub fn verify_tx_version(&self, tx_type: &TxType) -> TransactionExecutionResultWrapper<()> {
+        let version = match StarkFelt::new(U256::from(self.version).into()) {
+            Ok(felt) => TransactionVersion(felt),
+            Err(err) => {
+                return Err(TransactionExecutionErrorWrapper::StarknetApi(err));
+            }
+        };
+
+        let allowed_versions: vec::Vec<TransactionVersion> = match tx_type {
+            TxType::DeclareTx => {
+                // Support old versions in order to allow bootstrapping of a new system.
+                vec![TransactionVersion(StarkFelt::from(0)), TransactionVersion(StarkFelt::from(1))]
+            }
+            _ => vec![TransactionVersion(StarkFelt::from(1))],
+        };
+        if allowed_versions.contains(&version) {
+            Ok(())
+        } else {
+            Err(TransactionExecutionErrorWrapper::TransactionExecution(TransactionExecutionError::InvalidVersion {
+                version,
+                allowed_versions,
+            }))
+        }
     }
 
     /// Executes a transaction
@@ -266,6 +293,7 @@ impl Transaction {
     ) -> TransactionExecutionResultWrapper<Option<CallInfo>> {
         let block_context = BlockContext::serialize(block.header().clone());
         let execution_resources = &mut ExecutionResources::default();
+        self.verify_tx_version(&tx_type)?;
 
         match tx_type {
             TxType::InvokeTx => {
@@ -402,7 +430,7 @@ impl Default for Transaction {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
         ]);
         Self {
-            version: U256::default(),
+            version: 1_u8,
             hash: one,
             signature: BoundedVec::try_from(vec![one, one]).unwrap(),
             events: BoundedVec::try_from(vec![EventWrapper::default(), EventWrapper::default()]).unwrap(),

--- a/crates/primitives/starknet/src/transaction/mod.rs
+++ b/crates/primitives/starknet/src/transaction/mod.rs
@@ -247,6 +247,15 @@ impl Transaction {
     }
 
     /// Verifies if a transaction has the correct version
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The transaction to execute
+    /// * `tx_type` - The type of the transaction to execute
+    ///
+    /// # Returns
+    ///
+    /// * `TransactionExecutionResultWrapper<()>` - The result of the transaction version validation
     pub fn verify_tx_version(&self, tx_type: &TxType) -> TransactionExecutionResultWrapper<()> {
         let version = match StarkFelt::new(U256::from(self.version).into()) {
             Ok(felt) => TransactionVersion(felt),

--- a/crates/primitives/starknet/src/transaction/types.rs
+++ b/crates/primitives/starknet/src/transaction/types.rs
@@ -46,7 +46,7 @@ pub enum TxType {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct Transaction {
     /// The version of the transaction.
-    pub version: U256,
+    pub version: u8,
     /// Transaction hash.
     pub hash: H256,
     /// Signature.

--- a/crates/primitives/starknet/tests/crypto.rs
+++ b/crates/primitives/starknet/tests/crypto.rs
@@ -14,7 +14,7 @@ use starknet_crypto::FieldElement;
 fn test_merkle_tree() {
     let txs = vec![
         Transaction {
-            version: U256::zero(),
+            version: 0_u8,
             hash: H256::from_low_u64_be(6),
             signature: bounded_vec![H256::from_low_u64_be(10), H256::from_low_u64_be(20), H256::from_low_u64_be(30)],
             events: bounded_vec![EventWrapper::default(), EventWrapper::default()],
@@ -24,7 +24,7 @@ fn test_merkle_tree() {
             contract_class: None,
         },
         Transaction {
-            version: U256::zero(),
+            version: 0_u8,
             hash: H256::from_low_u64_be(28),
             signature: bounded_vec![H256::from_low_u64_be(40)],
             events: bounded_vec![],

--- a/crates/primitives/starknet/tests/transaction.rs
+++ b/crates/primitives/starknet/tests/transaction.rs
@@ -1,0 +1,36 @@
+use frame_support::bounded_vec;
+use mp_starknet::execution::CallEntryPointWrapper;
+use mp_starknet::transaction::types::{EventWrapper, Transaction, TxType};
+use sp_core::{H256, U256};
+
+#[test]
+fn verify_tx_version_passes_for_valid_version() {
+    let tx = Transaction {
+        version: 1_u8,
+        hash: H256::from_low_u64_be(6),
+        signature: bounded_vec![H256::from_low_u64_be(10), H256::from_low_u64_be(20), H256::from_low_u64_be(30)],
+        events: bounded_vec![EventWrapper::default(), EventWrapper::default()],
+        sender_address: [0; 32],
+        nonce: U256::zero(),
+        call_entrypoint: CallEntryPointWrapper::default(),
+        contract_class: None,
+    };
+
+    assert!(tx.verify_tx_version(&TxType::InvokeTx).is_ok())
+}
+
+#[test]
+fn verify_tx_version_fails_for_invalid_version() {
+    let tx = Transaction {
+        version: 0_u8,
+        hash: H256::from_low_u64_be(6),
+        signature: bounded_vec![H256::from_low_u64_be(10), H256::from_low_u64_be(20), H256::from_low_u64_be(30)],
+        events: bounded_vec![EventWrapper::default(), EventWrapper::default()],
+        sender_address: [0; 32],
+        nonce: U256::zero(),
+        call_entrypoint: CallEntryPointWrapper::default(),
+        contract_class: None,
+    };
+
+    assert!(tx.verify_tx_version(&TxType::InvokeTx).is_err())
+}


### PR DESCRIPTION
# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

The current `execute` method doesn't check if the transaction version being passed is valid or not.
`Transaction.version` uses a `U256` as the type.

Issue Number: #127 

# What is the new behavior?

This PR adds a transaction version validation similar to what happens in the [blockifier](https://github.com/tdelabro/blockifier/blob/no_std-support/crates/blockifier/src/transaction/account_transaction.rs#L100).
It also replaces the usage of `U256` for the version type in the `Transaction` struct to be an `u8`, as specified in the issue.

Existing tests were updated, and new ones were added.

# Does this introduce a breaking change?

- [ ] Yes
- [X] No


# Other information
