### PR TITLE
infra: fix docker-compose volume path

### DIFF
--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       - CARGO_HOME=/var/www/madara/.cargo
     volumes:
-      - .:/var/www/madara
+      - ../../:/var/www/madara
       - type: bind
         source: ./.local
         target: /root/.local


### PR DESCRIPTION
Relative paths in a docker-compose file are relative to the location of the `docker-compose.yml` file.

For this reason, if the relative path is not the madara root, an error occurs at the docker start saying that the `Cargo.toml` file can't be found.

<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [X] Other (please describe): related to docker (infra)

# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If the `docker-compose` command is used with the current `docker-compose.yml` file, there is an error
as the `Cargo.toml` file can't be found.

Issue Number: N/A

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
Docker container starts correctly as the whole madara repo is correctly added to the mounted volume.

# Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
