### PR TITLE
Push whole block to digest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4247,10 +4247,12 @@ dependencies = [
  "mc-db",
  "mc-storage",
  "mp-digest-log",
+ "mp-starknet",
  "pallet-starknet",
  "sc-client-api",
  "sp-api",
  "sp-blockchain",
+ "sp-core 7.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40)",
  "sp-runtime",
 ]
 
@@ -4437,7 +4439,6 @@ version = "0.1.0-dev"
 dependencies = [
  "mp-starknet",
  "parity-scale-codec",
- "sp-core 7.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40)",
  "sp-runtime",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4282,6 +4282,7 @@ version = "0.1.0"
 dependencies = [
  "jsonrpsee",
  "serde",
+ "serde_json",
  "sp-blockchain",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4437,6 +4437,7 @@ dependencies = [
 name = "mp-digest-log"
 version = "0.1.0-dev"
 dependencies = [
+ "assert_matches",
  "mp-starknet",
  "parity-scale-codec",
  "sp-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,3 +132,4 @@ futures = { version = "0.3.28", default-features = false }
 serde = { version = "1.0.160", default-features = false }
 serde_json = { version = "1.0.96", default-features = false }
 bitvec = { version = "0.17.4", default-features = false }
+thiserror = "1.0.40"

--- a/crates/client/mapping-sync/Cargo.toml
+++ b/crates/client/mapping-sync/Cargo.toml
@@ -18,9 +18,11 @@ futures-timer = "3.0.2"
 log = { workspace = true, default-features = true }
 sc-client-api = { workspace = true }
 sp-api = { workspace = true }
+sp-core = { workspace = true }
 sp-blockchain = { workspace = true }
 sp-runtime = { workspace = true }
 mp-digest-log = { workspace = true }
 mc-storage = { workspace = true }
 mc-db = { workspace = true }
+mp-starknet = { workspace = true }
 pallet-starknet = { workspace = true }

--- a/crates/client/rpc-core/Cargo.toml
+++ b/crates/client/rpc-core/Cargo.toml
@@ -19,3 +19,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 jsonrpsee = { workspace = true, features = ["server"], default-features = true }
 sp-blockchain = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/client/rpc-core/src/lib.rs
+++ b/crates/client/rpc-core/src/lib.rs
@@ -4,6 +4,9 @@
 //! using the openRPC specification.
 //! This crate uses `jsonrpsee` to define such an API in Rust terms.
 
+#[cfg(test)]
+mod tests;
+
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use serde::{Deserialize, Serialize};
@@ -37,53 +40,57 @@ pub struct FunctionCall {
 
 // In order to mix tagged and untagged {de}serialization for BlockId (see starknet RPC standard)
 // in the same object, we need this kind of workaround with intermediate types
+mod block_id {
+    use super::*;
 
-#[derive(Serialize, Deserialize)]
-enum BlockIdTagged {
-    #[serde(rename = "block_hash")]
-    BlockHash(BlockHash),
-    #[serde(rename = "block_number")]
-    BlockNumber(BlockNumber),
-}
+    #[derive(Serialize, Deserialize, Clone)]
+    enum BlockIdTaggedVariants {
+        #[serde(rename = "block_hash")]
+        BlockHash(BlockHash),
+        #[serde(rename = "block_number")]
+        BlockNumber(BlockNumber),
+    }
 
-#[derive(Serialize, Deserialize)]
-#[serde(untagged)]
-enum BlockIdUntagged {
-    Tagged(BlockIdTagged),
-    BlockTag(BlockTag),
-}
+    #[derive(Serialize, Deserialize, Clone)]
+    #[serde(untagged)]
+    enum BlockIdUntagged {
+        Tagged(BlockIdTaggedVariants),
+        BlockTag(BlockTag),
+    }
 
-/// A block hash, number or tag
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-#[serde(from = "BlockIdUntagged")]
-#[serde(into = "BlockIdUntagged")]
-pub enum BlockId {
-    BlockHash(BlockHash),
-    BlockNumber(BlockNumber),
-    BlockTag(BlockTag),
-}
+    /// A block hash, number or tag
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+    #[serde(from = "BlockIdUntagged")]
+    #[serde(into = "BlockIdUntagged")]
+    pub enum BlockId {
+        BlockHash(BlockHash),
+        BlockNumber(BlockNumber),
+        BlockTag(BlockTag),
+    }
 
-impl From<BlockIdUntagged> for BlockId {
-    fn from(value: BlockIdUntagged) -> Self {
-        match value {
-            BlockIdUntagged::Tagged(v) => match v {
-                BlockIdTagged::BlockHash(h) => Self::BlockHash(h),
-                BlockIdTagged::BlockNumber(n) => Self::BlockNumber(n),
-            },
-            BlockIdUntagged::BlockTag(t) => Self::BlockTag(t),
+    impl From<BlockIdUntagged> for BlockId {
+        fn from(value: BlockIdUntagged) -> Self {
+            match value {
+                BlockIdUntagged::Tagged(v) => match v {
+                    BlockIdTaggedVariants::BlockHash(h) => Self::BlockHash(h),
+                    BlockIdTaggedVariants::BlockNumber(n) => Self::BlockNumber(n),
+                },
+                BlockIdUntagged::BlockTag(t) => Self::BlockTag(t),
+            }
+        }
+    }
+
+    impl From<BlockId> for BlockIdUntagged {
+        fn from(value: BlockId) -> Self {
+            match value {
+                BlockId::BlockHash(h) => Self::Tagged(BlockIdTaggedVariants::BlockHash(h)),
+                BlockId::BlockNumber(n) => Self::Tagged(BlockIdTaggedVariants::BlockNumber(n)),
+                BlockId::BlockTag(t) => Self::BlockTag(t),
+            }
         }
     }
 }
-
-impl From<BlockId> for BlockIdUntagged {
-    fn from(value: BlockId) -> Self {
-        match value {
-            BlockId::BlockHash(h) => Self::Tagged(BlockIdTagged::BlockHash(h)),
-            BlockId::BlockNumber(n) => Self::Tagged(BlockIdTagged::BlockNumber(n)),
-            BlockId::BlockTag(t) => Self::BlockTag(t),
-        }
-    }
-}
+pub use block_id::BlockId;
 
 /// Starknet rpc interface.
 #[rpc(server, namespace = "starknet")]

--- a/crates/client/rpc-core/src/lib.rs
+++ b/crates/client/rpc-core/src/lib.rs
@@ -18,8 +18,10 @@ pub type BlockHash = FieldElement;
 /// A tag specifying a dynamic reference to a block
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum BlockTag {
+    /// The latest accepted block
     #[serde(rename = "latest")]
     Latest,
+    /// The current pending block
     #[serde(rename = "pending")]
     Pending,
 }

--- a/crates/client/rpc-core/src/lib.rs
+++ b/crates/client/rpc-core/src/lib.rs
@@ -35,15 +35,54 @@ pub struct FunctionCall {
     pub calldata: Vec<FieldElement>,
 }
 
-/// A block hash, number or tag
-/// TODO: fix block_tag
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-pub enum BlockId {
+// In order to mix tagged and untagged {de}serialization for BlockId (see starknet RPC standard)
+// in the same object, we need this kind of workaround with intermediate types
+
+#[derive(Serialize, Deserialize)]
+enum BlockIdTagged {
     #[serde(rename = "block_hash")]
     BlockHash(BlockHash),
     #[serde(rename = "block_number")]
     BlockNumber(BlockNumber),
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+enum BlockIdUntagged {
+    Tagged(BlockIdTagged),
     BlockTag(BlockTag),
+}
+
+/// A block hash, number or tag
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(from = "BlockIdUntagged")]
+#[serde(into = "BlockIdUntagged")]
+pub enum BlockId {
+    BlockHash(BlockHash),
+    BlockNumber(BlockNumber),
+    BlockTag(BlockTag),
+}
+
+impl From<BlockIdUntagged> for BlockId {
+    fn from(value: BlockIdUntagged) -> Self {
+        match value {
+            BlockIdUntagged::Tagged(v) => match v {
+                BlockIdTagged::BlockHash(h) => Self::BlockHash(h),
+                BlockIdTagged::BlockNumber(n) => Self::BlockNumber(n),
+            },
+            BlockIdUntagged::BlockTag(t) => Self::BlockTag(t),
+        }
+    }
+}
+
+impl From<BlockId> for BlockIdUntagged {
+    fn from(value: BlockId) -> Self {
+        match value {
+            BlockId::BlockHash(h) => Self::Tagged(BlockIdTagged::BlockHash(h)),
+            BlockId::BlockNumber(n) => Self::Tagged(BlockIdTagged::BlockNumber(n)),
+            BlockId::BlockTag(t) => Self::BlockTag(t),
+        }
+    }
 }
 
 /// Starknet rpc interface.

--- a/crates/client/rpc-core/src/tests.rs
+++ b/crates/client/rpc-core/src/tests.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+#[test]
+fn block_id_serialization() {
+    assert_eq!(serde_json::to_value(BlockId::BlockNumber(42)).unwrap(), serde_json::json!({"block_number": 42}));
+    assert_eq!(
+        serde_json::to_value(BlockId::BlockHash("0x42".to_string())).unwrap(),
+        serde_json::json!({"block_hash": "0x42"})
+    );
+    assert_eq!(serde_json::to_value(BlockId::BlockTag(BlockTag::Latest)).unwrap(), "latest");
+    assert_eq!(serde_json::to_value(BlockId::BlockTag(BlockTag::Pending)).unwrap(), "pending");
+}
+
+#[test]
+fn block_id_deserialization() {
+    #[derive(Serialize, Deserialize)]
+    struct Payload {
+        #[serde(rename = "block_id")]
+        block_id: BlockId,
+    }
+
+    assert_eq!(
+        serde_json::from_str::<Payload>("{ \"block_id\": \"latest\" }").unwrap().block_id,
+        BlockId::BlockTag(BlockTag::Latest)
+    );
+    assert_eq!(
+        serde_json::from_str::<Payload>("{ \"block_id\": \"pending\" }").unwrap().block_id,
+        BlockId::BlockTag(BlockTag::Pending)
+    );
+    assert_eq!(
+        serde_json::from_str::<Payload>("{ \"block_id\": { \"block_hash\": \"0x42\"} }").unwrap().block_id,
+        BlockId::BlockHash("0x42".to_string())
+    );
+    assert_eq!(
+        serde_json::from_str::<Payload>("{ \"block_id\": { \"block_number\": 42} }").unwrap().block_id,
+        BlockId::BlockNumber(42)
+    );
+}

--- a/crates/client/rpc/Cargo.toml
+++ b/crates/client/rpc/Cargo.toml
@@ -31,7 +31,10 @@ sp-blockchain = { workspace = true, default-features = true }
 # Substrate client
 sc-client-api = { workspace = true, default-features = true }
 # Others
-jsonrpsee = { workspace = true, default-features = true, features = ["server", "macros"] }
-thiserror = "1.0.40"
+jsonrpsee = { workspace = true, default-features = true, features = [
+	"server",
+	"macros",
+] }
+thiserror = { workspace = true }
 log = { workspace = true, default-features = true }
 hex = { workspace = true, default-features = true }

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -107,7 +107,7 @@ pub mod pallet {
     use frame_support::sp_runtime::offchain::storage::StorageValueRef;
     use frame_support::traits::{OriginTrait, Time};
     use frame_system::pallet_prelude::*;
-    use mp_digest_log::{PostLog, MADARA_ENGINE_ID};
+    use mp_digest_log::MADARA_ENGINE_ID;
     use mp_starknet::block::{Block as StarknetBlock, BlockTransactions, Header as StarknetHeader, MaxTransactions};
     use mp_starknet::crypto::commitment;
     use mp_starknet::crypto::hash::pedersen::PedersenHasher;
@@ -786,7 +786,7 @@ pub mod pallet {
             Pending::<T>::kill();
             PendingEvents::<T>::kill();
 
-            let digest = DigestItem::Consensus(MADARA_ENGINE_ID, PostLog::BlockHash(block.header().hash()).encode());
+            let digest = DigestItem::Consensus(MADARA_ENGINE_ID, mp_digest_log::Log::Block(block).encode());
             frame_system::Pallet::<T>::deposit_log(digest);
         }
 

--- a/crates/primitives/digest-log/Cargo.toml
+++ b/crates/primitives/digest-log/Cargo.toml
@@ -13,6 +13,9 @@ scale-codec = { package = "parity-scale-codec", workspace = true, default-featur
 # Substrate
 sp-runtime = { workspace = true }
 
+[dev-dependencies]
+assert_matches = "1.5.0"
+
 [features]
 default = ["std"]
 std = ["mp-starknet/std", "scale-codec/std", "sp-runtime/std"]

--- a/crates/primitives/digest-log/Cargo.toml
+++ b/crates/primitives/digest-log/Cargo.toml
@@ -11,9 +11,8 @@ repository = { workspace = true }
 mp-starknet = { workspace = true }
 scale-codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 # Substrate
-sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]
-std = ["mp-starknet/std", "scale-codec/std", "sp-core/std", "sp-runtime/std"]
+std = ["mp-starknet/std", "scale-codec/std", "sp-runtime/std"]

--- a/crates/primitives/digest-log/src/error.rs
+++ b/crates/primitives/digest-log/src/error.rs
@@ -1,0 +1,21 @@
+/// Error that may occur while searching a Madara [Log] in the [Digest]
+///
+/// As for now only one single Madara [Log] is expected per [Digest].
+/// No more, no less.
+#[derive(Clone, Debug)]
+pub enum FindLogError {
+    NotLog,
+    MultipleLogs,
+}
+
+impl core::fmt::Display for FindLogError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            FindLogError::NotLog => write!(f, "Madara log not found"),
+            FindLogError::MultipleLogs => write!(f, "Multiple Madara logs found"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for FindLogError {}

--- a/crates/primitives/digest-log/src/error.rs
+++ b/crates/primitives/digest-log/src/error.rs
@@ -4,7 +4,9 @@
 /// No more, no less.
 #[derive(Clone, Debug)]
 pub enum FindLogError {
+    /// There was no Madara [Log] in the [Digest]
     NotLog,
+    /// There was multiple Madara [Log] in the [Digest]
     MultipleLogs,
 }
 

--- a/crates/primitives/digest-log/src/lib.rs
+++ b/crates/primitives/digest-log/src/lib.rs
@@ -1,19 +1,15 @@
-// SPDX-License-Identifier: Apache-2.0
-// This file is part of Frontier.
-//
-// Copyright (c) 2020-2022 Parity Technologies (UK) Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+//! Utility to read the Starknet block form the Substrate block digest
+//!
+//! Following the wrapper block model, each one of the madara block contains a starknet block.
+//! This block is not only stored in the chain storage, but also pushed inton the wrapper block
+//! itself.
+//!
+//! We expect the starknet pallet to push a log into the substrate digest in it's `on_finalize`
+//! hook. This log must contain the whole new starknet block.
+//!
+//! In the current state of this crate, only one single log must be pushed to the digest each block,
+//! and it should contain the starknet block. Pushing more log will make it impossible for this set
+//! of reader functions to operate properly.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::large_enum_variant)]
@@ -21,34 +17,14 @@
 
 use mp_starknet::block::Block as StarknetBlock;
 use scale_codec::{Decode, Encode};
-use sp_core::H256;
 use sp_runtime::generic::{Digest, OpaqueDigestItemId};
 use sp_runtime::ConsensusEngineId;
 
 pub const MADARA_ENGINE_ID: ConsensusEngineId = [b'm', b'a', b'd', b'a'];
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Encode, Decode)]
 pub enum Log {
-    Post(PostLog),
-}
-
-#[derive(Decode, Encode, Clone, PartialEq, Eq)]
-pub enum PostLog {
-    /// Ethereum block hash.
-    #[codec(index = 3)]
-    BlockHash(H256),
-}
-
-#[derive(Decode, Encode, Clone, PartialEq, Eq)]
-pub struct Hashes {
-    /// Starknet block hash.
-    pub block_hash: H256,
-}
-
-impl Hashes {
-    pub fn from_block(block: StarknetBlock) -> Self {
-        Hashes { block_hash: block.header().hash() }
-    }
+    Block(StarknetBlock),
 }
 
 #[derive(Clone, Debug)]
@@ -57,8 +33,18 @@ pub enum FindLogError {
     MultipleLogs,
 }
 
-pub fn find_post_log(digest: &Digest) -> Result<PostLog, FindLogError> {
+pub fn find_starknet_block(digest: &Digest) -> Result<StarknetBlock, FindLogError> {
+    find_log(digest).map(|log| match log {
+        Log::Block(b) => b,
+    })
+}
+
+pub fn find_log(digest: &Digest) -> Result<Log, FindLogError> {
     _find_log(digest, OpaqueDigestItemId::Consensus(&MADARA_ENGINE_ID))
+}
+
+pub fn ensure_log(digest: &Digest) -> Result<(), FindLogError> {
+    find_log(digest).map(|_log| ())
 }
 
 fn _find_log<Log: Decode>(digest: &Digest, digest_item_id: OpaqueDigestItemId) -> Result<Log, FindLogError> {
@@ -74,23 +60,4 @@ fn _find_log<Log: Decode>(digest: &Digest, digest_item_id: OpaqueDigestItemId) -
     }
 
     found.ok_or(FindLogError::NotFound)
-}
-
-pub fn find_log(digest: &Digest) -> Result<Log, FindLogError> {
-    let mut found = None;
-
-    for log in digest.logs() {
-        let post_log = log.try_to::<PostLog>(OpaqueDigestItemId::Consensus(&MADARA_ENGINE_ID));
-        match (post_log, found.is_some()) {
-            (Some(_), true) => return Err(FindLogError::MultipleLogs),
-            (Some(post_log), false) => found = Some(Log::Post(post_log)),
-            (None, _) => (),
-        }
-    }
-
-    found.ok_or(FindLogError::NotFound)
-}
-
-pub fn ensure_log(digest: &Digest) -> Result<(), FindLogError> {
-    find_log(digest).map(|_log| ())
 }

--- a/crates/primitives/digest-log/src/lib.rs
+++ b/crates/primitives/digest-log/src/lib.rs
@@ -37,21 +37,22 @@ pub enum Log {
     Block(StarknetBlock),
 }
 
-/// Return the wrapped [StarknetBlock] contained in the [Digest]
+/// Return the wrapped [StarknetBlock] contained in a given [Digest]
 pub fn find_starknet_block(digest: &Digest) -> Result<StarknetBlock, FindLogError> {
     find_log(digest).map(|log| match log {
         Log::Block(b) => b,
     })
 }
 
-/// Return the Madara [Log]
+/// Return the Madara [Log] contained in a given [Digest]
 pub fn find_log(digest: &Digest) -> Result<Log, FindLogError> {
     _find_log(digest, OpaqueDigestItemId::Consensus(&MADARA_ENGINE_ID))
 }
 
-/// Ensure there is a single valid Madara [Log] in the Digest
+/// Ensure there is a single valid Madara [Log] in a given [Digest]
 ///
 /// It can be used to check if the wrapper block does contains the wrapped block
+/// without reading the wrapped block itself
 pub fn ensure_log(digest: &Digest) -> Result<(), FindLogError> {
     find_log(digest).map(|_log| ())
 }

--- a/crates/primitives/digest-log/src/tests.rs
+++ b/crates/primitives/digest-log/src/tests.rs
@@ -38,11 +38,11 @@ fn no_logs() {
 }
 
 #[test]
-fn wrong_consensus_engine_id() {
+fn other_consensus_engine_id() {
     let mut digest = Digest::default();
     let block = StarknetBlock::default();
 
-    digest.push(DigestItem::Consensus([b'f', b'a', b'k', b'e'], Log::Block(block).encode()));
+    digest.push(DigestItem::Consensus([b'o', b't', b'h', b'r'], Log::Block(block).encode()));
 
     assert_matches!(ensure_log(&digest), Err(FindLogError::NotLog));
     assert_matches!(find_log(&digest), Err(FindLogError::NotLog));

--- a/crates/primitives/digest-log/src/tests.rs
+++ b/crates/primitives/digest-log/src/tests.rs
@@ -1,4 +1,3 @@
-
 use assert_matches::assert_matches;
 use sp_runtime::{Digest, DigestItem};
 
@@ -22,7 +21,7 @@ fn multiple_logs() {
     let block = StarknetBlock::default();
 
     digest.push(DigestItem::Consensus(MADARA_ENGINE_ID, Log::Block(block.clone()).encode()));
-    digest.push(DigestItem::Consensus(MADARA_ENGINE_ID, Log::Block(block.clone()).encode()));
+    digest.push(DigestItem::Consensus(MADARA_ENGINE_ID, Log::Block(block).encode()));
 
     assert_matches!(ensure_log(&digest), Err(FindLogError::MultipleLogs));
     assert_matches!(find_log(&digest), Err(FindLogError::MultipleLogs));
@@ -43,7 +42,7 @@ fn wrong_consensus_engine_id() {
     let mut digest = Digest::default();
     let block = StarknetBlock::default();
 
-    digest.push(DigestItem::Consensus([b'f', b'a', b'k', b'e'], Log::Block(block.clone()).encode()));
+    digest.push(DigestItem::Consensus([b'f', b'a', b'k', b'e'], Log::Block(block).encode()));
 
     assert_matches!(ensure_log(&digest), Err(FindLogError::NotLog));
     assert_matches!(find_log(&digest), Err(FindLogError::NotLog));

--- a/crates/primitives/digest-log/src/tests.rs
+++ b/crates/primitives/digest-log/src/tests.rs
@@ -1,0 +1,51 @@
+
+use assert_matches::assert_matches;
+use sp_runtime::{Digest, DigestItem};
+
+use super::*;
+
+#[test]
+fn log_is_found() {
+    let mut digest = Digest::default();
+    let block = StarknetBlock::default();
+
+    digest.push(DigestItem::Consensus(MADARA_ENGINE_ID, Log::Block(block.clone()).encode()));
+
+    assert!(ensure_log(&digest).is_ok());
+    assert_eq!(find_log(&digest).unwrap(), Log::Block(block.clone()));
+    assert_eq!(find_starknet_block(&digest).unwrap(), block);
+}
+
+#[test]
+fn multiple_logs() {
+    let mut digest = Digest::default();
+    let block = StarknetBlock::default();
+
+    digest.push(DigestItem::Consensus(MADARA_ENGINE_ID, Log::Block(block.clone()).encode()));
+    digest.push(DigestItem::Consensus(MADARA_ENGINE_ID, Log::Block(block.clone()).encode()));
+
+    assert_matches!(ensure_log(&digest), Err(FindLogError::MultipleLogs));
+    assert_matches!(find_log(&digest), Err(FindLogError::MultipleLogs));
+    assert_matches!(find_starknet_block(&digest), Err(FindLogError::MultipleLogs));
+}
+
+#[test]
+fn no_logs() {
+    let digest = Digest::default();
+
+    assert_matches!(ensure_log(&digest), Err(FindLogError::NotLog));
+    assert_matches!(find_log(&digest), Err(FindLogError::NotLog));
+    assert_matches!(find_starknet_block(&digest), Err(FindLogError::NotLog));
+}
+
+#[test]
+fn wrong_consensus_engine_id() {
+    let mut digest = Digest::default();
+    let block = StarknetBlock::default();
+
+    digest.push(DigestItem::Consensus([b'f', b'a', b'k', b'e'], Log::Block(block.clone()).encode()));
+
+    assert_matches!(ensure_log(&digest), Err(FindLogError::NotLog));
+    assert_matches!(find_log(&digest), Err(FindLogError::NotLog));
+    assert_matches!(find_starknet_block(&digest), Err(FindLogError::NotLog));
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature


# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Only the starknet block hash was present in the substrate block digest

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- the whole starknet block is now pushed into the substrate block digest
- the `block_tag` variant of the `BlockId` rpc symbol is now serialized in snake_case

# Does this introduce a breaking change?

- [x] Yes
- [ ] No
