### PR TITLE
Add node version in package.json

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -47,6 +47,10 @@
         "ts-node": "^10.9.1",
         "typescript": "^4.9.3",
         "web3": "^1.8.2"
+      },
+      "engines": {
+        "node": ">=20",
+        "npm": ">=9.6.5"
       }
     },
     "node_modules/@acala-network/type-definitions": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "engines": {
+    "node": ">=20",
+    "npm": ">=9.6.5"
+  },
   "type": "commonjs",
   "watch": {
     "build": {


### PR DESCRIPTION
# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

The `package.json` for the tests doesn't specify any required version for node. However, with node 16 the "latest" version tag was not supported

# What is the new behavior?

Add `engine: node >= 18` in package.json

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

# Other information
