### PR TITLE
Remove checkboxes from issue and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/02_FEATURE_REQUEST.md
@@ -31,5 +31,4 @@ assignees: ""
 **If the feature request is approved, would you be willing to submit a PR?**
 _(Help can be provided if you need assistance submitting a PR)_
 
-- [ ] Yes
-- [ ] No
+<!-- Yes or  No -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 <!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->
 
-Please keep only the types of change your PR introduces:
+Please add the labels corresponding to the type of changes your PR introduces:
 
 - Bugfix
 - Feature

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,22 +4,22 @@
 
 <!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->
 
-Please check the type of change your PR introduces:
+Please keep only the types of change your PR introduces:
 
-- [ ] Bugfix
-- [ ] Feature
-- [ ] Code style update (formatting, renaming)
-- [ ] Refactoring (no functional changes, no API changes)
-- [ ] Build-related changes
-- [ ] Documentation content changes
-- [ ] Testing
-- [ ] Other (please describe):
+- Bugfix
+- Feature
+- Code style update (formatting, renaming)
+- Refactoring (no functional changes, no API changes)
+- Build-related changes
+- Documentation content changes
+- Testing
+- Other (please describe):
 
 # What is the current behavior?
 
 <!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
 
-Issue Number: N/A
+Resolves: #NA
 
 # What is the new behavior?
 
@@ -31,9 +31,7 @@ Issue Number: N/A
 
 # Does this introduce a breaking change?
 
-- [ ] Yes
-- [ ] No
-
+<!-- Yes or No -->
 <!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
 
 # Other information


### PR DESCRIPTION
# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [x] Other (please describe): github template

# What is the current behavior?

The feature request template and the pull request template use checkboxes (`[ ]`) to help the dev choose in between several categories of issues/update, etc.

However, the `[ ]` is interpreted by GitHub as a task list and GitHub consequently considers that issues and PR have partial tasks execution.

# What is the new behavior?

Updated the comments to make the dev choose differently.

# Does this introduce a breaking change?

No

# Other information

I have also renamed "Issue number" into "Resolves" as this is a special keywords used by github to link issues and PR