### PR TITLE
fix: fix get_class_at

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4415,6 +4415,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
+ "blockifier",
  "flate2",
  "frame-support",
  "hex",

--- a/crates/client/rpc-core/Cargo.toml
+++ b/crates/client/rpc-core/Cargo.toml
@@ -27,3 +27,5 @@ serde_json = { workspace = true }
 sp-blockchain = { workspace = true, default-features = true }
 starknet_api = { workspace = true, default-features = false }
 frame-support = { workspace = true }
+blockifier = { workspace = true, default-features = false, features = ["testing"]}
+

--- a/crates/client/rpc-core/src/lib.rs
+++ b/crates/client/rpc-core/src/lib.rs
@@ -12,13 +12,15 @@ use std::collections::{BTreeMap, HashMap};
 use anyhow::Result;
 use base64::engine::general_purpose;
 use base64::Engine;
+use blockifier::execution::contract_class::ContractClass;
 use frame_support::storage::bounded_vec::BoundedVec;
 use hex::ToHex;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
-use mp_starknet::execution::types::{ContractClassWrapper, EntryPointTypeWrapper, EntryPointWrapper, MaxEntryPoints};
+use mp_starknet::execution::types::{
+    ContractClassFromWrapperError, ContractClassWrapper, EntryPointTypeWrapper, EntryPointWrapper, MaxEntryPoints,
+};
 use serde::{Deserialize, Serialize};
-
 pub type FieldElement = String;
 pub type BlockNumber = u64;
 pub type BlockHash = FieldElement;
@@ -254,6 +256,31 @@ pub struct SierraContractClass {
     pub entry_points_by_type: EntryPointsByType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub abi: Option<ABI>,
+}
+
+// Conversion from ContractClassWrapper to SierraContractClass.
+impl TryFrom<ContractClassWrapper> for SierraContractClass {
+    type Error = ContractClassFromWrapperError;
+
+    fn try_from(wrapper: ContractClassWrapper) -> Result<Self, Self::Error> {
+        // Convert ContractClassWrapper to ContractClass.
+        let contract_class: ContractClass = ContractClass::try_from(wrapper)?;
+
+        // Extract the Sierra program from the ContractClass program.
+        // let sierra_program = contract_class.program.into_iter().map(|fe| fe.to_string()).collect();
+        let sierra_program = todo!();
+
+        // Convert entry_points_by_type from ContractClass to EntryPointsByType.
+        let mut entry_points_by_type = EntryPointsByType::default();
+
+        // Create a SierraContractClass.
+        Ok(Self {
+            sierra_program,
+            contract_class_version: "1.0.0".to_string(), // You can replace this with the appropriate version number.
+            entry_points_by_type,
+            abi: None, // Populate this field if ABI is available.
+        })
+    }
 }
 
 /// Starknet contract class

--- a/crates/client/rpc-core/src/lib.rs
+++ b/crates/client/rpc-core/src/lib.rs
@@ -263,14 +263,10 @@ impl TryFrom<ContractClassWrapper> for SierraContractClass {
     type Error = ContractClassFromWrapperError;
 
     fn try_from(wrapper: ContractClassWrapper) -> Result<Self, Self::Error> {
-        // Convert ContractClassWrapper to ContractClass.
-        let contract_class: ContractClass = ContractClass::try_from(wrapper)?;
-
-        // Extract the Sierra program from the ContractClass program.
-        // let sierra_program = contract_class.program.into_iter().map(|fe| fe.to_string()).collect();
+        // Extract the Sierra program from the ContractClassWrapper program.
         let sierra_program = todo!();
 
-        // Convert entry_points_by_type from ContractClass to EntryPointsByType.
+        // Convert entry_points_by_type from ContractClassWrapper to EntryPointsByType.
         let mut entry_points_by_type = EntryPointsByType::default();
 
         // Create a SierraContractClass.

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -19,6 +19,7 @@ use mc_rpc_core::{
     SierraContractClass, Syncing,
 };
 use mc_storage::OverrideHandle;
+use mp_starknet::execution::types::ContractClassWrapper;
 use pallet_starknet::runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_network_sync::SyncingService;
@@ -215,24 +216,24 @@ where
             StarknetRpcApiError::ContractNotFound
         })?;
 
-        // let contract_class: SierraContractClass = self
-        //     .overrides
-        //     .for_block_hash(self.client.as_ref(), substrate_block_hash)
-        //     .contract_class(substrate_block_hash, contract_address_wrapped)
-        //     .ok_or_else(|| {
-        //         error!("Failed to retrieve contract class at '{contract_address}'");
-        //         StarknetRpcApiError::ContractNotFound
-        //     })?
-        //     .try_into()
-        //     .map_err(|e| {
-        //         error!(
-        //             "Failed to convert `ContractClassWrapper` at '{contract_address}' to
-        // `ContractClass`: {e}"
-        //         );
-        //     StarknetRpcApiError::ContractNotFound
-        // })?;
+        let contract_class_wrapper: ContractClassWrapper = self
+            .overrides
+            .for_block_hash(self.client.as_ref(), _substrate_block_hash)
+            .contract_class(_substrate_block_hash, _contract_address_wrapped)
+            .ok_or_else(|| {
+                error!("Failed to retrieve contract class at '{contract_address}'");
+                StarknetRpcApiError::ContractNotFound
+            })?;
 
-        Ok(RPCContractClass::ContractClass(SierraContractClass::default()))
+        let contract_class: SierraContractClass = contract_class_wrapper.try_into().map_err(|e| {
+            error!(
+                "Failed to convert `ContractClassWrapper` at '{contract_address}' to
+        `ContractClass`: {e}"
+            );
+            StarknetRpcApiError::ContractNotFound
+        })?;
+
+        Ok(RPCContractClass::ContractClass(contract_class))
     }
 
     // Implementation of the `syncing` RPC Endpoint.


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build-related changes
- Documentation content changes
- Testing
- Other (please describe):

# What is the current behavior?

get_class_at returns a default SierraContractClass and should return an real SierraContractClass.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #309 

# What is the new behavior?

I'm working on a implementation of `TryFrom<ContractClassWrapper> for SierraContractClass`. This should allow me to easily achieve the goal of the PR afterwards. 

# Other information

It is a draft. I might need help for this one. 
<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
