### PR TITLE
Add Block Hash and Number to TransactionReceiptWrapper

### DIFF
--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -414,7 +414,7 @@ pub mod pallet {
             let transaction: Transaction = transaction.into();
             let call_info = transaction.execute(
                 &mut BlockifierStateAdapter::<T>::default(),
-                block,
+                block.clone(),
                 TxType::Invoke,
                 None,
                 fee_token_address,
@@ -444,6 +444,8 @@ pub mod pallet {
                         transaction_hash: transaction.hash,
                         tx_type: TxType::Invoke,
                         actual_fee: U256::from(actual_fee.0),
+                        block_hash: U256::from(block.header().hash().0),
+                        block_number: block.header().block_number.as_u64(),
                     }
                 }
                 Err(e) => {
@@ -501,7 +503,7 @@ pub mod pallet {
             // Execute transaction
             let call_info = transaction.execute(
                 &mut BlockifierStateAdapter::<T>::default(),
-                block,
+                block.clone(),
                 TxType::Declare,
                 Some(contract_class),
                 fee_token_address,
@@ -530,6 +532,8 @@ pub mod pallet {
                         events: BoundedVec::try_from(events).map_err(|_| Error::<T>::ReachedBoundedVecLimit)?,
                         transaction_hash: transaction.hash,
                         tx_type: TxType::Declare,
+                        block_hash: U256::from(block.header().hash().0),
+                        block_number: block.header().block_number.as_u64(),
                         actual_fee: U256::from(actual_fee.0),
                     }
                 }
@@ -583,7 +587,7 @@ pub mod pallet {
             // Execute transaction
             let call_info = transaction.execute(
                 &mut BlockifierStateAdapter::<T>::default(),
-                block,
+                block.clone(),
                 TxType::DeployAccount,
                 None,
                 fee_token_address,
@@ -612,6 +616,8 @@ pub mod pallet {
                         events: BoundedVec::try_from(events).map_err(|_| Error::<T>::ReachedBoundedVecLimit)?,
                         transaction_hash: transaction.hash,
                         tx_type: TxType::DeployAccount,
+                        block_hash: U256::from(block.header().hash().0),
+                        block_number: block.header().block_number.as_u64(),
                         actual_fee: U256::from(actual_fee.0),
                     }
                 }

--- a/crates/pallets/starknet/src/tests/invoke_tx.rs
+++ b/crates/pallets/starknet/src/tests/invoke_tx.rs
@@ -93,6 +93,8 @@ fn given_hardcoded_contract_run_invoke_tx_then_it_works() {
                 .unwrap(),
             actual_fee: U256::from(52980),
             tx_type: TxType::Invoke,
+            block_number: 2_u64,
+            block_hash: U256::from_str("0xb4eba7e7c15c481312451a04105527a26ff1ca7ff12db3f0822634421871ecea").unwrap(),
             events: bounded_vec![EventWrapper {
                 keys: bounded_vec!(
                     H256::from_str("0x0099cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9").unwrap(),
@@ -177,6 +179,8 @@ fn given_hardcoded_contract_run_invoke_tx_then_event_is_emitted() {
             transaction_hash: H256::from_str("0x0554f9443c06ce406badc7159f2c0da29eac095f8571fe1a6ce44a2076829a52").unwrap(),
             actual_fee: U256::from(53490),
             tx_type: TxType::Invoke,
+            block_number: 2_u64,
+            block_hash: U256::from_str("0xb4eba7e7c15c481312451a04105527a26ff1ca7ff12db3f0822634421871ecea").unwrap(),
             events: bounded_vec!(emitted_event, expected_fee_transfer_event),
         };
         let receipt = &pending.get(0).unwrap().1;

--- a/crates/primitives/starknet/src/transaction/mod.rs
+++ b/crates/primitives/starknet/src/transaction/mod.rs
@@ -154,7 +154,6 @@ impl Default for EventWrapper {
 impl TryInto<TransactionReceiptWrapper> for &TransactionReceipt {
     type Error = EventError;
 
-    // TODO: add block hash and block number (#252)
     fn try_into(self) -> Result<TransactionReceiptWrapper, Self::Error> {
         let _events: Result<vec::Vec<EventWrapper>, EventError> = self
             .output
@@ -175,6 +174,8 @@ impl TryInto<TransactionReceiptWrapper> for &TransactionReceipt {
                 TransactionOutput::L1Handler(_) => TxType::L1Handler,
                 _ => TxType::Invoke,
             },
+            block_hash: U256::from(self.block_hash.0.0),
+            block_number: self.block_number.0,
             events: BoundedVec::try_from(_events?).map_err(|_| EventError::TooManyEvents)?,
         })
     }
@@ -705,6 +706,8 @@ impl Default for TransactionReceiptWrapper {
             transaction_hash: H256::default(),
             actual_fee: U256::default(),
             tx_type: TxType::Invoke,
+            block_hash: U256::default(),
+            block_number: 0_u64,
             events: BoundedVec::try_from(vec![EventWrapper::default(), EventWrapper::default()]).unwrap(),
         }
     }

--- a/crates/primitives/starknet/src/transaction/types.rs
+++ b/crates/primitives/starknet/src/transaction/types.rs
@@ -391,6 +391,10 @@ pub struct TransactionReceiptWrapper {
     pub actual_fee: U256,
     /// Transaction type
     pub tx_type: TxType,
+    /// Block Number
+    pub block_number: u64,
+    /// Block Hash
+    pub block_hash: U256,
     /// Messages sent in the transaction.
     // pub messages_sent: BoundedVec<Message, MaxArraySize>, // TODO: add messages
     /// Events emitted in the transaction.


### PR DESCRIPTION
This PR adds the block Hash and Number to `TransactionReceiptWrapper`.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Refactoring (no functional changes, no API changes)

## What is the current behavior?

The `TransactionReceiptWrapper` Struct doesn't have the Block Number and Hash.

Resolves: #252 

## What is the new behavior?

`TransactionReceiptWrapper` now has these new fields.
Tests were also updated.

## Does this introduce a breaking change?

No