### PR TITLE
bug: docker instance not able to run npm scripts fix

### DIFF
--- a/infra/docker/Dockerfile.dev
+++ b/infra/docker/Dockerfile.dev
@@ -1,0 +1,36 @@
+# This is a DEV base image to build substrate nodes
+FROM docker.io/paritytech/ci-linux:production as builder
+
+WORKDIR /madara
+COPY . .
+RUN cargo build --locked --release
+
+# This is the 2nd stage: a very small image where we copy the binary."
+FROM docker.io/library/ubuntu:20.04
+LABEL description="Multistage Docker image for Madara" \
+  image.type="builder" \
+  image.authors="abdelhamid.bakhta@gmail.com" \
+  image.vendor="Substrate Developer Hub" \
+  image.description="Multistage Docker image for Madara" \
+  image.source="https://github.com/keep-starknet-strange/madara" \
+  image.documentation="https://github.com/keep-starknet-strange/madara"
+
+# Install the necessary dependencies for running the npm test scripts
+RUN apt-get update && apt-get install -y nodejs npm
+
+# Copy the node binary.
+COPY --from=builder /madara/target/release/madara /usr/local/bin
+
+RUN useradd -m -u 1000 -U -s /bin/sh -d /node-dev node-dev && \
+  mkdir -p /chain-data /node-dev/.local/share && \
+  chown -R node-dev:node-dev /chain-data && \
+  ln -s /chain-data /node-dev/.local/share/madara && \
+  # check if executable works in this container
+  /usr/local/bin/madara --version
+
+USER node-dev
+
+EXPOSE 30333 9933 9944 9615
+VOLUME ["/chain-data"]
+
+ENTRYPOINT ["/usr/local/bin/madara"]


### PR DESCRIPTION
The docker instance currently doesn't have the capability of running npm scripts since Node.js and npm aren't installed. This PR fixes that by adding a line to install them and removing a line which erases the bin directories.

# Pull Request type
Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?
Docker instance isn't able to run npm scripts

Resolves: #285 

## What is the new behavior?
Added missing step to install Node.js and npm in the container, which are required to run `npm run test-seq`.

I'm 100% sure about this other change but I eliminated the lines which removes /usr/bin and /usr/sbin since it's affecting the ability to run Node.js and npm inside the container.


Another alternative could be creating a separate container to run the npm scripts, this way we could avoid removing the line. Let me know!

## Does this introduce a breaking change?
No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
