### PR TITLE
build: add a docker compose for the starknet stack

### DIFF
--- a/infra/starknet-stack/docker-compose.yaml
+++ b/infra/starknet-stack/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: "3.2"
+
+services:
+  madara:
+    image: ghcr.io/keep-starknet-strange/madara:latest
+    ports:
+      - "9933:9933"
+      - "9615:9615"
+      - "9944:9944"
+      - "30333:30333"
+    platform: linux/x86_64
+    command: ["--prometheus-external", "--rpc-cors=all", "--rpc-external", "--ws-external"]
+
+  madara-app:
+    image: ghcr.io/keep-starknet-strange/madara-app:latest
+    ports:
+      - "8080:80"
+    environment:
+      WS_URL: "ws://0.0.0.0:9944"

--- a/infra/starknet-stack/docker-compose.yml
+++ b/infra/starknet-stack/docker-compose.yml
@@ -9,7 +9,11 @@ services:
       - "9944:9944"
       - "30333:30333"
     platform: linux/x86_64
-    command: ["--prometheus-external", "--rpc-cors=all", "--rpc-external", "--ws-external"]
+    command:
+      - "--prometheus-external"
+      - "--rpc-cors=all"
+      - "--rpc-external"
+      - "--ws-external"
 
   madara-app:
     image: ghcr.io/keep-starknet-strange/madara-app:latest


### PR DESCRIPTION
# Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- Build-related changes
- Other (please describe): infra, the closest conventional-commit tag is build IMO

## What is the current behavior?

Every piece of the starknet stack (madara, madara-app, etc...) needs to be run on its own.

Resolves: #412 

## What is the new behavior?

A new docker-compose.yml allows to start the services composing the starknet stack. This file serves as a foundation for adding later services. Current services are

- madara
- madara-app

## Does this introduce a breaking change?

No

## Other information

This configuration targets local setup and tries to maximize ease of use. As such : 
- madara is opened as much as possible (prometheus, rpc and websocket are exposed on the host)
- madara-app is exposed on port 8080 (to avoid conflicts with local HTTP servers)