### PR TITLE
feat: get runtime hasher into client

### DIFF
--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -607,7 +607,7 @@ where
         let block_with_txs = BlockWithTxs {
             // TODO: Get status from block
             status: BlockStatus::AcceptedOnL2,
-            block_hash: block.header().hash(PedersenHasher::default()).into(),
+            block_hash: block.header().hash(*self.hasher).into(),
             parent_hash: block.header().parent_block_hash.into(),
             block_number: block.header().block_number.as_u64(),
             new_root: block.header().global_state_root.into(),

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -15,8 +15,9 @@ use mc_rpc_core::utils::{to_deploy_account_tx, to_invoke_tx, to_rpc_contract_cla
 pub use mc_rpc_core::StarknetRpcApiServer;
 use mc_storage::OverrideHandle;
 use mp_starknet::block::BlockTransactions;
-use mp_starknet::crypto::hash::pedersen::PedersenHasher;
 use mp_starknet::execution::types::Felt252Wrapper;
+use mp_starknet::traits::hash::HasherT;
+use mp_starknet::traits::ThreadSafeCopy;
 use mp_starknet::transaction::types::{RPCTransactionConversionError, Transaction as MPTransaction, TxType};
 use pallet_starknet::runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
 use sc_client_api::backend::{Backend, StorageProvider};
@@ -38,13 +39,14 @@ use starknet_providers::jsonrpc::models::{
 };
 
 /// A Starknet RPC server for Madara
-pub struct Starknet<B: BlockT, BE, C, P> {
+pub struct Starknet<B: BlockT, BE, C, P, H> {
     client: Arc<C>,
     backend: Arc<mc_db::Backend<B>>,
     overrides: Arc<OverrideHandle<B>>,
     pool: Arc<P>,
     sync_service: Arc<SyncingService<B>>,
     starting_block: <<B>::Header as HeaderT>::Number,
+    hasher: Arc<H>,
     _marker: PhantomData<(B, BE)>,
 }
 
@@ -55,10 +57,11 @@ pub struct Starknet<B: BlockT, BE, C, P> {
 // * `overrides` - The OverrideHandle
 // * `sync_service` - The Substrate client sync service
 // * `starting_block` - The starting block for the syncing
+// * `hasher` - The hasher used by the runtime
 //
 // # Returns
 // * `Self` - The actual Starknet struct
-impl<B: BlockT, BE, C, P> Starknet<B, BE, C, P> {
+impl<B: BlockT, BE, C, P, H> Starknet<B, BE, C, P, H> {
     pub fn new(
         client: Arc<C>,
         backend: Arc<mc_db::Backend<B>>,
@@ -66,12 +69,13 @@ impl<B: BlockT, BE, C, P> Starknet<B, BE, C, P> {
         pool: Arc<P>,
         sync_service: Arc<SyncingService<B>>,
         starting_block: <<B>::Header as HeaderT>::Number,
+        hasher: Arc<H>,
     ) -> Self {
-        Self { client, backend, overrides, pool, sync_service, starting_block, _marker: PhantomData }
+        Self { client, backend, overrides, pool, sync_service, starting_block, hasher, _marker: PhantomData }
     }
 }
 
-impl<B, BE, C, P> Starknet<B, BE, C, P>
+impl<B, BE, C, P, H> Starknet<B, BE, C, P, H>
 where
     B: BlockT,
     C: HeaderBackend<B> + 'static,
@@ -81,13 +85,14 @@ where
     }
 }
 
-impl<B, BE, C, P> Starknet<B, BE, C, P>
+impl<B, BE, C, P, H> Starknet<B, BE, C, P, H>
 where
     B: BlockT,
     C: HeaderBackend<B> + StorageProvider<B, BE> + 'static,
     C: ProvideRuntimeApi<B>,
     C::Api: StarknetRuntimeApi<B> + ConvertTransactionRuntimeApi<B>,
     BE: Backend<B>,
+    H: HasherT + ThreadSafeCopy,
 {
     pub fn current_block_hash(&self) -> Result<H256, ApiError> {
         let substrate_block_hash = self.client.info().best_hash;
@@ -98,7 +103,7 @@ where
             .current_block(substrate_block_hash)
             .unwrap_or_default();
 
-        Ok(block.header().hash(PedersenHasher::default()).into())
+        Ok(block.header().hash(*self.hasher).into())
     }
 
     /// Returns the substrate block corresponding to the given Starknet block id
@@ -128,7 +133,7 @@ const TX_SOURCE: TransactionSource = TransactionSource::External;
 
 #[async_trait]
 #[allow(unused_variables)]
-impl<B, BE, C, P> StarknetRpcApiServer for Starknet<B, BE, C, P>
+impl<B, BE, C, P, H> StarknetRpcApiServer for Starknet<B, BE, C, P, H>
 where
     B: BlockT,
     P: TransactionPool<Block = B> + 'static,
@@ -136,6 +141,7 @@ where
     C: HeaderBackend<B> + StorageProvider<B, BE> + 'static,
     C: ProvideRuntimeApi<B>,
     C::Api: StarknetRuntimeApi<B> + ConvertTransactionRuntimeApi<B>,
+    H: HasherT + ThreadSafeCopy,
 {
     fn block_number(&self) -> RpcResult<u64> {
         self.current_block_number()
@@ -312,13 +318,13 @@ where
                 if starting_block.is_ok() && current_block.is_ok() && highest_block.is_ok() {
                     // Convert block numbers and hashes to the respective type required by the `syncing` endpoint.
                     let starting_block_num = UniqueSaturatedInto::<u64>::unique_saturated_into(self.starting_block);
-                    let starting_block_hash = starting_block?.header().hash(PedersenHasher::default()).0;
+                    let starting_block_hash = starting_block?.header().hash(*self.hasher).0;
 
                     let current_block_num = UniqueSaturatedInto::<u64>::unique_saturated_into(best_number);
-                    let current_block_hash = current_block?.header().hash(PedersenHasher::default()).0;
+                    let current_block_hash = current_block?.header().hash(*self.hasher).0;
 
                     let highest_block_num = UniqueSaturatedInto::<u64>::unique_saturated_into(highest_number);
-                    let highest_block_hash = highest_block?.header().hash(PedersenHasher::default()).0;
+                    let highest_block_hash = highest_block?.header().hash(*self.hasher).0;
 
                     // Build the `SyncStatus` struct with the respective syn information
                     Ok(SyncStatusType::Syncing(SyncStatus {
@@ -381,7 +387,7 @@ where
             .unwrap_or_default();
 
         let transactions = block.transactions_hashes().into_iter().map(FieldElement::from).collect();
-        let blockhash = block.header().hash(PedersenHasher::default());
+        let blockhash = block.header().hash(*self.hasher);
         let parent_blockhash = block.header().parent_block_hash;
         let block_with_tx_hashes = BlockWithTxHashes {
             transactions,

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -12,6 +12,7 @@ use futures::channel::mpsc;
 use jsonrpsee::RpcModule;
 use madara_runtime::opaque::Block;
 use madara_runtime::{AccountId, Balance, Hash, Index};
+use pallet_starknet::runtime_api::StarknetRuntimeApi;
 use sc_client_api::{Backend, StorageProvider};
 use sc_consensus_manual_seal::rpc::EngineCommand;
 pub use sc_rpc_api::DenyUnsafe;
@@ -57,6 +58,8 @@ where
     let mut module = RpcModule::new(());
     let FullDeps { client, pool, deny_unsafe, starknet: starknet_params, command_sink } = deps;
 
+    let hasher = client.runtime_api().get_hasher(client.info().best_hash)?.into();
+
     module.merge(System::new(client.clone(), pool.clone(), deny_unsafe).into_rpc())?;
     module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
     module.merge(
@@ -67,6 +70,7 @@ where
             pool,
             starknet_params.sync_service,
             starknet_params.starting_block,
+            hasher,
         )
         .into_rpc(),
     )?;

--- a/crates/pallets/starknet/src/runtime_api.rs
+++ b/crates/pallets/starknet/src/runtime_api.rs
@@ -5,6 +5,7 @@
 // Specifically, the macro generates a trait (`StarknetRuntimeApi`) with unused type parameters.
 #![allow(clippy::extra_unused_type_parameters)]
 
+use mp_starknet::crypto::hash::Hasher;
 use mp_starknet::execution::types::{
     ClassHashWrapper, ContractAddressWrapper, ContractClassWrapper, Felt252Wrapper, StorageKeyWrapper,
 };
@@ -37,6 +38,8 @@ sp_api::decl_runtime_apis! {
         fn chain_id() -> u128;
         /// Returns fee estimate
         fn estimate_fee(transaction: Transaction) -> Result<(u64, u64), DispatchError>;
+        /// Returns the hasher used by the runtime.
+        fn get_hasher() -> Hasher;
     }
 
     pub trait ConvertTransactionRuntimeApi {

--- a/crates/pallets/starknet/src/tests/invoke_tx.rs
+++ b/crates/pallets/starknet/src/tests/invoke_tx.rs
@@ -3,7 +3,6 @@ use core::str::FromStr;
 use blockifier::abi::abi_utils::get_storage_var_address;
 use frame_support::{assert_err, assert_ok, bounded_vec};
 use mp_starknet::crypto::commitment;
-use mp_starknet::crypto::hash::pedersen::PedersenHasher;
 use mp_starknet::execution::types::Felt252Wrapper;
 use mp_starknet::starknet_serde::transaction_from_json;
 use mp_starknet::transaction::types::{
@@ -177,7 +176,7 @@ fn given_hardcoded_contract_run_invoke_tx_then_event_is_emitted() {
         let events = Starknet::pending_events();
         let transactions: Vec<Transaction> = pending.clone().into_iter().map(|(transaction, _)| transaction).collect();
         let (_transaction_commitment, event_commitment) =
-            commitment::calculate_commitments::<PedersenHasher>(&transactions, &events);
+            commitment::calculate_commitments::<<MockRuntime as crate::Config>::SystemHash>(&transactions, &events);
 
         assert_eq!(
             event_commitment,

--- a/crates/primitives/starknet/src/block/header.rs
+++ b/crates/primitives/starknet/src/block/header.rs
@@ -2,7 +2,7 @@ use scale_codec::Encode;
 use sp_core::U256;
 
 use crate::execution::types::{ContractAddressWrapper, Felt252Wrapper};
-use crate::traits::hash::Hasher;
+use crate::traits::hash::HasherT;
 
 #[derive(
     Clone,
@@ -76,8 +76,8 @@ impl Header {
 
     /// Compute the hash of the header.
     #[must_use]
-    pub fn hash<H: Hasher>(&self, hasher: H) -> Felt252Wrapper {
-        <H as Hasher>::hash(&hasher, &self.block_number.encode())
+    pub fn hash<H: HasherT>(&self, hasher: H) -> Felt252Wrapper {
+        <H as HasherT>::hash(&hasher, &self.block_number.encode())
     }
 }
 

--- a/crates/primitives/starknet/src/crypto/hash/mod.rs
+++ b/crates/primitives/starknet/src/crypto/hash/mod.rs
@@ -1,30 +1,63 @@
 //! This module contains the hash functions used in the StarkNet protocol.
 use crate::execution::felt252_wrapper::Felt252Wrapper;
+use crate::traits::hash::HasherT;
+use crate::traits::ThreadSafeCopy;
 
 pub mod pedersen;
 pub mod poseidon;
 
-/// The type of hash function used in the StarkNet protocol.
-pub enum HashType {
-    /// The Poseidon hash function.
-    Poseidon,
+/// Available hashers in the StarkNet protocol.
+#[derive(Clone, Copy, scale_codec::Encode, scale_codec::Decode, scale_info::TypeInfo)]
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+pub enum Hasher {
     /// The Pedersen hash function.
-    Pedersen,
+    Pedersen(pedersen::PedersenHasher),
+    /// The Poseidon hash function.
+    Poseidon(poseidon::PoseidonHasher),
 }
 
-/// Hashes two field elements using the specified hash function.
+impl ThreadSafeCopy for Hasher {}
+
+/// Implement the `HasherT` trait for the `Hasher` enum.
+impl HasherT for Hasher {
+    fn hash(&self, data: &[u8]) -> Felt252Wrapper {
+        match self {
+            Self::Pedersen(p) => p.hash(data),
+            Self::Poseidon(p) => p.hash(data),
+        }
+    }
+}
+
+/// Implement the `From` trait for the `Hasher` enum.
+macro_rules! into_hasher {
+    ($(($hash_function:ident, $inner:ty)),+ ) => {
+        $(
+            impl From<$inner> for Hasher {
+                fn from(item: $inner) -> Self {
+                    Hasher::$hash_function(item)
+                }
+            }
+        )+
+    };
+}
+
+into_hasher! {
+    (Pedersen, pedersen::PedersenHasher),
+    (Poseidon, poseidon::PoseidonHasher)
+}
+
+/// Hashes a slice of bytes using the given hash function.
 /// # Arguments
 ///
-/// * `hash_type`: The type of hash function to use.
-/// * `x`: The x coordinate
-/// * `y`: The y coordinate
+/// * `hasher`: The hash function to use.
+/// * `data`: The data to hash.
 ///
 /// # Returns
 ///
-/// The hash of the two field elements.
-pub fn hash(hash_type: HashType, data: &[u8]) -> Felt252Wrapper {
-    match hash_type {
-        HashType::Poseidon => poseidon::hash(data),
-        HashType::Pedersen => pedersen::hash(data),
+/// The hash of the data.
+pub fn hash(hasher: Hasher, data: &[u8]) -> Felt252Wrapper {
+    match hasher {
+        Hasher::Pedersen(p) => p.hash(data),
+        Hasher::Poseidon(p) => p.hash(data),
     }
 }

--- a/crates/primitives/starknet/src/crypto/hash/pedersen.rs
+++ b/crates/primitives/starknet/src/crypto/hash/pedersen.rs
@@ -1,18 +1,8 @@
 //! Pedersen hash module.
 use starknet_crypto::{pedersen_hash, FieldElement};
 
+use crate::execution::felt252_wrapper::Felt252Wrapper;
 use crate::traits::hash::{CryptoHasherT, DefaultHasher, HasherT};
-
-/// The Pedersen hash function.
-/// ### Arguments
-/// * `x`: The x coordinate
-/// * `y`: The y coordinate
-pub fn hash(data: &[u8]) -> Felt252Wrapper {
-    // For now we use the first 31 bytes of the data as the field element, to avoid any panics.
-    // TODO: have proper error handling and think about how to hash efficiently big chunks of data.
-    let field_element = FieldElement::from_byte_slice_be(&data[..31]).unwrap();
-    Felt252Wrapper(pedersen_hash(&FieldElement::ZERO, &field_element))
-}
 
 /// The Pedersen hasher.
 #[derive(Clone, Copy, Default, scale_codec::Encode, scale_codec::Decode, scale_info::TypeInfo)]
@@ -21,13 +11,16 @@ pub struct PedersenHasher;
 
 /// The Pedersen hasher implementation.
 impl HasherT for PedersenHasher {
-    /// Hashes the given data.
+    /// The Pedersen hash function.
     /// # Arguments
     /// * `data` - The data to hash.
     /// # Returns
     /// The hash of the data.
     fn hash(&self, data: &[u8]) -> Felt252Wrapper {
-        hash(data)
+        // For now we use the first 31 bytes of the data as the field element, to avoid any panics.
+        // TODO: have proper error handling and think about how to hash efficiently big chunks of data.
+        let field_element = FieldElement::from_byte_slice_be(&data[..31]).unwrap();
+        Felt252Wrapper(pedersen_hash(&FieldElement::ZERO, &field_element))
     }
 }
 

--- a/crates/primitives/starknet/src/crypto/hash/poseidon.rs
+++ b/crates/primitives/starknet/src/crypto/hash/poseidon.rs
@@ -6,22 +6,23 @@ use starknet_crypto::FieldElement;
 
 use crate::execution::felt252_wrapper::Felt252Wrapper;
 use crate::traits::hash::{CryptoHasherT, DefaultHasher, HasherT};
+
 /// The poseidon hasher.
 #[derive(Clone, Copy, Default, scale_codec::Encode, scale_codec::Decode, scale_info::TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct PoseidonHasher;
 
-/// The Poseidon hash function.
-pub fn hash(_data: &[u8]) -> Felt252Wrapper {
-    let input = felts_from_u8s::<GF>(_data);
-    let binding = u8s_from_felts(&hash_sw8(&input));
-    let result = binding.as_slice();
-    result.try_into().unwrap()
-}
-
 impl HasherT for PoseidonHasher {
-    fn hash(&self, data: &[u8]) -> [u8; 32] {
-        hash(data)
+    /// The Poseidon hash function.
+    /// # Arguments
+    /// * `data` - The data to hash.
+    /// # Returns
+    /// The hash of the data.
+    fn hash(&self, data: &[u8]) -> Felt252Wrapper {
+        let input = felts_from_u8s::<GF>(data);
+        let binding = u8s_from_felts(&hash_sw8(&input));
+        let result = binding.as_slice();
+        result.try_into().unwrap() // TODO: remove unwrap
     }
 }
 

--- a/crates/primitives/starknet/src/crypto/merkle_patricia_tree/merkle_node.rs
+++ b/crates/primitives/starknet/src/crypto/merkle_patricia_tree/merkle_node.rs
@@ -12,7 +12,7 @@ use bitvec::prelude::BitVec;
 use bitvec::slice::BitSlice;
 use starknet_crypto::FieldElement;
 
-use crate::traits::hash::CryptoHasher;
+use crate::traits::hash::CryptoHasherT;
 
 /// A node in a Binary Merkle-Patricia Tree graph.
 #[derive(Clone, Debug, PartialEq)]
@@ -144,7 +144,7 @@ impl BinaryNode {
     ///
     /// If either child's hash is [None], then the hash cannot
     /// be calculated and it will remain [None].
-    pub(crate) fn calculate_hash<H: CryptoHasher>(&mut self) {
+    pub(crate) fn calculate_hash<H: CryptoHasherT>(&mut self) {
         if self.hash.is_some() {
             return;
         }
@@ -249,7 +249,7 @@ impl EdgeNode {
     ///
     /// If the child's hash is [None], then the hash cannot
     /// be calculated and it will remain [None].
-    pub(crate) fn calculate_hash<H: CryptoHasher>(&mut self) {
+    pub(crate) fn calculate_hash<H: CryptoHasherT>(&mut self) {
         if self.hash.is_some() {
             return;
         }

--- a/crates/primitives/starknet/src/crypto/merkle_patricia_tree/merkle_tree.rs
+++ b/crates/primitives/starknet/src/crypto/merkle_patricia_tree/merkle_tree.rs
@@ -9,7 +9,7 @@ use bitvec::prelude::{BitSlice, BitVec, Msb0};
 use starknet_crypto::FieldElement;
 
 use crate::crypto::merkle_patricia_tree::merkle_node::{BinaryNode, Direction, EdgeNode, Node};
-use crate::traits::hash::CryptoHasher;
+use crate::traits::hash::CryptoHasherT;
 
 /// Lightweight representation of [BinaryNode]. Only holds left and right hashes.
 #[derive(Debug, PartialEq, Eq)]
@@ -65,12 +65,12 @@ pub enum ProofNode {
 ///
 /// For more information on how this functions internally, see [here](super::merkle_tree).
 #[derive(Debug, Clone)]
-pub struct MerkleTree<H: CryptoHasher> {
+pub struct MerkleTree<H: CryptoHasherT> {
     root: Rc<RefCell<Node>>,
     _hasher: PhantomData<H>,
 }
 
-impl<H: CryptoHasher> MerkleTree<H> {
+impl<H: CryptoHasherT> MerkleTree<H> {
     /// Less visible initialization for `MerkleTree<T>` as the main entry points should be
     /// [`MerkleTree::<RcNodeStorage>::load`] for persistent trees and [`MerkleTree::empty`] for
     /// transient ones.

--- a/crates/primitives/starknet/src/tests/crypto.rs
+++ b/crates/primitives/starknet/src/tests/crypto.rs
@@ -11,12 +11,12 @@ use crate::crypto::commitment::{
     calculate_invoke_tx_hash, calculate_transaction_commitment,
 };
 use crate::crypto::hash::pedersen::PedersenHasher;
-use crate::crypto::hash::{hash, HashType};
+use crate::crypto::hash::{hash, Hasher};
 use crate::crypto::merkle_patricia_tree::merkle_node::{BinaryNode, Direction, Node};
 use crate::execution::call_entrypoint_wrapper::CallEntryPointWrapper;
 use crate::execution::contract_class_wrapper::ContractClassWrapper;
 use crate::execution::types::Felt252Wrapper;
-use crate::traits::hash::{CryptoHasher, Hasher};
+use crate::traits::hash::{CryptoHasherT, HasherT};
 use crate::transaction::types::{
     DeclareTransaction, DeployAccountTransaction, EventWrapper, InvokeTransaction, Transaction, TxType,
 };
@@ -139,7 +139,7 @@ fn test_event_hash() {
 fn test_pedersen_hash() {
     let pedersen_hasher = PedersenHasher::default();
     let hash_result = pedersen_hasher.hash(&test_data());
-    let expected_hash = hash(HashType::Pedersen, &test_data());
+    let expected_hash = hash(Hasher::Pedersen(PedersenHasher::default()), &test_data());
 
     assert_eq!(hash_result, expected_hash);
 }
@@ -154,7 +154,7 @@ fn test_data() -> Vec<u8> {
 
 struct TestCryptoHasher;
 
-impl CryptoHasher for TestCryptoHasher {
+impl CryptoHasherT for TestCryptoHasher {
     fn hash(a: FieldElement, b: FieldElement) -> FieldElement {
         a + b
     }

--- a/crates/primitives/starknet/src/traits/hash.rs
+++ b/crates/primitives/starknet/src/traits/hash.rs
@@ -5,20 +5,23 @@ use starknet_crypto::FieldElement;
 use crate::execution::felt252_wrapper::Felt252Wrapper;
 
 /// A trait for hashing.
-pub trait Hasher {
+pub trait HasherT {
     /// Hashes the given data.
     /// # Arguments
     /// * `data` - The data to hash.
     /// # Returns
     /// The hash of the data.
     fn hash(&self, data: &[u8]) -> Felt252Wrapper;
+}
 
+/// A trait for default hashing instance.
+pub trait DefaultHasher {
     /// Get Hasher default instance.
     fn hasher() -> Self;
 }
 
 /// A trait for hashing with pedersen.
-pub trait CryptoHasher {
+pub trait CryptoHasherT {
     /// Hashes the 2 felts sent.
     ///
     /// # Arguments

--- a/crates/primitives/starknet/src/traits/mod.rs
+++ b/crates/primitives/starknet/src/traits/mod.rs
@@ -1,8 +1,5 @@
 /// Define traits related to hash functions.
 pub mod hash;
 
-/// Define traits related to transaction.
-pub mod transaction;
-
 /// A trait for types that can be shared between threads + copied.
 pub trait ThreadSafeCopy: Send + Sync + Copy + 'static {}

--- a/crates/primitives/starknet/src/traits/mod.rs
+++ b/crates/primitives/starknet/src/traits/mod.rs
@@ -1,2 +1,8 @@
 /// Define traits related to hash functions.
 pub mod hash;
+
+/// Define traits related to transaction.
+pub mod transaction;
+
+/// A trait for types that can be shared between threads + copied.
+pub trait ThreadSafeCopy: Send + Sync + Copy + 'static {}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -25,6 +25,7 @@ pub use frame_support::weights::constants::{
 pub use frame_support::weights::{IdentityFee, Weight};
 pub use frame_support::{construct_runtime, parameter_types, StorageValue};
 pub use frame_system::Call as SystemCall;
+use mp_starknet::crypto::hash::Hasher;
 use mp_starknet::execution::types::{
     ClassHashWrapper, ContractAddressWrapper, ContractClassWrapper, Felt252Wrapper, StorageKeyWrapper,
 };
@@ -316,6 +317,10 @@ impl_runtime_apis! {
 
         fn estimate_fee(transaction: Transaction) -> Result<(u64, u64), DispatchError> {
             Starknet::estimate_fee(transaction)
+        }
+
+        fn get_hasher() -> Hasher {
+            Starknet::get_system_hash().into()
         }
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Client uses default Pedersen hasher in order to compute block header hash. PR updates the runtime API in order to provide a way to retrieve the hasher used by the runtime.

# Pull Request type

- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #402 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds runtime API endpoint in order for the client to retrieve runtime hasher.

## Does this introduce a breaking change?
No

## Other information
Please note that I was not able to update the Pedersen hasher to a generic type hasher in one file for the functions relating to [transaction hash calculation](https://github.com/keep-starknet-strange/madara/blob/main/crates/primitives/starknet/src/crypto/commitment/mod.rs#L138), this being due to the fact that these functions are currently used in [From implementations](https://github.com/keep-starknet-strange/madara/blob/main/crates/primitives/starknet/src/transaction/types.rs#L309).
