### PR TITLE
Fix: update the Transaction type used in pallet

### DIFF
--- a/crates/primitives/starknet/src/block/mod.rs
+++ b/crates/primitives/starknet/src/block/mod.rs
@@ -8,7 +8,7 @@ pub use header::*;
 use sp_core::ConstU32;
 
 use crate::execution::types::Felt252Wrapper;
-use crate::transaction::types::Transaction;
+use crate::transaction::types::{Transaction, TransactionInfo};
 
 /// Serializer
 pub mod serialize;
@@ -86,7 +86,9 @@ impl Block {
     /// Return a reference to all transaction hashes
     pub fn transactions_hashes(&self) -> Vec<Felt252Wrapper> {
         match &self.transactions {
-            BlockTransactions::Full(transactions) => transactions.into_iter().map(|tx| tx.hash).collect(),
+            BlockTransactions::Full(transactions) => {
+                transactions.into_iter().map(|tx| Into::<TransactionInfo>::into(*tx).transaction_hash).collect()
+            }
 
             BlockTransactions::Hashes(hashes) => hashes.to_vec(),
         }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Updates the Transaction structure used in Starknet pallet in order to reflect the type of the transaction (deploy, declare, invoke,...).

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Feature
- Refactoring (no functional changes, no API changes)
- Testing

## What is the current behavior?
The Starknet pallet uses a Transaction structure which doesn't reflect the type of the transaction. This causes issues for certain RPC endpoints which cannot determine the type of the transaction when querying the runtime/storage.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #457 

## What is the new behavior?
Transaction is updated to an enum in order to reflect the type of the transaction that is stored in the block.

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Update the type of the structure Transaction to an enum
- Refactor the Starknet pallet in order to use the new enum
- Test the updated type

