### PR TITLE
Add Substrate tutorials to the Starter pack Docs

### DIFF
--- a/docs/contributor-starter-pack.md
+++ b/docs/contributor-starter-pack.md
@@ -255,6 +255,10 @@ blockchain, even without connecting it to Polkadot. This is referred to as
 [Substrate and Polkadot](
 https://medium.com/polkadot-network/a-brief-summary-of-everything-substrate-and-polkadot-f1f21071499d)
 
+For a more practical learning experience, these [Substrate
+Tutorials](https://github.com/rusty-crewmates/substrate-tutorials) would be a
+great place to start.
+
 ## Diving into Madara <a name="madara-dive"/>
 
 Now that you have a better understanding of the context, what Madara is?


### PR DESCRIPTION
@tdelabro sent me [this repo](https://github.com/rusty-crewmates/substrate-tutorials) for substrate tutorials some days ago. I've been finding them helpful in understanding some Substrate details, which I had read in the docs. 

More people probably know about them, but they should be a reference in the contributor starter pack.

# Pull Request type

- Documentation content changes

## Does this introduce a breaking change?

No