### PR TITLE
fix: clean the macros and unused code

### DIFF
--- a/crates/primitives/starknet/src/execution/felt252_wrapper.rs
+++ b/crates/primitives/starknet/src/execution/felt252_wrapper.rs
@@ -109,34 +109,29 @@ impl TryFrom<&[u8]> for Felt252Wrapper {
     }
 }
 
-macro_rules! impl_from_primitive {
-    ($($t:ty),*) => {
-        $(
-            impl From<$t> for Felt252Wrapper {
-                fn from(value: $t) -> Self {
-                    Felt252Wrapper::try_from(U256::from(value)).unwrap()
-                }
-            }
-        )*
-    };
+/// [`u64`] to [`Felt252Wrapper`].
+impl From<u64> for Felt252Wrapper {
+    fn from(value: u64) -> Self {
+        Self(FieldElement::from(value))
+    }
 }
 
-impl_from_primitive!(u8, u16, u32, u64, u128);
-
-macro_rules! impl_try_into_primitive {
-    ($($t:ty),*) => {
-        $(
-            impl TryFrom<Felt252Wrapper> for $t {
-                type Error = Felt252WrapperError;
-                fn try_from(value: Felt252Wrapper) -> Result<Self, Self::Error> {
-                    <$t>::try_from(value.0).map_err(|_| Felt252WrapperError::ValueTooLarge)
-                }
-            }
-        )*
-    };
+/// [`u128`] to [`Felt252Wrapper`].
+impl From<u128> for Felt252Wrapper {
+    fn from(value: u128) -> Self {
+        Felt252Wrapper::try_from(U256::from(value)).unwrap()
+    }
 }
 
-impl_try_into_primitive!(u8, u16, u32, u64);
+/// [`Felt252Wrapper`] to [`u64`].
+/// Overflow may occur and return [`Felt252WrapperError::ValueTooLarge`].
+impl TryFrom<Felt252Wrapper> for u64 {
+    type Error = Felt252WrapperError;
+
+    fn try_from(value: Felt252Wrapper) -> Result<Self, Self::Error> {
+        u64::try_from(value.0).map_err(|_| Felt252WrapperError::ValueTooLarge)
+    }
+}
 
 /// [`Felt252Wrapper`] to [`U256`].
 impl From<Felt252Wrapper> for U256 {
@@ -427,15 +422,6 @@ mod felt252_wrapper_tests {
 
     #[test]
     fn felt252_from_primitives() {
-        let felt_u8 = Felt252Wrapper::from(1u8);
-        assert_eq!(felt_u8, Felt252Wrapper::from_dec_str("1").unwrap());
-
-        let felt_u16 = Felt252Wrapper::from(256u16);
-        assert_eq!(felt_u16, Felt252Wrapper::from_dec_str("256").unwrap());
-
-        let felt_u32 = Felt252Wrapper::from(65_536u32);
-        assert_eq!(felt_u32, Felt252Wrapper::from_dec_str("65536").unwrap());
-
         let felt_u64 = Felt252Wrapper::from(4_294_967_296u64);
         assert_eq!(felt_u64, Felt252Wrapper::from_dec_str("4294967296").unwrap());
 
@@ -445,15 +431,6 @@ mod felt252_wrapper_tests {
 
     #[test]
     fn primitives_try_from_felt252() {
-        let felt_u8 = Felt252Wrapper::from(1u8);
-        assert_eq!(TryInto::<u8>::try_into(felt_u8).unwrap(), 1u8);
-
-        let felt_u16 = Felt252Wrapper::from(256u16);
-        assert_eq!(TryInto::<u16>::try_into(felt_u16).unwrap(), 256u16);
-
-        let felt_u32 = Felt252Wrapper::from(65_536u32);
-        assert_eq!(TryInto::<u32>::try_into(felt_u32).unwrap(), 65_536u32);
-
         let felt_u64 = Felt252Wrapper::from(4_294_967_296u64);
         assert_eq!(TryInto::<u64>::try_into(felt_u64).unwrap(), 4_294_967_296u64);
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Revert the macro introduced which implemented From and TryFrom for Felt252Wrapper, only keeping the implementations for u64 and u128, thus applying KISS and YAGNI.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Refactoring (no functional changes, no API changes)

## What is the current behavior?
Macro was added to Felt252Wrapper and introduces unneeded implementations for conversion between Felt252Wrapper and other built-in types (u8, u16, u32, u64).

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?
Remove the macro to simplify the code and keep only the needed implementation (u64 and u128).

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Cleaning unneeded impls

## Does this introduce a breaking change?
No

## Other information
Done to follow the Keep It Simple Stupid (KISS) and the You Aren't Gonna Need It (YAGNI) principles.
