### PR TITLE
feat: add `Felt252Wrapper` for `nonce` and `max_fees`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ pallet-utility = { default-features = false, git = "https://github.com/paritytec
 pallet-starknet = { path = "crates/pallets/starknet", default-features = false }
 
 # Madara primtitives
-mp-starknet = { path = "crates/primitives/starknet", default-features = false }
+mp-starknet = { path = "crates/primitives/starknet", default-features = false}
 mp-digest-log = { path = "crates/primitives/digest-log", default-features = false }
 
 # Madara client

--- a/crates/client/rpc-core/src/utils.rs
+++ b/crates/client/rpc-core/src/utils.rs
@@ -67,12 +67,12 @@ pub fn to_invoke_tx(tx: BroadcastedInvokeTransaction) -> Result<InvokeTransactio
             .map_err(|e| anyhow!("failed to convert signature: {:?}", e))?,
 
             sender_address: invoke_tx_v1.sender_address.into(),
-            nonce: U256::from(invoke_tx_v1.nonce.to_bytes_be()),
+            nonce: Felt252Wrapper::from(invoke_tx_v1.nonce),
             calldata: BoundedVec::try_from(
                 invoke_tx_v1.calldata.iter().map(|x| (*x).into()).collect::<Vec<Felt252Wrapper>>(),
             )
             .map_err(|e| anyhow!("failed to convert calldata: {:?}", e))?,
-            max_fee: U256::from(invoke_tx_v1.max_fee.to_bytes_be()),
+            max_fee: Felt252Wrapper::from(invoke_tx_v1.max_fee),
         }),
     }
 }
@@ -112,8 +112,8 @@ pub fn to_deploy_account_tx(tx: BroadcastedDeployAccountTransaction) -> Result<D
         .try_into()
         .map_err(|_| anyhow!("failed to bound calldata Vec<U256> by MaxArraySize"))?;
 
-    let nonce = U256::from(tx.nonce.to_bytes_be());
-    let max_fee = U256::from(tx.max_fee.to_bytes_be());
+    let nonce = Felt252Wrapper::from(tx.nonce);
+    let max_fee = Felt252Wrapper::from(tx.max_fee);
 
     Ok(DeployAccountTransaction {
         version: 1_u8,

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -732,25 +732,25 @@ pub mod pallet {
             // Once we have a real fee market this is where we'll chose the most profitable transaction.
             match call {
                 Call::invoke { transaction } => ValidTransaction::with_tag_prefix("starknet")
-                    .priority(u64::MAX - transaction.nonce.as_u64())
+                    .priority(u64::MAX - (TryInto::<u64>::try_into(transaction.nonce)).unwrap())
                     .and_provides((transaction.sender_address, transaction.nonce))
                     .longevity(64_u64)
                     .propagate(true)
                     .build(),
                 Call::declare { transaction } => ValidTransaction::with_tag_prefix("starknet")
-                    .priority(u64::MAX - transaction.nonce.as_u64())
+                    .priority(u64::MAX - (TryInto::<u64>::try_into(transaction.nonce)).unwrap())
                     .and_provides((transaction.sender_address, transaction.nonce))
                     .longevity(64_u64)
                     .propagate(true)
                     .build(),
                 Call::deploy_account { transaction } => ValidTransaction::with_tag_prefix("starknet")
-                    .priority(u64::MAX - transaction.nonce.as_u64())
+                    .priority(u64::MAX - (TryInto::<u64>::try_into(transaction.nonce)).unwrap())
                     .and_provides((transaction.sender_address, transaction.nonce))
                     .longevity(64_u64)
                     .propagate(true)
                     .build(),
                 Call::consume_l1_message { transaction } => ValidTransaction::with_tag_prefix("starknet")
-                    .priority(u64::MAX - transaction.nonce.as_u64())
+                    .priority(u64::MAX - (TryInto::<u64>::try_into(transaction.nonce)).unwrap())
                     .and_provides((transaction.sender_address, transaction.nonce))
                     .longevity(64_u64)
                     .propagate(true)

--- a/crates/pallets/starknet/src/message.rs
+++ b/crates/pallets/starknet/src/message.rs
@@ -68,8 +68,9 @@ impl Message {
         // string which is the concatenation of those fields).
         let data_map = char_vec.chunks(64).map(|chunk| chunk.iter().collect::<String>());
         // L1 message nonce.
-        let nonce = Felt252Wrapper::from_hex_be(&data_map.clone().last().ok_or(OffchainWorkerError::ToTransactionError)?)
-            .map_err(|_| OffchainWorkerError::ToTransactionError)?;
+        let nonce =
+            Felt252Wrapper::from_hex_be(&data_map.clone().last().ok_or(OffchainWorkerError::ToTransactionError)?)
+                .map_err(|_| OffchainWorkerError::ToTransactionError)?;
         let mut calldata: Vec<Felt252Wrapper> = Vec::new();
         for val in data_map.take(self.data.len() - 2) {
             calldata.push(match Felt252Wrapper::from_hex_be(val.as_str()) {
@@ -109,7 +110,7 @@ mod test {
             Message { topics: vec![hex.clone(), hex.clone(), hex.clone(), hex.clone()], data: hex };
         let expected_tx = Transaction {
             sender_address,
-            nonce: Felt252Wrapper::ONE, 
+            nonce: Felt252Wrapper::ONE,
             call_entrypoint: CallEntryPointWrapper {
                 class_hash: None,
                 entrypoint_type: EntryPointTypeWrapper::L1Handler,

--- a/crates/pallets/starknet/src/message.rs
+++ b/crates/pallets/starknet/src/message.rs
@@ -5,7 +5,6 @@ use mp_starknet::execution::types::{
 use mp_starknet::transaction::types::Transaction;
 use scale_codec::{Decode, Encode};
 use serde::Deserialize;
-use sp_core::U256;
 
 use crate::alloc::format;
 use crate::alloc::string::String;
@@ -69,7 +68,7 @@ impl Message {
         // string which is the concatenation of those fields).
         let data_map = char_vec.chunks(64).map(|chunk| chunk.iter().collect::<String>());
         // L1 message nonce.
-        let nonce = U256::from_str_radix(&data_map.clone().last().ok_or(OffchainWorkerError::ToTransactionError)?, 16)
+        let nonce = Felt252Wrapper::from_hex_be(&data_map.clone().last().ok_or(OffchainWorkerError::ToTransactionError)?)
             .map_err(|_| OffchainWorkerError::ToTransactionError)?;
         let mut calldata: Vec<Felt252Wrapper> = Vec::new();
         for val in data_map.take(self.data.len() - 2) {
@@ -97,7 +96,6 @@ mod test {
     use mp_starknet::execution::types::{CallEntryPointWrapper, ContractAddressWrapper, EntryPointTypeWrapper};
     use mp_starknet::transaction::types::Transaction;
     use pretty_assertions;
-    use sp_core::U256;
 
     use super::*;
     use crate::offchain_worker::OffchainWorkerError;
@@ -111,7 +109,7 @@ mod test {
             Message { topics: vec![hex.clone(), hex.clone(), hex.clone(), hex.clone()], data: hex };
         let expected_tx = Transaction {
             sender_address,
-            nonce: U256::from(1),
+            nonce: Felt252Wrapper::ONE, 
             call_entrypoint: CallEntryPointWrapper {
                 class_hash: None,
                 entrypoint_type: EntryPointTypeWrapper::L1Handler,

--- a/crates/pallets/starknet/src/tests/call_contract.rs
+++ b/crates/pallets/starknet/src/tests/call_contract.rs
@@ -1,7 +1,7 @@
 use frame_support::{assert_ok, bounded_vec};
 use mp_starknet::execution::types::Felt252Wrapper;
 use mp_starknet::transaction::types::InvokeTransaction;
-use sp_core::{ConstU32, U256};
+use sp_core::{ConstU32};
 use sp_runtime::BoundedVec;
 
 use super::constants::TOKEN_CONTRACT_CLASS_HASH;
@@ -39,9 +39,9 @@ fn given_call_contract_call_works() {
             version: 1,
             sender_address: sender_account,
             signature: bounded_vec!(),
-            nonce: U256::zero(),
+            nonce: Felt252Wrapper::ZERO,
             calldata: constructor_calldata,
-            max_fee: U256::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u128::MAX),
         };
 
         assert_ok!(Starknet::invoke(origin, deploy_transaction));

--- a/crates/pallets/starknet/src/tests/call_contract.rs
+++ b/crates/pallets/starknet/src/tests/call_contract.rs
@@ -1,7 +1,7 @@
 use frame_support::{assert_ok, bounded_vec};
 use mp_starknet::execution::types::Felt252Wrapper;
 use mp_starknet::transaction::types::InvokeTransaction;
-use sp_core::{ConstU32};
+use sp_core::ConstU32;
 use sp_runtime::BoundedVec;
 
 use super::constants::TOKEN_CONTRACT_CLASS_HASH;

--- a/crates/pallets/starknet/src/tests/declare_tx.rs
+++ b/crates/pallets/starknet/src/tests/declare_tx.rs
@@ -1,7 +1,6 @@
 use frame_support::{assert_err, assert_ok, bounded_vec};
 use mp_starknet::execution::types::{ContractClassWrapper, Felt252Wrapper};
 use mp_starknet::transaction::types::DeclareTransaction;
-use sp_core::U256;
 
 use super::mock::*;
 use super::utils::{get_contract_class, sign_message_hash};
@@ -25,8 +24,8 @@ fn given_contract_declare_tx_works_once_not_twice() {
             version: 1,
             compiled_class_hash: erc20_class_hash,
             contract_class: erc20_class,
-            nonce: U256::zero(),
-            max_fee: U256::from(u128::MAX),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
         };
 
@@ -58,8 +57,8 @@ fn given_contract_declare_tx_fails_sender_not_deployed() {
             contract_class: erc20_class,
             version: 1,
             compiled_class_hash: erc20_class_hash,
-            nonce: U256::zero(),
-            max_fee: U256::from(u128::MAX),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
         };
 
@@ -88,8 +87,8 @@ fn given_contract_declare_tx_fails_wrong_tx_version() {
             contract_class: erc20_class,
             version: wrong_tx_version,
             compiled_class_hash: erc20_class_hash,
-            nonce: U256::zero(),
-            max_fee: U256::from(u128::MAX),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
         };
 
@@ -117,8 +116,8 @@ fn given_contract_declare_on_openzeppelin_account_then_it_works() {
             contract_class: erc20_class,
             version: 1,
             compiled_class_hash: erc20_class_hash,
-            nonce: U256::zero(),
-            max_fee: U256::from(u128::MAX),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: sign_message_hash(tx_hash),
         };
 
@@ -148,8 +147,8 @@ fn given_contract_declare_on_openzeppelin_account_with_incorrect_signature_then_
             contract_class: erc20_class,
             version: 1,
             compiled_class_hash: erc20_class_hash,
-            nonce: U256::zero(),
-            max_fee: U256::from(u128::MAX),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(Felt252Wrapper::ZERO, Felt252Wrapper::ONE),
         };
 
@@ -177,8 +176,8 @@ fn given_contract_declare_on_braavos_account_then_it_works() {
             contract_class: erc20_class,
             version: 1,
             compiled_class_hash: erc20_class_hash,
-            nonce: U256::zero(),
-            max_fee: U256::from(u128::MAX),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: sign_message_hash(tx_hash),
         };
 
@@ -208,8 +207,8 @@ fn given_contract_declare_on_braavos_account_with_incorrect_signature_then_it_fa
             contract_class: erc20_class,
             version: 1,
             compiled_class_hash: erc20_class_hash,
-            nonce: U256::zero(),
-            max_fee: U256::from(u128::MAX),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(Felt252Wrapper::ZERO, Felt252Wrapper::ONE),
         };
 
@@ -237,8 +236,8 @@ fn given_contract_declare_on_argent_account_then_it_works() {
             contract_class: erc20_class,
             version: 1,
             compiled_class_hash: erc20_class_hash,
-            nonce: U256::zero(),
-            max_fee: U256::from(u128::MAX),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: sign_message_hash(tx_hash),
         };
 
@@ -268,8 +267,8 @@ fn given_contract_declare_on_argent_account_with_incorrect_signature_then_it_fai
             contract_class: erc20_class,
             version: 1,
             compiled_class_hash: erc20_class_hash,
-            nonce: U256::zero(),
-            max_fee: U256::from(u128::MAX),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(Felt252Wrapper::ZERO, Felt252Wrapper::ONE),
         };
 

--- a/crates/pallets/starknet/src/tests/deploy_account_tx.rs
+++ b/crates/pallets/starknet/src/tests/deploy_account_tx.rs
@@ -37,9 +37,9 @@ fn given_contract_run_deploy_account_tx_works() {
                     .collect::<Vec<Felt252Wrapper>>(),
             )
             .unwrap(),
-            nonce: U256::zero(),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
-            max_fee: U256::from(u128::MAX),
         };
 
         assert_ok!(Starknet::deploy_account(none_origin, transaction));
@@ -88,9 +88,9 @@ fn given_contract_run_deploy_account_tx_twice_fails() {
             .unwrap(),
             salt: U256::from_str(salt).unwrap(),
             version: 1,
-            nonce: U256::zero(),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
-            max_fee: U256::from(u128::MAX),
         };
 
         assert_ok!(Starknet::deploy_account(none_origin.clone(), transaction.clone()));
@@ -114,10 +114,10 @@ fn given_contract_run_deploy_account_tx_undeclared_then_it_fails() {
             sender_address: rand_address,
             version: 1,
             calldata: bounded_vec!(),
-            nonce: U256::zero(),
             salt: U256::zero(),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
-            max_fee: U256::from(u128::MAX),
         };
 
         assert_err!(
@@ -153,10 +153,10 @@ fn given_contract_run_deploy_account_tx_fails_wrong_tx_version() {
                     .collect::<Vec<Felt252Wrapper>>(),
             )
             .unwrap(),
-            nonce: U256::zero(),
             salt: U256::zero(),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
-            max_fee: U256::from(u128::MAX),
         };
 
         assert_err!(
@@ -196,9 +196,9 @@ fn given_contract_run_deploy_account_openzeppelin_tx_works() {
                     .collect::<Vec<Felt252Wrapper>>(),
             )
             .unwrap(),
-            nonce: U256::zero(),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: sign_message_hash(tx_hash),
-            max_fee: U256::from(u128::MAX),
         };
 
         assert_ok!(Starknet::deploy_account(none_origin, transaction));
@@ -234,9 +234,9 @@ fn given_contract_run_deploy_account_openzeppelin_with_incorrect_signature_then_
                     .collect::<Vec<Felt252Wrapper>>(),
             )
             .unwrap(),
-            nonce: U256::zero(),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(Felt252Wrapper::ONE, Felt252Wrapper::ONE),
-            max_fee: U256::from(u128::MAX),
         };
 
         assert_err!(
@@ -276,9 +276,9 @@ fn given_contract_run_deploy_account_argent_tx_works() {
                     .collect::<Vec<Felt252Wrapper>>(),
             )
             .unwrap(),
-            nonce: U256::zero(),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: sign_message_hash(tx_hash),
-            max_fee: U256::from(u128::MAX),
         };
 
         assert_ok!(Starknet::deploy_account(none_origin, transaction));
@@ -314,9 +314,9 @@ fn given_contract_run_deploy_account_argent_with_incorrect_signature_then_it_fai
                     .collect::<Vec<Felt252Wrapper>>(),
             )
             .unwrap(),
-            nonce: U256::zero(),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(Felt252Wrapper::ONE, Felt252Wrapper::ONE),
-            max_fee: U256::from(u128::MAX),
         };
 
         assert_err!(
@@ -363,9 +363,9 @@ fn given_contract_run_deploy_account_braavos_tx_works() {
                     .collect::<Vec<Felt252Wrapper>>(),
             )
             .unwrap(),
-            nonce: U256::zero(),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: signatures.try_into().unwrap(),
-            max_fee: U256::from(u128::MAX),
         };
 
         assert_ok!(Starknet::deploy_account(none_origin, transaction));
@@ -403,9 +403,9 @@ fn given_contract_run_deploy_account_braavos_with_incorrect_signature_then_it_fa
                     .collect::<Vec<Felt252Wrapper>>(),
             )
             .unwrap(),
-            nonce: U256::zero(),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: [Felt252Wrapper::ZERO; 10].to_vec().try_into().unwrap(),
-            max_fee: U256::from(u128::MAX),
         };
 
         assert_err!(

--- a/crates/pallets/starknet/src/tests/erc20.rs
+++ b/crates/pallets/starknet/src/tests/erc20.rs
@@ -2,7 +2,6 @@ use frame_support::{assert_ok, bounded_vec};
 use lazy_static::lazy_static;
 use mp_starknet::execution::types::{ContractClassWrapper, Felt252Wrapper};
 use mp_starknet::transaction::types::{EventWrapper, InvokeTransaction};
-use sp_core::U256;
 
 use super::mock::*;
 use super::utils::get_contract_class_wrapper;
@@ -40,9 +39,9 @@ fn given_erc20_transfer_when_invoke_then_it_works() {
                 Felt252Wrapper::from_hex_be("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").unwrap(), // Initial supply high
                 sender_account  // recipient
             ],
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
-            nonce: U256::zero(),
-            max_fee: U256::from(u128::MAX),
         };
         let expected_erc20_address =
             Felt252Wrapper::from_hex_be("0x00dc58c1280862c95964106ef9eba5d9ed8c0c16d05883093e4540f22b829dff").unwrap();
@@ -116,9 +115,9 @@ fn given_erc20_transfer_when_invoke_then_it_works() {
                 Felt252Wrapper::from(15u128), // initial supply low
                 Felt252Wrapper::ZERO,   // initial supply high
             ],
+            nonce: Felt252Wrapper::ONE,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
-            nonce: U256::one(),
-            max_fee: U256::from(u128::MAX),
         };
         // Also asserts that the deployment has been saved.
         assert_ok!(Starknet::invoke(origin, transfer_transaction));

--- a/crates/pallets/starknet/src/tests/invoke_tx.rs
+++ b/crates/pallets/starknet/src/tests/invoke_tx.rs
@@ -8,7 +8,7 @@ use mp_starknet::starknet_serde::transaction_from_json;
 use mp_starknet::transaction::types::{
     EventWrapper, InvokeTransaction, Transaction, TransactionReceiptWrapper, TxType,
 };
-use sp_core::{H256, U256};
+use sp_core::{H256};
 use starknet_core::utils::get_selector_from_name;
 
 use super::mock::*;
@@ -32,8 +32,8 @@ fn given_hardcoded_contract_run_invoke_tx_fails_sender_not_deployed() {
             version: 1_u8,
             sender_address: contract_address,
             calldata: bounded_vec!(),
-            nonce: U256::zero(),
-            max_fee: U256::from(u128::MAX),
+            nonce: Felt252Wrapper::ZERO,
+            max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
         };
 

--- a/crates/pallets/starknet/src/tests/invoke_tx.rs
+++ b/crates/pallets/starknet/src/tests/invoke_tx.rs
@@ -8,7 +8,7 @@ use mp_starknet::starknet_serde::transaction_from_json;
 use mp_starknet::transaction::types::{
     EventWrapper, InvokeTransaction, Transaction, TransactionReceiptWrapper, TxType,
 };
-use sp_core::{H256};
+use sp_core::H256;
 use starknet_core::utils::get_selector_from_name;
 
 use super::mock::*;

--- a/crates/primitives/starknet/src/crypto/commitment/mod.rs
+++ b/crates/primitives/starknet/src/crypto/commitment/mod.rs
@@ -2,7 +2,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use bitvec::vec::BitVec;
-use sp_core::{H256};
+use sp_core::H256;
 use starknet_crypto::FieldElement;
 
 use super::hash::pedersen::PedersenHasher;

--- a/crates/primitives/starknet/src/crypto/commitment/mod.rs
+++ b/crates/primitives/starknet/src/crypto/commitment/mod.rs
@@ -2,7 +2,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use bitvec::vec::BitVec;
-use sp_core::{H256, U256};
+use sp_core::{H256};
 use starknet_crypto::FieldElement;
 
 use super::hash::pedersen::PedersenHasher;
@@ -185,8 +185,8 @@ pub fn calculate_deploy_account_tx_hash(transaction: DeployAccountTransaction) -
 fn calculate_transaction_hash_common<T>(
     sender_address: [u8; 32],
     calldata: &[Felt252Wrapper],
-    max_fee: U256,
-    nonce: U256,
+    max_fee: Felt252Wrapper,
+    nonce: Felt252Wrapper,
     version: u8,
     tx_prefix: &[u8],
 ) -> Felt252Wrapper

--- a/crates/primitives/starknet/src/execution/felt252_wrapper.rs
+++ b/crates/primitives/starknet/src/execution/felt252_wrapper.rs
@@ -65,7 +65,6 @@ impl Felt252Wrapper {
         let fe = FieldElement::from_dec_str(value)?;
         Ok(Self(fe))
     }
-
 }
 
 impl Default for Felt252Wrapper {
@@ -215,7 +214,6 @@ impl From<Felt252Wrapper> for StarkFelt {
         StarkFelt::new(buf).unwrap()
     }
 }
-
 
 /// SCALE trait.
 impl Encode for Felt252Wrapper {

--- a/crates/primitives/starknet/src/execution/felt252_wrapper.rs
+++ b/crates/primitives/starknet/src/execution/felt252_wrapper.rs
@@ -65,6 +65,7 @@ impl Felt252Wrapper {
         let fe = FieldElement::from_dec_str(value)?;
         Ok(Self(fe))
     }
+
 }
 
 impl Default for Felt252Wrapper {
@@ -214,6 +215,7 @@ impl From<Felt252Wrapper> for StarkFelt {
         StarkFelt::new(buf).unwrap()
     }
 }
+
 
 /// SCALE trait.
 impl Encode for Felt252Wrapper {

--- a/crates/primitives/starknet/src/starknet_serde/mod.rs
+++ b/crates/primitives/starknet/src/starknet_serde/mod.rs
@@ -214,7 +214,7 @@ impl TryFrom<DeserializeTransaction> for Transaction {
             .map_err(DeserializeTransactionError::InvalidSenderAddress)?;
 
         // Convert nonce to U256
-        let nonce = U256::from(d.nonce);
+        let nonce = Felt252Wrapper::try_from( U256::from(d.nonce)).unwrap();
 
         // Convert call_entrypoint to CallEntryPointWrapper
         let call_entrypoint = CallEntryPointWrapper::try_from(d.call_entrypoint)

--- a/crates/primitives/starknet/src/starknet_serde/mod.rs
+++ b/crates/primitives/starknet/src/starknet_serde/mod.rs
@@ -214,7 +214,7 @@ impl TryFrom<DeserializeTransaction> for Transaction {
             .map_err(DeserializeTransactionError::InvalidSenderAddress)?;
 
         // Convert nonce to U256
-        let nonce = Felt252Wrapper::try_from( U256::from(d.nonce)).unwrap();
+        let nonce = Felt252Wrapper::try_from(U256::from(d.nonce)).unwrap();
 
         // Convert call_entrypoint to CallEntryPointWrapper
         let call_entrypoint = CallEntryPointWrapper::try_from(d.call_entrypoint)

--- a/crates/primitives/starknet/src/tests/crypto.rs
+++ b/crates/primitives/starknet/src/tests/crypto.rs
@@ -31,11 +31,11 @@ fn test_deploy_account_tx_hash() {
         version: 1,
         sender_address: Felt252Wrapper::from(19911991_u128),
         calldata: bounded_vec!(Felt252Wrapper::ONE, Felt252Wrapper::TWO, Felt252Wrapper::THREE),
-        nonce: U256::zero(),
+        nonce: Felt252Wrapper::ZERO,
         salt: U256::zero(),
         signature: bounded_vec!(),
         account_class_hash: Felt252Wrapper::THREE,
-        max_fee: U256::one(),
+        max_fee: Felt252Wrapper::ONE,
     };
     assert_eq!(calculate_deploy_account_tx_hash(transaction), expected_tx_hash);
 }
@@ -49,9 +49,9 @@ fn test_declare_tx_hash() {
     let transaction = DeclareTransaction {
         version: 1,
         sender_address: Felt252Wrapper::from(19911991_u128),
-        nonce: U256::zero(),
+        nonce: Felt252Wrapper::ZERO,
         signature: bounded_vec!(),
-        max_fee: U256::one(),
+        max_fee: Felt252Wrapper::ONE,
         compiled_class_hash: Felt252Wrapper::THREE,
         contract_class: ContractClassWrapper::default(),
     };
@@ -68,9 +68,9 @@ fn test_invoke_tx_hash() {
         version: 1,
         sender_address: Felt252Wrapper::from(19911991_u128),
         calldata: bounded_vec!(Felt252Wrapper::ONE, Felt252Wrapper::TWO, Felt252Wrapper::THREE),
-        nonce: U256::zero(),
+        nonce: Felt252Wrapper::ZERO,
         signature: bounded_vec!(),
-        max_fee: U256::one(),
+        max_fee: Felt252Wrapper::ONE,
     };
     assert_eq!(calculate_invoke_tx_hash(transaction), expected_tx_hash);
 }
@@ -88,11 +88,11 @@ fn test_merkle_tree() {
                 Felt252Wrapper::from(30_u128),
             ],
             sender_address: Felt252Wrapper::ZERO,
-            nonce: U256::zero(),
+            nonce: Felt252Wrapper::ZERO,
             call_entrypoint: CallEntryPointWrapper::default(),
             contract_class: None,
             contract_address_salt: None,
-            max_fee: U256::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u128::MAX),
         },
         Transaction {
             tx_type: TxType::Invoke,
@@ -100,11 +100,11 @@ fn test_merkle_tree() {
             hash: Felt252Wrapper::from(28_u128),
             signature: bounded_vec![Felt252Wrapper::from(40_u128)],
             sender_address: Felt252Wrapper::try_from(&[1; 32]).unwrap(),
-            nonce: U256::zero(),
+            nonce: Felt252Wrapper::ZERO,
             call_entrypoint: CallEntryPointWrapper::default(),
             contract_class: None,
             contract_address_salt: None,
-            max_fee: U256::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u128::MAX),
         },
     ];
     let tx_com = calculate_transaction_commitment::<PedersenHasher>(&txs);

--- a/crates/primitives/starknet/src/tests/transaction.rs
+++ b/crates/primitives/starknet/src/tests/transaction.rs
@@ -175,7 +175,7 @@ fn verify_tx_version_passes_for_valid_version() {
             Felt252Wrapper::from(30_u128)
         ],
         sender_address: Felt252Wrapper::ZERO,
-        nonce: U256::zero(),
+        nonce: Felt252Wrapper::ZERO,
         ..Transaction::default()
     };
 
@@ -193,7 +193,7 @@ fn verify_tx_version_fails_for_invalid_version() {
             Felt252Wrapper::from(30_u128)
         ],
         sender_address: Felt252Wrapper::ZERO,
-        nonce: U256::zero(),
+        nonce: Felt252Wrapper::ZERO,
         ..Transaction::default()
     };
 

--- a/crates/primitives/starknet/src/transaction/mod.rs
+++ b/crates/primitives/starknet/src/transaction/mod.rs
@@ -282,11 +282,11 @@ impl Transaction {
         hash: Felt252Wrapper,
         signature: BoundedVec<Felt252Wrapper, MaxArraySize>,
         sender_address: ContractAddressWrapper,
-        nonce: U256,
+        nonce: Felt252Wrapper,
         call_entrypoint: CallEntryPointWrapper,
         contract_class: Option<ContractClassWrapper>,
         contract_address_salt: Option<U256>,
-        max_fee: U256,
+        max_fee: Felt252Wrapper,
     ) -> Self {
         Self {
             tx_type,
@@ -686,12 +686,12 @@ impl Default for Transaction {
             version: 1_u8,
             hash: one,
             signature: BoundedVec::try_from(vec![one, one]).unwrap(),
-            nonce: U256::default(),
+            nonce: Felt252Wrapper::default(),
             sender_address: ContractAddressWrapper::default(),
             call_entrypoint: CallEntryPointWrapper::default(),
             contract_class: None,
             contract_address_salt: None,
-            max_fee: U256::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u128::MAX),
         }
     }
 }

--- a/crates/primitives/starknet/src/transaction/types.rs
+++ b/crates/primitives/starknet/src/transaction/types.rs
@@ -159,11 +159,11 @@ pub struct DeclareTransaction {
     /// Contract to declare.
     pub contract_class: ContractClassWrapper,
     /// Account contract nonce.
-    pub nonce: U256,
+    pub nonce: Felt252Wrapper,
     /// Transaction signature.
     pub signature: BoundedVec<Felt252Wrapper, MaxArraySize>,
     /// Max fee.
-    pub max_fee: U256,
+    pub max_fee: Felt252Wrapper,
 }
 
 /// Deploy account transaction.
@@ -187,7 +187,7 @@ pub struct DeployAccountTransaction {
     /// Transaction calldata.
     pub calldata: BoundedVec<Felt252Wrapper, MaxCalldataSize>,
     /// Account contract nonce.
-    pub nonce: U256,
+    pub nonce: Felt252Wrapper,
     /// Transaction salt.
     pub salt: U256,
     /// Transaction signature.
@@ -195,7 +195,7 @@ pub struct DeployAccountTransaction {
     /// Account class hash.
     pub account_class_hash: Felt252Wrapper,
     /// Max fee.
-    pub max_fee: U256,
+    pub max_fee: Felt252Wrapper,
 }
 
 /// Error of conversion between [DeclareTransaction], [InvokeTransaction],
@@ -246,11 +246,11 @@ pub struct InvokeTransaction {
     /// Transaction calldata.
     pub calldata: BoundedVec<Felt252Wrapper, MaxCalldataSize>,
     /// Account contract nonce.
-    pub nonce: U256,
+    pub nonce: Felt252Wrapper,
     /// Transaction signature.
     pub signature: BoundedVec<Felt252Wrapper, MaxArraySize>,
     /// Max fee.
-    pub max_fee: U256,
+    pub max_fee: Felt252Wrapper,
 }
 
 impl From<Transaction> for InvokeTransaction {
@@ -290,7 +290,7 @@ pub struct Transaction {
     /// Sender Address
     pub sender_address: ContractAddressWrapper,
     /// Nonce
-    pub nonce: U256,
+    pub nonce: Felt252Wrapper,
     /// Call entrypoint
     pub call_entrypoint: CallEntryPointWrapper,
     /// Contract Class
@@ -298,7 +298,7 @@ pub struct Transaction {
     /// Contract Address Salt
     pub contract_address_salt: Option<U256>,
     /// Max fee.
-    pub max_fee: U256,
+    pub max_fee: Felt252Wrapper,
 }
 
 impl TryFrom<Transaction> for DeployAccountTransaction {
@@ -426,9 +426,9 @@ impl TryFrom<Transaction> for RPCTransaction {
     type Error = RPCTransactionConversionError;
     fn try_from(value: Transaction) -> Result<Self, Self::Error> {
         let transaction_hash = value.hash.0;
-        let max_fee = Felt252Wrapper::try_from(value.max_fee)?.0;
+        let max_fee = value.max_fee.0;
         let signature = value.signature.iter().map(|&f| f.0).collect();
-        let nonce = Felt252Wrapper::try_from(value.nonce)?.0;
+        let nonce = value.nonce.0;
         let sender_address = value.sender_address.0;
         let class_hash = value.call_entrypoint.class_hash.ok_or(RPCTransactionConversionError::MissingInformation);
         let contract_address = value.call_entrypoint.storage_address.0;
@@ -493,7 +493,7 @@ impl TryFrom<Transaction> for RPCTransaction {
                 class_hash: class_hash?.0,
             })),
             TxType::L1Handler => {
-                let nonce = value.nonce.as_u64(); // this panics in case of overflow
+                let nonce = TryInto::try_into(value.nonce).unwrap(); // this panics in case of overflow
                 Ok(RPCTransaction::L1Handler(RPCL1HandlerTransaction {
                     transaction_hash,
                     version: value.version.into(),

--- a/tests/util/starknet.ts
+++ b/tests/util/starknet.ts
@@ -2,8 +2,9 @@ import "@keep-starknet-strange/madara-api-augment";
 import { type ApiPromise } from "@polkadot/api";
 import { type ApiTypes, type SubmittableExtrinsic } from "@polkadot/api/types";
 import { type ISubmittableResult } from "@polkadot/types/types";
-import { stringify, u8aWrapBytes } from "@polkadot/util";
+import { stringify, u8aWrapBytes, numberToU8a } from "@polkadot/util";
 import erc20Json from "../contracts/compiled/erc20.json";
+import { numberToU832Bytes } from "./utils";
 export async function sendTransactionNoValidation(
   transaction: SubmittableExtrinsic<"promise", ISubmittableResult>
 ): Promise<void> {
@@ -248,7 +249,7 @@ export function transfer(
     version: 1, // version of the transaction
     signature: [], // leave empty for now, will be filled in when signing the transaction
     sender_address: contractAddress, // address of the sender contract
-    nonce: nonce || 0, // nonce of the transaction
+    nonce: numberToU832Bytes(nonce ? nonce : 0), // nonce of the transaction
     calldata: [
       tokenAddress, // CONTRACT ADDRESS
       "0x0083afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e", // SELECTOR (transfer)

--- a/tests/util/starknet.ts
+++ b/tests/util/starknet.ts
@@ -2,7 +2,7 @@ import "@keep-starknet-strange/madara-api-augment";
 import { type ApiPromise } from "@polkadot/api";
 import { type ApiTypes, type SubmittableExtrinsic } from "@polkadot/api/types";
 import { type ISubmittableResult } from "@polkadot/types/types";
-import { stringify, u8aWrapBytes, numberToU8a } from "@polkadot/util";
+import { stringify, u8aWrapBytes } from "@polkadot/util";
 import erc20Json from "../contracts/compiled/erc20.json";
 import { numberToU832Bytes } from "./utils";
 export async function sendTransactionNoValidation(

--- a/tests/util/utils.ts
+++ b/tests/util/utils.ts
@@ -27,7 +27,7 @@ export function toBN(value: BigNumberish) {
 
 // Convert a BigNumberish to a 32 byte uint array
 export function numberToU832Bytes(value: number) {
-  return numberToU8a(value,256)
+  return numberToU8a(value, 256);
 }
 
 export async function rpcTransfer(

--- a/tests/util/utils.ts
+++ b/tests/util/utils.ts
@@ -11,6 +11,7 @@ import {
   FEE_TOKEN_ADDRESS,
   SIGNER_PRIVATE,
 } from "../tests/constants";
+import { numberToU8a } from "@polkadot/util";
 
 export type BigNumberish = string | number | BN__default;
 
@@ -22,6 +23,11 @@ export function toHex(value: BigNumberish) {
 // Convert a string or number to a BN
 export function toBN(value: BigNumberish) {
   return number.toBN(value);
+}
+
+// Convert a BigNumberish to a 32 byte uint array
+export function numberToU832Bytes(value: number) {
+  return numberToU8a(value,256)
 }
 
 export async function rpcTransfer(


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- Feature

## What is the current behavior?

The current transaction types use `U256` for `nonce` and `max_fees`.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #456 

## What is the new behavior?

This PR makes the type of `nonce` and `max_fees` -> `Felt252Wrapper`.