### PR TITLE
bug: Corrections on docker_run.sh and the documentation relative to it

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -204,17 +204,15 @@ docker-compose -f infra/docker/docker-compose.yml up -d
 ```
 
 This command will firstly compile your code, and then start a local development
-network. You can also replace the default command
-(`cargo build --release && ./target/release/madara --dev --ws-external`) by
-appending your own. A few useful ones are as follow.
+network. You can also use the `docker_run.sh` script appending your own command. A few useful ones are as follow.
 
 ```bash
 # Run Substrate node without re-compiling
-./infra/docker_run.sh ./target/release/madara --dev --ws-external
+./infra/docker/docker_run.sh ./target/release/madara --dev --ws-external
 
 # Purge the local dev chain
-./infra/docker_run.sh ./target/release/madara purge-chain --dev
+./infra/docker/docker_run.sh ./target/release/madara purge-chain --dev
 
 # Check whether the code is compilable
-./infra/docker_run.sh cargo check
+./infra/docker/docker_run.sh cargo check
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -204,7 +204,8 @@ docker-compose -f infra/docker/docker-compose.yml up -d
 ```
 
 This command will firstly compile your code, and then start a local development
-network. You can also use the `docker_run.sh` script appending your own command. A few useful ones are as follow.
+network. You can also use the `docker_run.sh` script appending your own command.
+A few useful ones are as follow.
 
 ```bash
 # Run Substrate node without re-compiling

--- a/infra/docker/docker_run.sh
+++ b/infra/docker/docker_run.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "*** Start Substrate node template ***"
 
-cd $(dirname ${BASH_SOURCE[0]})/..
+cd $(dirname $0)
 
 docker-compose down --remove-orphans
 docker-compose run --rm --service-ports dev $@


### PR DESCRIPTION
This PR introduces some corrections to the `docker_run.sh` file and the documentation. It also tries to clarify the usage of the script.

# Pull Request type
Bug

Please add the labels corresponding to the type of changes your PR introduces:
- Bugfix
- Documentation content changes

## What is the current behavior?
- It was not possible to run the `infra/docker/docker_run.sh` due to permissions
- The `infra/docker/docker_run.sh` would fail to run if we were not in the right folder
- The `Getting Started` documentation had wrong paths for running some commands
- The `Getting Started` documentation was unclear on running the `docker_run.sh`. From the text, it seemed that you should change the content of the `docker-compose.yml`, replacing the content of the command. In reality, the `docker_run.sh` is a wrapper for the `docker-compose.yml` and should be run ad-hoc

Resolves: #NA

## What is the new behavior?
- It is now possible to run the `infra/docker/docker_run.sh` as soon as you clone the repo
- We can run the `infra/docker/docker_run.sh` from any folder
- The `Getting Started` documentation was corrected. Please verify if you agree with the sentence that was "clarified"

## Does this introduce a breaking change?
No

## Other information
None