### PR TITLE
feat: Improve docker-compose performance

### DIFF
--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -3,12 +3,14 @@ version: "3.2"
 services:
   dev:
     container_name: madara
+    platform: linux/amd64
     image: paritytech/ci-linux:production
     working_dir: /var/www/madara
     ports:
       - "9944:9944"
     environment:
       - CARGO_HOME=/var/www/madara/.cargo
+      - CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
     volumes:
       - ../../:/var/www/madara
       - type: bind


### PR DESCRIPTION
This PR contains some small improvements in the docker-compose performance.

# Pull Request type
Feature

Please add the labels corresponding to the type of changes your PR introduces:
- Feature
- Build-related changes

## What is the current behavior?
- There are warnings while running the `docker-compose` when not running it in amd64 architectures (tested in a Mac M1) due to using `paritytech/ci-linux` as the base container
- When you run amd64 containers on Mac, they are runned with some emulator, which leads Cargo to use way more memory ([users.rust-lang.org](https://users.rust-lang.org/t/cargo-uses-too-much-memory-being-run-in-qemu/76531), [rust-lang/cargo#10781](https://github.com/rust-lang/cargo/issues/10781)). In some systems, the `cargo build --release` will crash while updating the crates.io index

Resolves: #NA

## What is the new behavior?
- Specified the platform for the container, this way there are no more warnings. Although the performance is not improved by doing this
- Use Cargo's new sparse index protocol to reduce the memory footprint of updating the crates.io index ([Cargo Sparse Protocol](https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html)), leading to some performance improvements
  - The sparse protocol seems to be a nice approach to be used not only for the docker build, but also for the whole project config
  - An alternative that also reduces the memory footprint (I tested, and it works), is to use the command-line `git` instead of `libgit2`. We can do that by appending `--config net.git-fetch-with-cli=true` to the build command, or add that configurations in the Cargo config file

## Does this introduce a breaking change?
No

## Other information
This PR was opened as a draft for us to discuss if this is the best approach to go and ignore performance issues on aarch64 (such as Macs Mx and RPi), or if we should support docker on other architectures (replacing `paritytech/ci-linux` base image).
