### PR TITLE
Add describe for route in rpc tests

### DIFF
--- a/tests/tests/test-rpc/test-starknet-rpc.ts
+++ b/tests/tests/test-rpc/test-starknet-rpc.ts
@@ -1,41 +1,40 @@
 import "@keep-starknet-strange/madara-api-augment";
 import chai, { expect } from "chai";
-import { createAndFinalizeBlock } from "../../util/block";
 import deepEqualInAnyOrder from "deep-equal-in-any-order";
 import {
+  Account,
   LibraryError,
   RpcProvider,
-  Account,
+  constants,
   ec,
   hash,
-  constants,
   validateAndParseAddress,
 } from "starknet";
-import { jumpBlocks } from "../../util/block";
+import { createAndFinalizeBlock, jumpBlocks } from "../../util/block";
 import { describeDevMadara } from "../../util/setup-dev-tests";
+import { rpcTransfer, toBN, toHex } from "../../util/utils";
 import {
   ACCOUNT_CONTRACT,
   ACCOUNT_CONTRACT_CLASS_HASH,
+  ARGENT_ACCOUNT_CLASS_HASH,
   ARGENT_CONTRACT_ADDRESS,
+  ARGENT_PROXY_CLASS_HASH,
   CHAIN_ID_STARKNET_TESTNET,
+  ERC20_COMPILED,
   FEE_TOKEN_ADDRESS,
   MINT_AMOUNT,
+  SALT,
+  SIGNER_PRIVATE,
+  SIGNER_PUBLIC,
   TEST_CONTRACT,
   TEST_CONTRACT_CLASS_HASH,
   TOKEN_CLASS_HASH,
-  ARGENT_ACCOUNT_CLASS_HASH,
-  ARGENT_PROXY_CLASS_HASH,
-  SIGNER_PRIVATE,
-  SIGNER_PUBLIC,
-  SALT,
-  ERC20_COMPILED,
 } from "../constants";
-import { toHex, toBN, rpcTransfer } from "../../util/utils";
 
 chai.use(deepEqualInAnyOrder);
 
 // keep "let" over "const" as the nonce is passed by reference
-// to abstract the incrementation
+// to abstract the increment
 // eslint-disable-next-line prefer-const
 let ARGENT_CONTRACT_NONCE = { value: 0 };
 
@@ -49,373 +48,378 @@ describeDevMadara("Starknet RPC", (context) => {
     }); // substrate node
   });
 
-  it("getBlockhashAndNumber", async function () {
-    const block = await providerRPC.getBlockHashAndNumber();
+  describe("getBlockhashAndNumber", () => {
+    it("should not be undefined", async function () {
+      const block = await providerRPC.getBlockHashAndNumber();
 
-    expect(block).to.not.be.undefined;
-  });
-
-  it("getBlockNumber", async function () {
-    const blockNumber = await providerRPC.getBlockNumber();
-
-    expect(blockNumber).to.not.be.undefined;
-
-    await jumpBlocks(context, 10);
-
-    const blockNumber2 = await providerRPC.getBlockNumber();
-
-    expect(blockNumber2).to.be.equal(blockNumber + 10);
-  });
-
-  it("getBlockTransactionCount", async function () {
-    const transactionCount = await providerRPC.getTransactionCount("latest");
-
-    expect(transactionCount).to.not.be.undefined;
-    expect(transactionCount).to.be.equal(0);
-  });
-
-  it("getNonce", async function () {
-    let nonce = await providerRPC.getNonceForAddress(
-      ARGENT_CONTRACT_ADDRESS,
-      "latest"
-    );
-
-    expect(nonce).to.not.be.undefined;
-    expect(toHex(nonce)).to.be.equal(toHex(ARGENT_CONTRACT_NONCE.value));
-
-    await context.createBlock(
-      rpcTransfer(
-        providerRPC,
-        ARGENT_CONTRACT_NONCE,
-        ARGENT_CONTRACT_ADDRESS,
-        MINT_AMOUNT
-      )
-    );
-
-    nonce = await providerRPC.getNonceForAddress(
-      ARGENT_CONTRACT_ADDRESS,
-      "latest"
-    );
-
-    expect(nonce).to.not.be.undefined;
-    expect(toHex(nonce)).to.be.equal(toHex(ARGENT_CONTRACT_NONCE.value));
-  });
-
-  it("call", async function () {
-    const call = await providerRPC.callContract(
-      {
-        contractAddress: TEST_CONTRACT,
-        entrypoint: "return_result",
-        calldata: ["0x19"],
-      },
-      "latest"
-    );
-
-    expect(call.result).to.contain("0x19");
-  });
-
-  it("getClassAt", async function () {
-    const contract_class = await providerRPC.getClassAt(
-      TEST_CONTRACT,
-      "latest"
-    );
-
-    expect(contract_class).to.not.be.undefined;
-  });
-
-  it("getClassHashAt", async function () {
-    const account_contract_class_hash = await providerRPC.getClassHashAt(
-      ACCOUNT_CONTRACT,
-      "latest"
-    );
-
-    expect(account_contract_class_hash).to.not.be.undefined;
-    expect(validateAndParseAddress(account_contract_class_hash)).to.be.equal(
-      ACCOUNT_CONTRACT_CLASS_HASH
-    );
-
-    const test_contract_class_hash = await providerRPC.getClassHashAt(
-      TEST_CONTRACT,
-      "latest"
-    );
-
-    expect(test_contract_class_hash).to.not.be.undefined;
-    expect(validateAndParseAddress(test_contract_class_hash)).to.be.equal(
-      TEST_CONTRACT_CLASS_HASH
-    );
-
-    // Invalid block id
-    try {
-      await providerRPC.getClassHashAt(TEST_CONTRACT, "0x123");
-    } catch (error) {
-      expect(error).to.be.instanceOf(LibraryError);
-      expect(error.message).to.equal("24: Block not found");
-    }
-
-    // Invalid/un-deployed contract address
-    try {
-      await providerRPC.getClassHashAt("0x123", "latest");
-    } catch (error) {
-      expect(error).to.be.instanceOf(LibraryError);
-      expect(error.message).to.equal("20: Contract not found");
-    }
-  });
-
-  it("syncing", async function () {
-    await jumpBlocks(context, 10);
-
-    const status = await providerRPC.getSyncingStats();
-    const current_block = await providerRPC.getBlockHashAndNumber();
-
-    // starknet starting block number should be 0 with this test setup
-    expect(status["starting_block_num"]).to.be.equal("0x0");
-    // starknet current and highest block number should be equal to
-    // the current block with this test setup
-    expect(parseInt(status["current_block_num"])).to.be.equal(
-      current_block["block_number"]
-    );
-    expect(parseInt(status["highest_block_num"])).to.be.equal(
-      current_block["block_number"]
-    );
-
-    // the starknet block hash for number 0 starts with "0x49ee" with this test setup
-    expect(status["starting_block_hash"]).to.contain("0x49ee");
-    // starknet current and highest block number should be equal to
-    // the current block with this test setup
-    expect(status["current_block_hash"]).to.be.equal(
-      current_block["block_hash"]
-    );
-    expect(status["highest_block_hash"]).to.be.equal(
-      current_block["block_hash"]
-    );
-  });
-
-  it("getClass", async function () {
-    const contract_class = await providerRPC.getClass(
-      TOKEN_CLASS_HASH,
-      "latest"
-    );
-
-    expect(contract_class).to.not.be.undefined;
-  });
-
-  it("getBlockWithTxHashes returns transactions", async function () {
-    await context.createBlock(
-      rpcTransfer(
-        providerRPC,
-        ARGENT_CONTRACT_NONCE,
-        ARGENT_CONTRACT_ADDRESS,
-        MINT_AMOUNT
-      )
-    );
-
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const blockWithTxHashes: { status: string; transactions: string[] } =
-      await providerRPC.getBlockWithTxHashes("latest");
-    expect(blockWithTxHashes).to.not.be.undefined;
-    expect(blockWithTxHashes.status).to.be.equal("ACCEPTED_ON_L2");
-    expect(blockWithTxHashes.transactions.length).to.be.equal(1);
-  });
-
-  it("getBlockWithTxHashes throws block not found error", async function () {
-    await providerRPC.getBlockWithTxHashes("0x123").catch((error) => {
-      expect(error).to.be.instanceOf(LibraryError);
-      expect(error.message).to.equal("24: Block not found");
+      expect(block).to.not.be.undefined;
     });
   });
 
-  it("getBlockWithTxs returns transactions", async function () {
-    await context.createBlock(
-      rpcTransfer(
-        providerRPC,
-        ARGENT_CONTRACT_NONCE,
+  describe("getBlockNumber", async () => {
+    it("should return current block number", async function () {
+      const blockNumber = await providerRPC.getBlockNumber();
+
+      expect(blockNumber).to.not.be.undefined;
+
+      await jumpBlocks(context, 10);
+
+      const blockNumber2 = await providerRPC.getBlockNumber();
+
+      expect(blockNumber2).to.be.equal(blockNumber + 10);
+    });
+  });
+
+  describe("getBlockTransactionCount", async () => {
+    it("should return 0 for latest block", async function () {
+      const transactionCount = await providerRPC.getTransactionCount("latest");
+
+      expect(transactionCount).to.not.be.undefined;
+      expect(transactionCount).to.be.equal(0);
+    });
+  });
+
+  describe("getNonce", async () => {
+    it("should increase after a transaction", async function () {
+      let nonce = await providerRPC.getNonceForAddress(
         ARGENT_CONTRACT_ADDRESS,
-        MINT_AMOUNT
-      )
-    );
-
-    const blockHash = await providerRPC.getBlockHashAndNumber();
-    await jumpBlocks(context, 10);
-
-    const blockWithTxHashes = await providerRPC.getBlockWithTxs(
-      blockHash.block_hash
-    );
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const tx: { type: string; sender_address: string; calldata: string[] } =
-      blockWithTxHashes.transactions[0];
-    expect(blockWithTxHashes).to.not.be.undefined;
-    expect(blockWithTxHashes.transactions.length).to.be.equal(1);
-    expect(tx.type).to.be.equal("INVOKE");
-    expect(tx.sender_address).to.be.equal(toHex(ARGENT_CONTRACT_ADDRESS));
-    expect(tx.calldata).to.deep.equal(
-      [
-        1,
-        FEE_TOKEN_ADDRESS,
-        hash.getSelectorFromName("transfer"),
-        0,
-        3,
-        3,
-        ARGENT_CONTRACT_ADDRESS,
-        MINT_AMOUNT,
-        0,
-      ].map(toHex)
-    );
-  });
-
-  it("getBlockWithTxs throws block not found error", async function () {
-    await providerRPC.getBlockWithTxHashes("0x123").catch((error) => {
-      expect(error).to.be.instanceOf(LibraryError);
-      expect(error.message).to.equal("24: Block not found");
-    });
-  });
-
-  it("getBlockWithTxs returns empty block", async function () {
-    await context.createBlock(undefined, {
-      parentHash: undefined,
-      finalize: true,
-    });
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const latestBlock: { status: string; transactions: string[] } =
-      await providerRPC.getBlockWithTxHashes("latest");
-    expect(latestBlock).to.not.be.undefined;
-    expect(latestBlock.status).to.be.equal("ACCEPTED_ON_L2");
-    expect(latestBlock.transactions.length).to.be.equal(0);
-  });
-
-  it("getBlockWithTxHashes returns empty block", async function () {
-    await context.createBlock(undefined, {
-      parentHash: undefined,
-      finalize: true,
-    });
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const latestBlock: { status: string; transactions: string[] } =
-      await providerRPC.getBlockWithTxHashes("latest");
-    expect(latestBlock).to.not.be.undefined;
-    expect(latestBlock.status).to.be.equal("ACCEPTED_ON_L2");
-    expect(latestBlock.transactions.length).to.be.equal(0);
-  });
-
-  it("Gets value from the fee contract storage", async function () {
-    const value = await providerRPC.getStorageAt(
-      FEE_TOKEN_ADDRESS,
-      // ERC20_balances(0x02).low
-      "0x1d8bbc4f93f5ab9858f6c0c0de2769599fb97511503d5bf2872ef6846f2146f",
-      "latest"
-    );
-    // fees were paid du to the transfer in the previous test so the value is still u128::MAX
-    expect(toHex(value)).to.be.equal("0xffffffffffffffffffffffffffffffff");
-  });
-
-  it("Returns 0 if the storage slot is not set", async function () {
-    const value = await providerRPC.getStorageAt(
-      FEE_TOKEN_ADDRESS,
-      "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "latest"
-    );
-    expect(value).to.be.equal("0");
-  });
-
-  it("Returns an error if the contract does not exist", async function () {
-    try {
-      await providerRPC.getStorageAt(
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
         "latest"
       );
-    } catch (error) {
-      expect(error).to.be.instanceOf(LibraryError);
-      expect(error.message).to.equal("20: Contract not found");
-    }
-  });
+      await context.createBlock(
+        rpcTransfer(
+          providerRPC,
+          ARGENT_CONTRACT_NONCE,
+          ARGENT_CONTRACT_ADDRESS,
+          MINT_AMOUNT
+        )
+      );
 
-  it("chainId", async function () {
-    const chainId = await providerRPC.getChainId();
-
-    expect(chainId).to.not.be.undefined;
-    expect(chainId).to.be.equal(CHAIN_ID_STARKNET_TESTNET);
-  });
-
-  it("getTransactionByBlockIdAndIndex returns transactions", async function () {
-    // Send a transaction
-    await context.createBlock(
-      rpcTransfer(
-        providerRPC,
-        ARGENT_CONTRACT_NONCE,
+      nonce = await providerRPC.getNonceForAddress(
         ARGENT_CONTRACT_ADDRESS,
-        MINT_AMOUNT
-      )
-    );
+        "latest"
+      );
 
-    const getTransactionByBlockIdAndIndexResponse =
-      await providerRPC.getTransactionByBlockIdAndIndex("latest", 0);
-
-    expect(getTransactionByBlockIdAndIndexResponse).to.not.be.undefined;
+      expect(nonce).to.not.be.undefined;
+      expect(toHex(nonce)).to.be.equal(toHex(ARGENT_CONTRACT_NONCE.value));
+    });
   });
 
-  it("getTransactionByBlockIdAndIndex throws block not found error", async function () {
-    await providerRPC
-      .getTransactionByBlockIdAndIndex("0x123", 2)
-      .catch((error) => {
+  describe("call", async () => {
+    it("should return calldata on return_result entrypoint", async function () {
+      const call = await providerRPC.callContract(
+        {
+          contractAddress: TEST_CONTRACT,
+          entrypoint: "return_result",
+          calldata: ["0x19"],
+        },
+        "latest"
+      );
+
+      expect(call.result).to.contain("0x19");
+    });
+  });
+
+  describe("getClassAt", async () => {
+    it("should not be undefined", async function () {
+      const contract_class = await providerRPC.getClassAt(
+        TEST_CONTRACT,
+        "latest"
+      );
+
+      expect(contract_class).to.not.be.undefined;
+    });
+  });
+
+  describe("getClassHashAt", async () => {
+    it("should return correct class hashes for account and test contract", async function () {
+      const account_contract_class_hash = await providerRPC.getClassHashAt(
+        ACCOUNT_CONTRACT,
+        "latest"
+      );
+
+      expect(account_contract_class_hash).to.not.be.undefined;
+      expect(validateAndParseAddress(account_contract_class_hash)).to.be.equal(
+        ACCOUNT_CONTRACT_CLASS_HASH
+      );
+
+      const test_contract_class_hash = await providerRPC.getClassHashAt(
+        TEST_CONTRACT,
+        "latest"
+      );
+
+      expect(test_contract_class_hash).to.not.be.undefined;
+      expect(validateAndParseAddress(test_contract_class_hash)).to.be.equal(
+        TEST_CONTRACT_CLASS_HASH
+      );
+    });
+    it("should raise with invalid block id", async () => {
+      // Invalid block id
+      try {
+        await providerRPC.getClassHashAt(TEST_CONTRACT, "0x123");
+      } catch (error) {
+        expect(error).to.be.instanceOf(LibraryError);
+        expect(error.message).to.equal("24: Block not found");
+      }
+    });
+    it("should raise with invalid contract address", async () => {
+      // Invalid/un-deployed contract address
+      try {
+        await providerRPC.getClassHashAt("0x123", "latest");
+      } catch (error) {
+        expect(error).to.be.instanceOf(LibraryError);
+        expect(error.message).to.equal("20: Contract not found");
+      }
+    });
+  });
+
+  describe("syncing", async () => {
+    it("should return starting setup and current_block info", async function () {
+      await jumpBlocks(context, 10);
+
+      const status = await providerRPC.getSyncingStats();
+      const current_block = await providerRPC.getBlockHashAndNumber();
+
+      // starknet starting block number should be 0 with this test setup
+      expect(status["starting_block_num"]).to.be.equal("0x0");
+      // starknet current and highest block number should be equal to
+      // the current block with this test setup
+      expect(parseInt(status["current_block_num"])).to.be.equal(
+        current_block["block_number"]
+      );
+      expect(parseInt(status["highest_block_num"])).to.be.equal(
+        current_block["block_number"]
+      );
+
+      // the starknet block hash for number 0 starts with "0x49ee" with this test setup
+      expect(status["starting_block_hash"]).to.contain("0x49ee");
+      // starknet current and highest block number should be equal to
+      // the current block with this test setup
+      expect(status["current_block_hash"]).to.be.equal(
+        current_block["block_hash"]
+      );
+      expect(status["highest_block_hash"]).to.be.equal(
+        current_block["block_hash"]
+      );
+    });
+  });
+
+  describe("getClass", async () => {
+    it("should not be undefined", async function () {
+      const contract_class = await providerRPC.getClass(
+        TOKEN_CLASS_HASH,
+        "latest"
+      );
+      expect(contract_class).to.not.be.undefined;
+    });
+  });
+
+  describe("getBlockWithTxHashes", async () => {
+    it("should returns transactions", async function () {
+      await context.createBlock(
+        rpcTransfer(
+          providerRPC,
+          ARGENT_CONTRACT_NONCE,
+          ARGENT_CONTRACT_ADDRESS,
+          MINT_AMOUNT
+        )
+      );
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      const blockWithTxHashes: { status: string; transactions: string[] } =
+        await providerRPC.getBlockWithTxHashes("latest");
+      expect(blockWithTxHashes).to.not.be.undefined;
+      expect(blockWithTxHashes.status).to.be.equal("ACCEPTED_ON_L2");
+      expect(blockWithTxHashes.transactions.length).to.be.equal(1);
+    });
+
+    it("should throws block not found error", async function () {
+      await providerRPC.getBlockWithTxHashes("0x123").catch((error) => {
         expect(error).to.be.instanceOf(LibraryError);
         expect(error.message).to.equal("24: Block not found");
       });
-  });
-
-  it("getTransactionByBlockIdAndIndex throws invalid transaction index error", async function () {
-    await context.createBlock(undefined, {
-      parentHash: undefined,
-      finalize: true,
     });
-    const latestBlockCreated = await providerRPC.getBlockHashAndNumber();
-    await providerRPC
-      .getTransactionByBlockIdAndIndex(latestBlockCreated.block_hash, 2)
-      .catch((error) => {
+  });
+
+  describe("getBlockWithTxs", async () => {
+    it("should returns transactions", async function () {
+      await context.createBlock(
+        rpcTransfer(
+          providerRPC,
+          ARGENT_CONTRACT_NONCE,
+          ARGENT_CONTRACT_ADDRESS,
+          MINT_AMOUNT
+        )
+      );
+
+      const blockHash = await providerRPC.getBlockHashAndNumber();
+      await jumpBlocks(context, 10);
+
+      const blockWithTxHashes = await providerRPC.getBlockWithTxs(
+        blockHash.block_hash
+      );
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      const tx: { type: string; sender_address: string; calldata: string[] } =
+        blockWithTxHashes.transactions[0];
+      expect(blockWithTxHashes).to.not.be.undefined;
+      expect(blockWithTxHashes.transactions.length).to.be.equal(1);
+      expect(tx.type).to.be.equal("INVOKE");
+      expect(tx.sender_address).to.be.equal(toHex(ARGENT_CONTRACT_ADDRESS));
+      expect(tx.calldata).to.deep.equal(
+        [
+          1,
+          FEE_TOKEN_ADDRESS,
+          hash.getSelectorFromName("transfer"),
+          0,
+          3,
+          3,
+          ARGENT_CONTRACT_ADDRESS,
+          MINT_AMOUNT,
+          0,
+        ].map(toHex)
+      );
+    });
+
+    it("should throws block not found error", async function () {
+      await providerRPC.getBlockWithTxHashes("0x123").catch((error) => {
         expect(error).to.be.instanceOf(LibraryError);
-        expect(error.message).to.equal(
-          "27: Invalid transaction index in a block"
-        );
+        expect(error.message).to.equal("24: Block not found");
       });
+    });
+
+    it("should returns empty block", async function () {
+      await context.createBlock(undefined, {
+        parentHash: undefined,
+        finalize: true,
+      });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      const latestBlock: { status: string; transactions: string[] } =
+        await providerRPC.getBlockWithTxHashes("latest");
+      expect(latestBlock).to.not.be.undefined;
+      expect(latestBlock.status).to.be.equal("ACCEPTED_ON_L2");
+      expect(latestBlock.transactions.length).to.be.equal(0);
+    });
   });
 
-  it("Adds an invocation transaction successfully", async function () {
-    const nonce = await providerRPC.getNonceForAddress(
-      ARGENT_CONTRACT_ADDRESS,
-      "latest"
-    );
+  describe("getBlockWithTxHashes", async () => {
+    it("should return an empty block", async function () {
+      await context.createBlock(undefined, {
+        parentHash: undefined,
+        finalize: true,
+      });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      const latestBlock: { status: string; transactions: string[] } =
+        await providerRPC.getBlockWithTxHashes("latest");
+      expect(latestBlock).to.not.be.undefined;
+      expect(latestBlock.status).to.be.equal("ACCEPTED_ON_L2");
+      expect(latestBlock.transactions.length).to.be.equal(0);
+    });
+  });
 
-    const keyPair = ec.getKeyPair(SIGNER_PRIVATE);
-    const account = new Account(providerRPC, ARGENT_CONTRACT_ADDRESS, keyPair);
+  describe("getStorageAt", async () => {
+    it("should return value from the fee contract storage", async function () {
+      const value = await providerRPC.getStorageAt(
+        FEE_TOKEN_ADDRESS,
+        // ERC20_balances(0x02).low
+        "0x1d8bbc4f93f5ab9858f6c0c0de2769599fb97511503d5bf2872ef6846f2146f",
+        "latest"
+      );
+      // fees were paid du to the transfer in the previous test so the value is still u128::MAX
+      expect(toHex(value)).to.be.equal("0xffffffffffffffffffffffffffffffff");
+    });
 
-    const resp = await account.execute(
-      {
-        contractAddress: TEST_CONTRACT,
-        entrypoint: "test_storage_var",
-        calldata: [],
-      },
-      undefined,
-      {
-        nonce: nonce,
-        maxFee: "123456",
+    it("should return 0 if the storage slot is not set", async function () {
+      const value = await providerRPC.getStorageAt(
+        FEE_TOKEN_ADDRESS,
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "latest"
+      );
+      expect(value).to.be.equal("0");
+    });
+
+    it("should raise if the contract does not exist", async function () {
+      try {
+        await providerRPC.getStorageAt(
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "latest"
+        );
+      } catch (error) {
+        expect(error).to.be.instanceOf(LibraryError);
+        expect(error.message).to.equal("20: Contract not found");
       }
-    );
-
-    expect(resp).to.not.be.undefined;
-    expect(resp.transaction_hash).to.contain("0x");
+    });
   });
 
-  it("Returns error when invocation absent entrypoint", async function () {
-    const keyPair = ec.getKeyPair(SIGNER_PRIVATE);
-    const account = new Account(providerRPC, ARGENT_CONTRACT_ADDRESS, keyPair);
+  describe("chainId", async () => {
+    it("should return the correct value", async function () {
+      const chainId = await providerRPC.getChainId();
 
-    try {
-      await account.execute(
+      expect(chainId).to.not.be.undefined;
+      expect(chainId).to.be.equal(CHAIN_ID_STARKNET_TESTNET);
+    });
+  });
+
+  describe("getTransactionByBlockIdAndIndex", async () => {
+    it("should returns transactions", async function () {
+      // Send a transaction
+      await context.createBlock(
+        rpcTransfer(
+          providerRPC,
+          ARGENT_CONTRACT_NONCE,
+          ARGENT_CONTRACT_ADDRESS,
+          MINT_AMOUNT
+        )
+      );
+
+      const getTransactionByBlockIdAndIndexResponse =
+        await providerRPC.getTransactionByBlockIdAndIndex("latest", 0);
+
+      expect(getTransactionByBlockIdAndIndexResponse).to.not.be.undefined;
+    });
+
+    it("should throws block not found error", async function () {
+      await providerRPC
+        .getTransactionByBlockIdAndIndex("0x123", 2)
+        .catch((error) => {
+          expect(error).to.be.instanceOf(LibraryError);
+          expect(error.message).to.equal("24: Block not found");
+        });
+    });
+
+    it("should throws invalid transaction index error", async function () {
+      await context.createBlock(undefined, {
+        parentHash: undefined,
+        finalize: true,
+      });
+      const latestBlockCreated = await providerRPC.getBlockHashAndNumber();
+      await providerRPC
+        .getTransactionByBlockIdAndIndex(latestBlockCreated.block_hash, 2)
+        .catch((error) => {
+          expect(error).to.be.instanceOf(LibraryError);
+          expect(error.message).to.equal(
+            "27: Invalid transaction index in a block"
+          );
+        });
+    });
+  });
+
+  describe("addInvokeTransaction", async () => {
+    it("should invoke successfully", async function () {
+      const keyPair = ec.getKeyPair(SIGNER_PRIVATE);
+      const account = new Account(
+        providerRPC,
+        ARGENT_CONTRACT_ADDRESS,
+        keyPair
+      );
+
+      const resp = await account.execute(
         {
           contractAddress: TEST_CONTRACT,
-          entrypoint: "test_storage_var_WRONG",
+          entrypoint: "test_storage_var",
           calldata: [],
         },
         undefined,
@@ -424,144 +428,190 @@ describeDevMadara("Starknet RPC", (context) => {
           maxFee: "123456",
         }
       );
-    } catch (error) {
-      expect(error).to.be.instanceOf(LibraryError);
-      expect(error.message).to.equal("40: Contract error");
-    }
+
+      expect(resp).to.not.be.undefined;
+      expect(resp.transaction_hash).to.contain("0x");
+    });
+
+    it("should raise with unknown entrypoint", async function () {
+      const keyPair = ec.getKeyPair(SIGNER_PRIVATE);
+      const account = new Account(
+        providerRPC,
+        ARGENT_CONTRACT_ADDRESS,
+        keyPair
+      );
+
+      try {
+        await account.execute(
+          {
+            contractAddress: TEST_CONTRACT,
+            entrypoint: "test_storage_var_WRONG",
+            calldata: [],
+          },
+          undefined,
+          {
+            nonce: "0",
+            maxFee: "123456",
+          }
+        );
+      } catch (error) {
+        expect(error).to.be.instanceOf(LibraryError);
+        expect(error.message).to.equal("40: Contract error");
+      }
+    });
   });
 
-  it("Adds an deploy account transaction successfully", async function () {
-    // Compute contract address
-    const selector = hash.getSelectorFromName("initialize");
-    const calldata = [ARGENT_ACCOUNT_CLASS_HASH, selector, 2, SIGNER_PUBLIC, 0];
+  describe("addDeployAccountTransaction", async () => {
+    it("should deploy successfully", async function () {
+      // Compute contract address
+      const selector = hash.getSelectorFromName("initialize");
+      const calldata = [
+        ARGENT_ACCOUNT_CLASS_HASH,
+        selector,
+        2,
+        SIGNER_PUBLIC,
+        0,
+      ];
 
-    const deployedContractAddress = hash.calculateContractAddressFromHash(
-      SALT,
-      ARGENT_PROXY_CLASS_HASH,
-      calldata,
-      0
-    );
+      const deployedContractAddress = hash.calculateContractAddressFromHash(
+        SALT,
+        ARGENT_PROXY_CLASS_HASH,
+        calldata,
+        0
+      );
 
-    const invocationDetails = {
-      nonce: "0x0",
-      maxFee: "0x1111111111111111111111",
-      version: "0x1",
-    };
+      const invocationDetails = {
+        nonce: "0x0",
+        maxFee: "0x1111111111111111111111",
+        version: "0x1",
+      };
 
-    const txHash = hash.calculateDeployAccountTransactionHash(
-      deployedContractAddress,
-      ARGENT_PROXY_CLASS_HASH,
-      calldata,
-      SALT,
-      invocationDetails.version,
-      invocationDetails.maxFee,
-      constants.StarknetChainId.TESTNET,
-      invocationDetails.nonce
-    );
+      const txHash = hash.calculateDeployAccountTransactionHash(
+        deployedContractAddress,
+        ARGENT_PROXY_CLASS_HASH,
+        calldata,
+        SALT,
+        invocationDetails.version,
+        invocationDetails.maxFee,
+        constants.StarknetChainId.TESTNET,
+        invocationDetails.nonce
+      );
 
-    const keyPair = ec.getKeyPair(SIGNER_PRIVATE);
-    const signature = ec.sign(keyPair, txHash);
+      const keyPair = ec.getKeyPair(SIGNER_PRIVATE);
+      const signature = ec.sign(keyPair, txHash);
 
-    // Deploy account contract
-    const txDeployAccount = {
-      signature: signature, // signature
-      contractAddress: deployedContractAddress, // address of the sender contract
-      addressSalt: SALT, // contract address salt
-      classHash: ARGENT_PROXY_CLASS_HASH, // class hash of the contract
-      constructorCalldata: calldata,
-    };
+      // Deploy account contract
+      const txDeployAccount = {
+        signature: signature, // signature
+        contractAddress: deployedContractAddress, // address of the sender contract
+        addressSalt: SALT, // contract address salt
+        classHash: ARGENT_PROXY_CLASS_HASH, // class hash of the contract
+        constructorCalldata: calldata,
+      };
 
-    await providerRPC.deployAccountContract(txDeployAccount, invocationDetails);
-    await createAndFinalizeBlock(context.polkadotApi);
+      await providerRPC.deployAccountContract(
+        txDeployAccount,
+        invocationDetails
+      );
+      await createAndFinalizeBlock(context.polkadotApi);
 
-    const accountContractClass = await providerRPC.getClassHashAt(
-      deployedContractAddress
-    );
+      const accountContractClass = await providerRPC.getClassHashAt(
+        deployedContractAddress
+      );
 
-    expect(validateAndParseAddress(accountContractClass)).to.be.equal(
-      ARGENT_PROXY_CLASS_HASH
-    );
+      expect(validateAndParseAddress(accountContractClass)).to.be.equal(
+        ARGENT_PROXY_CLASS_HASH
+      );
+    });
   });
 
   // TODO:
   //    - once starknet-rs supports query tx version
-  //    - test w/ account.estimateInvokeFee, account.estimateDeclareFee, account.estiamteAccountDeployFee
-  it("Estimates the fee of an invoke tx successfully", async function () {
-    const tx = {
-      contractAddress: ACCOUNT_CONTRACT,
-      calldata: [
-        TEST_CONTRACT,
-        "0x36fa6de2810d05c3e1a0ebe23f60b9c2f4629bbead09e5a9704e1c5632630d5",
-        "0x0",
-      ],
-    };
+  //    - test w/ account.estimateInvokeFee, account.estimateDeclareFee, account.estimateAccountDeployFee
+  describe("estimateFee", async () => {
+    it("should estimate fee to 0", async function () {
+      const tx = {
+        contractAddress: ACCOUNT_CONTRACT,
+        calldata: [
+          TEST_CONTRACT,
+          "0x36fa6de2810d05c3e1a0ebe23f60b9c2f4629bbead09e5a9704e1c5632630d5",
+          "0x0",
+        ],
+      };
 
-    const nonce = await providerRPC.getNonceForAddress(
-      ACCOUNT_CONTRACT,
-      "latest"
-    );
+      const nonce = await providerRPC.getNonceForAddress(
+        ACCOUNT_CONTRACT,
+        "latest"
+      );
 
-    const txDetails = {
-      nonce: nonce,
-      version: "0x1",
-    };
+      const txDetails = {
+        nonce: nonce,
+        version: "0x1",
+      };
 
-    const fee_estimate = await providerRPC.getEstimateFee(
-      tx,
-      txDetails,
-      "latest"
-    );
+      const fee_estimate = await providerRPC.getEstimateFee(
+        tx,
+        txDetails,
+        "latest"
+      );
 
-    expect(fee_estimate.overall_fee.cmp(toBN(0))).to.be.equal(1);
-    expect(fee_estimate.gas_consumed.cmp(toBN(0))).to.be.equal(1);
+      expect(fee_estimate.overall_fee.cmp(toBN(0))).to.be.equal(1);
+      expect(fee_estimate.gas_consumed.cmp(toBN(0))).to.be.equal(1);
+    });
+
+    it("should raise if contract does not exist", async function () {
+      const tx = {
+        contractAddress: ACCOUNT_CONTRACT,
+        calldata: [
+          "0x000000000000000000000000000000000000000000000000000000000000DEAD",
+          "0x36fa6de2810d05c3e1a0ebe23f60b9c2f4629bbead09e5a9704e1c5632630d5",
+          "0x0",
+        ],
+      };
+
+      const nonce = await providerRPC.getNonceForAddress(
+        ACCOUNT_CONTRACT,
+        "latest"
+      );
+
+      const txDetails = {
+        nonce: nonce,
+        version: "0x1",
+      };
+      try {
+        await providerRPC.getEstimateFee(tx, txDetails, "latest");
+      } catch (error) {
+        expect(error).to.be.instanceOf(LibraryError);
+        expect(error.message).to.equal("40: Contract error");
+      }
+    });
   });
 
-  it("getEstimateFee throws error if contract does not exist", async function () {
-    const tx = {
-      contractAddress: ACCOUNT_CONTRACT,
-      calldata: [
-        "0x000000000000000000000000000000000000000000000000000000000000DEAD",
-        "0x36fa6de2810d05c3e1a0ebe23f60b9c2f4629bbead09e5a9704e1c5632630d5",
-        "0x0",
-      ],
-    };
+  describe("addDeclareTransaction", async () => {
+    it("should return hash starting with 0x", async function () {
+      const nonce = await providerRPC.getNonceForAddress(
+        ARGENT_CONTRACT_ADDRESS,
+        "latest"
+      );
 
-    const nonce = await providerRPC.getNonceForAddress(
-      ACCOUNT_CONTRACT,
-      "latest"
-    );
+      const keyPair = ec.getKeyPair(SIGNER_PRIVATE);
+      const account = new Account(
+        providerRPC,
+        ARGENT_CONTRACT_ADDRESS,
+        keyPair
+      );
 
-    const txDetails = {
-      nonce: nonce,
-      version: "0x1",
-    };
-    try {
-      await providerRPC.getEstimateFee(tx, txDetails, "latest");
-    } catch (error) {
-      expect(error).to.be.instanceOf(LibraryError);
-      expect(error.message).to.equal("40: Contract error");
-    }
-  });
+      const resp = await account.declare(
+        {
+          classHash:
+            "0x057eca87f4b19852cfd4551cf4706ababc6251a8781733a0a11cf8e94211da95",
+          contract: ERC20_COMPILED,
+        },
+        { nonce, version: 1, maxFee: "123456" }
+      );
 
-  it("Adds a declare transaction successfully", async function () {
-    const nonce = await providerRPC.getNonceForAddress(
-      ARGENT_CONTRACT_ADDRESS,
-      "latest"
-    );
-
-    const keyPair = ec.getKeyPair(SIGNER_PRIVATE);
-    const account = new Account(providerRPC, ARGENT_CONTRACT_ADDRESS, keyPair);
-
-    const resp = await account.declare(
-      {
-        classHash:
-          "0x057eca87f4b19852cfd4551cf4706ababc6251a8781733a0a11cf8e94211da95",
-        contract: ERC20_COMPILED,
-      },
-      { nonce, version: 1, maxFee: "123456" }
-    );
-
-    expect(resp).to.not.be.undefined;
-    expect(resp.transaction_hash).to.contain("0x");
+      expect(resp).to.not.be.undefined;
+      expect(resp.transaction_hash).to.contain("0x");
+    });
   });
 });

--- a/tests/util/setup-dev-tests.ts
+++ b/tests/util/setup-dev-tests.ts
@@ -1,4 +1,4 @@
-import { type ApiPromise, Keyring } from "@polkadot/api";
+import { Keyring, type ApiPromise } from "@polkadot/api";
 import { type ApiTypes, type SubmittableExtrinsic } from "@polkadot/api/types";
 import { type EventRecord } from "@polkadot/types/interfaces";
 import { type RegistryError } from "@polkadot/types/types";
@@ -7,12 +7,12 @@ import { type ChildProcess } from "child_process";
 import { createAndFinalizeBlock } from "./block";
 import { DEBUG_MODE, SPAWNING_TIME } from "./constants";
 import {
-  type RuntimeChain,
   startMadaraDevNode,
   startMadaraForkedNode,
+  type RuntimeChain,
 } from "./dev-node";
 import { providePolkadotApi } from "./providers";
-import { type ExtrinsicCreation, extractError } from "./substrate-rpc";
+import { extractError, type ExtrinsicCreation } from "./substrate-rpc";
 
 import { type KeyringPair } from "@polkadot/keyring/types";
 import debugFactory from "debug";
@@ -267,7 +267,7 @@ export function describeDevMadara(
         };
       };
 
-      debug(`Setup ready for ${this.currentTest.title}`);
+      debug(`Setup ready`);
     });
 
     after(async function () {


### PR DESCRIPTION
# Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- Refactoring (no functional changes, no API changes)

## What is the current behavior?

All the tests are in the same describe, hindering readability of input file and output results.

## What is the new behavior?

Added a `describe` per route (SUT) and rephrased the `it` to be descriptive of what's being actually tested.

## Does this introduce a breaking change?

No

## Other information

We could add test scaffolding for not implemented routes as well, with "describe.skip" and ask the contributor to "unskip and make pass".

See <img width="489" alt="image" src="https://github.com/keep-starknet-strange/madara/assets/18620296/0b106866-c46a-47a6-8588-602fd183a933"> compared to <img width="492" alt="image" src="https://github.com/keep-starknet-strange/madara/assets/18620296/d77df974-8dc5-49ee-8b3d-fbf545b58a21">.

I didn't remove tests, so not sure why codecov complains.