### PR TITLE
Update madara gh page with benchmark graphs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,12 +12,12 @@ on:
       - "README.md"
   pull_request:
     branches: [main]
-    # paths-ignore:
-    # - ".github/**"
-    # - "docs/**"
-    # - "examples/**"
-    # - ".*"
-    # - "README.md"
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "examples/**"
+      - ".*"
+      - "README.md"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -54,7 +54,7 @@ jobs:
         with:
           tool: "customBiggerIsBetter"
           output-file-path: ./benchmarking/reports/metrics.json
-          alert-threshold: "150%"
+          alert-threshold: "120%"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-alert: true
           comment-on-alert: true
@@ -62,7 +62,7 @@ jobs:
           comment-always: true
           auto-push: false
       - name: Push result on gh page
-        # if: github.event_name == 'push' && github.base_ref == 'main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run:
           git push
           'https://keep-starknet-strange:${{secrets.GITHUB_TOKEN}}@github.com/keep-starknet-strange/madara.git'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -62,7 +62,7 @@ jobs:
           comment-always: true
           auto-push: false
       - name: Push result on gh page
-        if: github.event_name == 'push' && github.base_ref == 'main'
+        # if: github.event_name == 'push' && github.base_ref == 'main'
         run:
           git push
           'https://keep-starknet-strange:${{secrets.GITHUB_TOKEN}}@github.com/keep-starknet-strange/madara.git'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,27 +49,20 @@ jobs:
           cd benchmarking
           cargo run --release -- --dev  --pool-limit=100000 --pool-kbytes=500000 --rpc-methods=unsafe --rpc-cors=all --in-peers=0 --out-peers=0 --no-telemetry &
           npm run test
-
-      - name: Download previous benchmark data
-        uses: actions/cache@v1
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-benchmark
-
-      - name: Store benchmark result
+      - name: Compare result
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          # What benchmark tool the output.txt came from
           tool: "customBiggerIsBetter"
-          # Where the output from the benchmark tool is stored
           output-file-path: ./benchmarking/reports/metrics.json
-          # Where the previous data file is stored
-          external-data-json-path: ./cache/benchmark-data.json
-          # Workflow will fail when an alert happens
+          alert-threshold: "150%"
           fail-on-alert: true
-          # GitHub API token to make a commit comment
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Enable alert commit comment
           comment-on-alert: true
-          # Enable Job Summary for PRs
           summary-always: true
+          comment-always: true
+          auto-push: false
+      - name: Push result on gh page
+        if: github.event_name == 'push' && github.base_ref == 'main'
+        run:
+          git push
+          'https://keep-starknet-strange:${{secrets.GITHUB_TOKEN}}@github.com/keep-starknet-strange/madara.git'
+          gh-pages:gh-pages

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,12 +12,12 @@ on:
       - "README.md"
   pull_request:
     branches: [main]
-    paths-ignore:
-      - ".github/**"
-      - "docs/**"
-      - "examples/**"
-      - ".*"
-      - "README.md"
+    # paths-ignore:
+    # - ".github/**"
+    # - "docs/**"
+    # - "examples/**"
+    # - ".*"
+    # - "README.md"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -55,6 +55,7 @@ jobs:
           tool: "customBiggerIsBetter"
           output-file-path: ./benchmarking/reports/metrics.json
           alert-threshold: "150%"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-alert: true
           comment-on-alert: true
           summary-always: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,8 +58,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-alert: true
           comment-on-alert: true
-          summary-always: true
-          comment-always: true
+          summary-always: false
+          comment-always: false
           auto-push: false
       - name: Push result on gh page
         if: github.event_name == 'push' && github.base_ref == 'main'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,7 +59,7 @@ jobs:
           fail-on-alert: true
           comment-on-alert: true
           summary-always: false
-          comment-always: false
+          comment-always: true
           auto-push: false
       - name: Push result on gh page
         if: github.event_name == 'push' && github.base_ref == 'main'


### PR DESCRIPTION
# Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- Feature
- Build-related changes

## What is the current behavior?

Benchmarks are run against the main branch but historical data is not available.

Resolves: #488

## What is the new behavior?

TPS and Extrinsic/block metrics are visible at [keep-starknet-strange.github.io/madara/dev/bench](https://keep-starknet-strange.github.io/madara/dev/bench)

## Does this introduce a breaking change?

No

## Other information
