### PR TITLE
Add pull-requests permissions to benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,6 +27,8 @@ permissions:
   deployments: write
   # contents permission to update benchmark contents in gh-pages branch
   contents: write
+  # post on the pull-request page
+  pull-requests: write
 
 jobs:
   benchmark:


### PR DESCRIPTION
# Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?

The Benchmarking CI fails, most probably because of a permission issue, see

- [this failing run](https://github.com/keep-starknet-strange/madara/actions/runs/5132996057/jobs/9235548571?pr=501)
- [this SO thread](https://stackoverflow.com/questions/70435286/resource-not-accessible-by-integration-on-github-post-repos-owner-repo-ac)

## What is the new behavior?

Added the `pull-requests: write` permission.

## Does this introduce a breaking change?

No

## Other information

See also [the GH doc about permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
