### PR TITLE
bugfix: fixed the endless loop in benchmarking if node start fails

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,8 +47,7 @@ jobs:
       - name: Run benchmark
         run: |
           cd benchmarking
-          cargo run --release -- --dev  --pool-limit=100000 --pool-kbytes=500000 --rpc-methods=unsafe --rpc-cors=all --in-peers=0 --out-peers=1 --no-telemetry &
-          npm run test
+          npm run test:ci
       - name: Compare result
         uses: benchmark-action/github-action-benchmark@v1
         with:

--- a/benchmarking/package.json
+++ b/benchmarking/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:transfer && npm run metrics",
     "chain:dev": "../scripts/run_node.sh",
     "test:wait": "wait-on tcp:9944 && npm run test",
-    "test:ci": "concurrently -k 'npm run chain:dev' 'npm run test:wait'"
+    "test:ci": "concurrently -k --success last 'npm run chain:dev' 'npm run test:wait'"
   },
   "keywords": [
     "madara",

--- a/benchmarking/package.json
+++ b/benchmarking/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:transfer && npm run metrics",
     "chain:dev": "../scripts/run_node.sh",
     "test:wait": "wait-on tcp:9944 && npm run test",
-    "test:ci": "concurrently -k --success last 'npm run chain:dev' 'npm run test:wait'"
+    "test:ci": "concurrently -k --success 'command-1' 'npm run chain:dev' 'npm run test:wait'"
   },
   "keywords": [
     "madara",

--- a/benchmarking/package.json
+++ b/benchmarking/package.json
@@ -13,7 +13,7 @@
     "metrics": "node scripts/metrics.js",
     "test": "npm run test:transfer && npm run metrics",
     "chain:dev": "../scripts/run_node.sh",
-    "test:wait": "wait-on tcp:9944 --timeout 300000 && npm run test",
+    "test:wait": "wait-on tcp:9944 && npm run test",
     "test:ci": "concurrently -k 'npm run chain:dev' 'npm run test:wait'"
   },
   "keywords": [

--- a/benchmarking/package.json
+++ b/benchmarking/package.json
@@ -13,8 +13,8 @@
     "metrics": "node scripts/metrics.js",
     "test": "npm run test:transfer && npm run metrics",
     "chain:dev": "../scripts/run_node.sh",
-    "test:wait": "wait-on tcp:9944 && npm run test",
-    "test:ci": "concurrently 'npm run chain:dev' '../scripts/test.sh'"
+    "test:wait": "wait-on tcp:9944 --timeout 300000 && npm run test",
+    "test:ci": "concurrently -k --sucess first 'npm run chain:dev' 'npm run test:wait'"
   },
   "keywords": [
     "madara",

--- a/benchmarking/package.json
+++ b/benchmarking/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:transfer && npm run metrics",
     "chain:dev": "../scripts/run_node.sh",
     "test:wait": "wait-on tcp:9944 --timeout 300000 && npm run test",
-    "test:ci": "concurrently -k --sucess first 'npm run chain:dev' 'npm run test:wait'"
+    "test:ci": "concurrently -k 'npm run chain:dev' 'npm run test:wait'"
   },
   "keywords": [
     "madara",

--- a/scripts/run_node.sh
+++ b/scripts/run_node.sh
@@ -2,4 +2,4 @@
 # This script is meant to be run on Unix/Linux based systems
 set -e
 
-exec ./target/release/madara --dev --ws-external --execution native --pool-limit=100000 --pool-kbytes=500000
+exec ../target/release/madara --dev --pool-limit=100000 --pool-kbytes=500000 --rpc-methods=unsafe --rpc-cors=all --in-peers=0 --out-peers=1 --no-telemetry


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If the benchmarking tests fail to start a madara node, the artillery tests keep retrying the connection and never end. This causes the benchmarking test to keep running and never fail.

Resolves: #498 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Instead of using `cargo run` in the `Run benchmark` step of the workflow, we can now use `npm run test:ci` as it's more standard and any changes in CI testing will automatically reflect in benchmarking.
- `npm run test:ci` command uses the `concurrently` package to start the node (1) and run the tests (2). The command has now been configured to kill other commands if any one of the command fails (-k option). 
    - If the node fails, the benchmarking fails and exits with code 1. 
    - If the node runs, the tests are executed. After test execution, the node is killed and the entire command exits with the status of test execution (--success 'command-1')

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
