### PR TITLE
Add host spec in benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -60,4 +60,5 @@ jobs:
           fail-on-alert: true
           summary-always: ${{ github.ref == 'refs/heads/main' }}
           comment-always: false
+          comment-on-alert: false
           auto-push: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,5 +59,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-alert: true
           summary-always: ${{ github.ref == 'refs/heads/main' }}
-          comment-always: true
+          comment-always: false
           auto-push: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,13 +58,6 @@ jobs:
           alert-threshold: "120%"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-alert: true
-          comment-on-alert: false
-          summary-always: false
-          comment-always: false
-          auto-push: false
-      - name: Push result on gh page
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run:
-          git push
-          'https://keep-starknet-strange:${{secrets.GITHUB_TOKEN}}@github.com/keep-starknet-strange/madara.git'
-          gh-pages:gh-pages
+          summary-always: ${{ github.ref == 'refs/heads/main' }}
+          comment-always: true
+          auto-push: ${{ github.ref == 'refs/heads/main' }}

--- a/benchmarking/scripts/metrics.js
+++ b/benchmarking/scripts/metrics.js
@@ -1,7 +1,32 @@
 const { ApiPromise, WsProvider } = require("@polkadot/api");
 const fs = require("fs");
+const os = require("os");
 
 const BLOCK_TIME = 6; // in seconds
+
+function hostSpec() {
+  // Retrieve the CPU information
+  const cpuCount = os.cpus().length;
+  const cpu = os.cpus()[0];
+  const cpuModel = cpu.model;
+  const cpuSpeed = cpu.speed;
+
+  // Retrieve the total memory in bytes
+  const totalMemory = os.totalmem();
+
+  // Retrieve the operating system platform
+  const platform = os.platform();
+
+  // Retrieve the operating system release
+  const release = os.release();
+
+  // Retrieve the architecture of the machine
+  const architecture = os.arch();
+
+  return `CPU Count: ${cpuCount}\nCPU Model: ${cpuModel}\nCPU Speed (MHz): ${cpuSpeed}\nTotal Memory: ${
+    totalMemory / 1e9
+  } GB\nPlatform: ${platform}\nRelease: ${release}\nArchitecture: ${architecture}`;
+}
 
 async function main() {
   const wsProvider = new WsProvider("ws://localhost:9944");
@@ -32,11 +57,13 @@ async function main() {
         name: "Average Extrinsics per block",
         unit: "extrinsics/block",
         value: avgExtrinsicsPerBlock,
+        extra: hostSpec(),
       },
-      { name: "Average TPS", unit: "tps", value: avgTps },
+      { name: "Average TPS", unit: "tps", value: avgTps, extra: hostSpec() },
     ])
   );
 
+  console.log(`Benchmark running on:\n${hostSpec()}`);
   console.log(
     `Average TPS : ${avgTps} (avgExtrinsicsPerBlock: ${avgExtrinsicsPerBlock})`
   );


### PR DESCRIPTION
# Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- Build-related changes

## What is the current behavior?

The spec of the host machines are not reported in the benchmark

## What is the new behavior?

Spec are added in the tooltip for each data point.

## Does this introduce a breaking change?

No

## Other information

The GH action actually dumps the data in the follows [data file](../blob/gh-pages/dev/bench/data.js)
When needed, we could update the default FE [index.html](../blob/gh-pages/dev/bench/index.html) to do more data viz.
