### PR TITLE
feat: move calculation of deployed account address #500

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4678,7 +4678,6 @@ dependencies = [
 name = "mp-starknet"
 version = "0.1.0-alpha"
 dependencies = [
- "anyhow",
  "bitvec 0.17.4",
  "blockifier",
  "cairo-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4678,6 +4678,7 @@ dependencies = [
 name = "mp-starknet"
 version = "0.1.0-alpha"
 dependencies = [
+ "anyhow",
  "bitvec 0.17.4",
  "blockifier",
  "cairo-vm",

--- a/crates/client/rpc-core/src/utils.rs
+++ b/crates/client/rpc-core/src/utils.rs
@@ -13,6 +13,8 @@ use mp_starknet::execution::types::{
     ContractClassWrapper, EntryPointTypeWrapper, EntryPointWrapper, Felt252Wrapper, MaxEntryPoints,
 };
 use mp_starknet::transaction::types::{DeclareTransaction, DeployAccountTransaction, InvokeTransaction, Transaction};
+use sp_api::HeaderT;
+use sp_blockchain::HeaderBackend;
 use sp_runtime::{BoundedBTreeMap, BoundedVec};
 use starknet_core::types::{
     BroadcastedDeclareTransaction, BroadcastedDeployAccountTransaction, BroadcastedInvokeTransaction,

--- a/crates/client/rpc-core/src/utils.rs
+++ b/crates/client/rpc-core/src/utils.rs
@@ -104,16 +104,16 @@ pub fn to_deploy_account_tx(tx: BroadcastedDeployAccountTransaction) -> Result<D
         .try_into()
         .map_err(|_| anyhow!("failed to bound signatures Vec<H256> by MaxArraySize"))?;
 
-    let sender_address = calculate_contract_address(
-        ContractAddressSalt(StarkFelt(contract_address_salt)),
-        ClassHash(StarkFelt(account_class_hash.to_bytes_be())),
-        &Calldata(calldata.into()),
-        StarknetContractAddress::default(),
-    )
-    .map_err(|e| anyhow!("Failed to calculate contract address: {e}"))?
-    .0
-    .0
-    .into();
+    // let sender_address = calculate_contract_address(
+    //     ContractAddressSalt(StarkFelt(contract_address_salt)),
+    //     ClassHash(StarkFelt(account_class_hash.to_bytes_be())),
+    //     &Calldata(calldata.into()),
+    //     StarknetContractAddress::default(),
+    // )
+    // .map_err(|e| anyhow!("Failed to calculate contract address: {e}"))?
+    // .0
+    // .0
+    // .into();
 
     let calldata = tx
         .constructor_calldata
@@ -128,7 +128,7 @@ pub fn to_deploy_account_tx(tx: BroadcastedDeployAccountTransaction) -> Result<D
 
     Ok(DeployAccountTransaction {
         version: 1_u8,
-        sender_address,
+        // sender_address,
         calldata,
         salt: U256::from(contract_address_salt),
         signature,

--- a/crates/client/rpc-core/src/utils.rs
+++ b/crates/client/rpc-core/src/utils.rs
@@ -55,9 +55,8 @@ pub fn to_tx(request: BroadcastedTransaction, chain_id: &str) -> Result<Transact
     match request {
         BroadcastedTransaction::Invoke(invoke_tx) => to_invoke_tx(invoke_tx).map(|inner| inner.from_invoke(chain_id)),
         BroadcastedTransaction::Declare(_) => Err(StarknetError::FailedToReceiveTransaction.into()), /* TODO: add support once #341 is supported */
-        BroadcastedTransaction::DeployAccount(deploy_account_tx) => {
-            to_deploy_account_tx(deploy_account_tx).map(|inner| inner.from_deploy(chain_id))
-        }
+        BroadcastedTransaction::DeployAccount(deploy_account_tx) => to_deploy_account_tx(deploy_account_tx)
+            .and_then(|inner| inner.from_deploy(chain_id).map_err(|e| anyhow!(e))),
     }
 }
 

--- a/crates/client/rpc-core/src/utils.rs
+++ b/crates/client/rpc-core/src/utils.rs
@@ -100,7 +100,7 @@ pub fn to_deploy_account_tx(tx: BroadcastedDeployAccountTransaction) -> Result<D
         .map(|f| (*f).into())
         .collect::<Vec<Felt252Wrapper>>()
         .try_into()
-        .map_err(|_| anyhow!("failed to bound calldata Vec<U256> by MaxArraySize"))?;
+        .map_err(|_| anyhow!("failed to bound calldata Vec<U256> by MaxCalldataSize"))?;
 
     let nonce = Felt252Wrapper::from(tx.nonce);
     let max_fee = Felt252Wrapper::from(tx.max_fee);

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -625,7 +625,12 @@ where
             StarknetRpcApiError::InternalServerError
         })?;
 
-        let transaction: MPTransaction = deploy_account_transaction.from_deploy(&self.chain_id_str(best_block_hash)?);
+        let transaction: MPTransaction =
+            deploy_account_transaction.from_deploy(&self.chain_id_str(best_block_hash)?).map_err(|e| {
+                error!("{e}");
+                StarknetRpcApiError::InternalServerError
+            })?;
+
         let extrinsic = self
             .client
             .runtime_api()

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -364,6 +364,7 @@ pub mod pallet {
         StateDiffError,
         ContractNotFound,
         ReachedBoundedVecLimit,
+        TransactionConversionError,
     }
 
     /// The Starknet pallet external functions.
@@ -594,7 +595,8 @@ pub mod pallet {
             ensure_none(origin)?;
 
             let chain_id = Self::chain_id_str();
-            let transaction: Transaction = transaction.from_deploy(&chain_id).unwrap();
+            let transaction: Transaction =
+                transaction.from_deploy(&chain_id).map_err(|_| Error::<T>::TransactionConversionError)?;
 
             // Check if contract is deployed
             ensure!(

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -593,14 +593,14 @@ pub mod pallet {
             // This ensures that the function can only be called via unsigned transaction.
             ensure_none(origin)?;
 
+            let chain_id = Self::chain_id_str();
+            let transaction: Transaction = transaction.from_deploy(&chain_id);
+
             // Check if contract is deployed
             ensure!(
                 !ContractClassHashes::<T>::contains_key(transaction.sender_address),
                 Error::<T>::AccountAlreadyDeployed
             );
-
-            let chain_id = Self::chain_id_str();
-            let transaction: Transaction = transaction.from_deploy(&chain_id);
 
             // Get current block
             let block = Self::current_block();

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -594,7 +594,7 @@ pub mod pallet {
             ensure_none(origin)?;
 
             let chain_id = Self::chain_id_str();
-            let transaction: Transaction = transaction.from_deploy(&chain_id);
+            let transaction: Transaction = transaction.from_deploy(&chain_id).unwrap();
 
             // Check if contract is deployed
             ensure!(

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -787,11 +787,14 @@ pub mod pallet {
                 }
                 Call::deploy_account { transaction } => {
                     // don't validate deploy txs for now
-                    // let deploy_account_transaction = transaction.clone().from_deploy(&Self::chain_id_str());
+                    let deploy_account_transaction = transaction
+                        .clone()
+                        .from_deploy(&Self::chain_id_str())
+                        .map_err(|_| TransactionValidityError::Unknown(UnknownTransaction::CannotLookup))?;
                     // Pallet::<T>::validate_tx(deploy_account_transaction, TxType::DeployAccount)?;
                     ValidTransaction::with_tag_prefix("starknet")
                         .priority(u64::MAX - (TryInto::<u64>::try_into(transaction.nonce)).unwrap())
-                        .and_provides((transaction.sender_address, transaction.nonce))
+                        .and_provides((deploy_account_transaction.sender_address, transaction.nonce))
                         .longevity(64_u64)
                         .propagate(true)
                         .build()

--- a/crates/pallets/starknet/src/tests/deploy_account_tx.rs
+++ b/crates/pallets/starknet/src/tests/deploy_account_tx.rs
@@ -190,11 +190,6 @@ fn given_contract_run_deploy_account_openzeppelin_tx_works() {
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
         };
-        let chain_id = Starknet::chain_id().0.to_bytes_be();
-        let chain_id = std::str::from_utf8(&chain_id[..]).unwrap();
-        let transaction_hash = calculate_deploy_account_tx_hash(transaction.clone(), chain_id);
-        transaction.signature = sign_message_hash(transaction_hash);
-
         let mp_transaction = transaction.clone().from_deploy(&get_chain_id()).unwrap();
 
         let tx_hash = mp_transaction.hash;

--- a/crates/pallets/starknet/src/tests/deploy_account_tx.rs
+++ b/crates/pallets/starknet/src/tests/deploy_account_tx.rs
@@ -26,8 +26,7 @@ fn given_contract_run_deploy_account_tx_works() {
 
         let transaction = DeployAccountTransaction {
             account_class_hash,
-            sender_address: test_addr,
-            salt: U256::from_str(salt).unwrap(),
+            salt: Felt252Wrapper::from_hex_be(salt).unwrap(),
             version: 1,
             // Calldata is hex so this works fine
             calldata: BoundedVec::try_from(
@@ -82,7 +81,6 @@ fn given_contract_run_deploy_account_tx_twice_fails() {
         // - ref testnet tx(0x0751b4b5b95652ad71b1721845882c3852af17e2ed0c8d93554b5b292abb9810)
         let transaction = DeployAccountTransaction {
             account_class_hash,
-            sender_address: test_addr,
             calldata: BoundedVec::try_from(
                 calldata
                     .clone()
@@ -91,7 +89,7 @@ fn given_contract_run_deploy_account_tx_twice_fails() {
                     .collect::<Vec<Felt252Wrapper>>(),
             )
             .unwrap(),
-            salt: U256::from_str(salt).unwrap(),
+            salt: Felt252Wrapper::from_hex_be(salt).unwrap(),
             version: 1,
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
@@ -116,10 +114,9 @@ fn given_contract_run_deploy_account_tx_undeclared_then_it_fails() {
         let (_, account_class_hash, _) = account_helper(salt, AccountType::ArgentV0);
         let transaction = DeployAccountTransaction {
             account_class_hash,
-            sender_address: rand_address,
             version: 1,
             calldata: bounded_vec!(),
-            salt: U256::zero(),
+            salt: Felt252Wrapper::ZERO,
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
@@ -148,7 +145,6 @@ fn given_contract_run_deploy_account_tx_fails_wrong_tx_version() {
 
         let transaction = DeployAccountTransaction {
             account_class_hash,
-            sender_address: test_addr,
             version: wrong_tx_version,
             calldata: BoundedVec::try_from(
                 calldata
@@ -158,7 +154,7 @@ fn given_contract_run_deploy_account_tx_fails_wrong_tx_version() {
                     .collect::<Vec<Felt252Wrapper>>(),
             )
             .unwrap(),
-            salt: U256::zero(),
+            salt: Felt252Wrapper::ZERO,
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
@@ -188,8 +184,7 @@ fn given_contract_run_deploy_account_openzeppelin_tx_works() {
 
         let mut transaction = DeployAccountTransaction {
             account_class_hash,
-            sender_address: test_addr,
-            salt: U256::from_str(salt).unwrap(),
+            salt: Felt252Wrapper::from_hex_be(salt).unwrap(),
             version: 1,
             calldata: BoundedVec::try_from(
                 calldata
@@ -230,8 +225,7 @@ fn given_contract_run_deploy_account_openzeppelin_with_incorrect_signature_then_
 
         let transaction = DeployAccountTransaction {
             account_class_hash,
-            sender_address: test_addr,
-            salt: U256::from_str(salt).unwrap(),
+            salt: Felt252Wrapper::from_hex_be(salt).unwrap(),
             version: 1,
             calldata: BoundedVec::try_from(
                 calldata
@@ -270,8 +264,7 @@ fn given_contract_run_deploy_account_argent_tx_works() {
 
         let mut transaction = DeployAccountTransaction {
             account_class_hash,
-            sender_address: test_addr,
-            salt: U256::from_str(salt).unwrap(),
+            salt: Felt252Wrapper::from_hex_be(salt).unwrap(),
             version: 1,
             calldata: BoundedVec::try_from(
                 calldata
@@ -313,8 +306,7 @@ fn given_contract_run_deploy_account_argent_with_incorrect_signature_then_it_fai
 
         let transaction = DeployAccountTransaction {
             account_class_hash,
-            sender_address: test_addr,
-            salt: U256::from_str(salt).unwrap(),
+            salt: Felt252Wrapper::from_hex_be(salt).unwrap(),
             version: 1,
             calldata: BoundedVec::try_from(
                 calldata
@@ -362,8 +354,7 @@ fn given_contract_run_deploy_account_braavos_tx_works() {
 
         let transaction = DeployAccountTransaction {
             account_class_hash: proxy_class_hash,
-            sender_address: test_addr,
-            salt: U256::from_str(salt).unwrap(),
+            salt: Felt252Wrapper::from_hex_be(salt).unwrap(),
             version: 1,
             calldata: BoundedVec::try_from(
                 calldata
@@ -402,8 +393,7 @@ fn given_contract_run_deploy_account_braavos_with_incorrect_signature_then_it_fa
 
         let transaction = DeployAccountTransaction {
             account_class_hash: proxy_class_hash,
-            sender_address: test_addr,
-            salt: U256::from_str(salt).unwrap(),
+            salt: Felt252Wrapper::from_hex_be(salt).unwrap(),
             version: 1,
             calldata: BoundedVec::try_from(
                 calldata

--- a/crates/pallets/starknet/src/tests/deploy_account_tx.rs
+++ b/crates/pallets/starknet/src/tests/deploy_account_tx.rs
@@ -43,7 +43,8 @@ fn given_contract_run_deploy_account_tx_works() {
         };
         let chain_id = Starknet::chain_id().0.to_bytes_be();
         let chain_id = std::str::from_utf8(&chain_id[..]).unwrap();
-        let transaction_hash = calculate_deploy_account_tx_hash(transaction.clone(), chain_id);
+        let address = transaction.clone().from_deploy(chain_id).unwrap().sender_address;
+        let transaction_hash = calculate_deploy_account_tx_hash(transaction.clone(), chain_id, address.into());
 
         assert_ok!(Starknet::deploy_account(none_origin, transaction));
         assert_eq!(Starknet::contract_class_hash_by_address(test_addr).unwrap(), account_class_hash);

--- a/crates/pallets/starknet/src/tests/deploy_account_tx.rs
+++ b/crates/pallets/starknet/src/tests/deploy_account_tx.rs
@@ -1,10 +1,7 @@
-use std::str::FromStr;
-
 use frame_support::{assert_err, assert_ok, bounded_vec, BoundedVec};
 use mp_starknet::crypto::commitment::calculate_deploy_account_tx_hash;
 use mp_starknet::execution::types::Felt252Wrapper;
 use mp_starknet::transaction::types::{DeployAccountTransaction, EventWrapper};
-use sp_core::U256;
 
 use super::mock::*;
 use super::utils::sign_message_hash;
@@ -111,7 +108,6 @@ fn given_contract_run_deploy_account_tx_undeclared_then_it_fails() {
         run_to_block(2);
         let salt = "0x03b37cbe4e9eac89d54c5f7cc6329a63a63e8c8db2bf936f981041e086752463";
         let none_origin = RuntimeOrigin::none();
-        let rand_address = Felt252Wrapper::from_hex_be("0x1234").unwrap();
         let (_, account_class_hash, _) = account_helper(salt, AccountType::ArgentV0);
         let transaction = DeployAccountTransaction {
             account_class_hash,
@@ -140,7 +136,7 @@ fn given_contract_run_deploy_account_tx_fails_wrong_tx_version() {
         // TEST ACCOUNT CONTRACT
         // - ref testnet tx(0x0751b4b5b95652ad71b1721845882c3852af17e2ed0c8d93554b5b292abb9810)
         let salt = "0x03b37cbe4e9eac89d54c5f7cc6329a63a63e8c8db2bf936f981041e086752463";
-        let (test_addr, account_class_hash, calldata) = account_helper(salt, AccountType::ArgentV0);
+        let (_, account_class_hash, calldata) = account_helper(salt, AccountType::ArgentV0);
 
         let wrong_tx_version = 50_u8;
 
@@ -339,15 +335,12 @@ fn given_contract_run_deploy_account_braavos_tx_works() {
         // TEST ACCOUNT CONTRACT
         // - ref testnet tx(0x0751b4b5b95652ad71b1721845882c3852af17e2ed0c8d93554b5b292abb9810)
         let salt = "0x03b37cbe4e9eac89d54c5f7cc6329a63a63e8c8db2bf936f981041e086752463";
-        let (test_addr, proxy_class_hash, mut calldata) = account_helper(salt, AccountType::BraavosProxy);
+        let (_, proxy_class_hash, mut calldata) = account_helper(salt, AccountType::BraavosProxy);
         calldata.push("0x1");
         calldata.push(ACCOUNT_PUBLIC_KEY);
 
-        set_infinite_tokens(test_addr);
-        set_signer(test_addr, AccountType::Braavos);
-
         let tx_hash =
-            Felt252Wrapper::from_hex_be("0x06ae3d81978d498def89e1121b2d84a873d63c30d80f7ed81e2dc9be6a961770").unwrap();
+            Felt252Wrapper::from_hex_be("0x00de7a5bc4a54852d47b99070ac74baf71d5993a9029dbc45fa1d48f28acb0a4").unwrap();
 
         let mut signatures: Vec<Felt252Wrapper> = sign_message_hash(tx_hash).into();
         let empty_signatures = [Felt252Wrapper::ZERO; 8];
@@ -370,8 +363,14 @@ fn given_contract_run_deploy_account_braavos_tx_works() {
             signature: signatures.try_into().unwrap(),
         };
 
+        let chain_id = Starknet::chain_id().0.to_bytes_be();
+        let chain_id = std::str::from_utf8(&chain_id[..]).unwrap();
+        let address = transaction.clone().from_deploy(chain_id).unwrap().sender_address;
+        set_infinite_tokens(address);
+        set_signer(address, AccountType::Braavos);
+
         assert_ok!(Starknet::deploy_account(none_origin, transaction));
-        assert_eq!(Starknet::contract_class_hash_by_address(test_addr).unwrap(), proxy_class_hash);
+        assert_eq!(Starknet::contract_class_hash_by_address(address).unwrap(), proxy_class_hash);
     });
 }
 

--- a/crates/pallets/starknet/src/tests/mock.rs
+++ b/crates/pallets/starknet/src/tests/mock.rs
@@ -346,3 +346,11 @@ pub fn calculate_contract_address(
         ContractAddress::default(),
     )
 }
+
+/// Returns the chain id used by the mock runtime.
+/// # Returns
+/// The chain id of the mock runtime.
+pub fn get_chain_id() -> String {
+    let chain_id = Starknet::chain_id().0.to_bytes_be();
+    std::str::from_utf8(&chain_id[..]).unwrap().to_string()
+}

--- a/crates/primitives/starknet/Cargo.toml
+++ b/crates/primitives/starknet/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = { version = "1.0.96", default-features = false }
 thiserror-no-std = { workspace = true }
 derive_more = { workspace = true, features = ["constructor"] }
 lazy_static = { workspace = true }
-anyhow = { workspace = true }
+# anyhow = { workspace = true }
 
 
 [dev-dependencies]

--- a/crates/primitives/starknet/Cargo.toml
+++ b/crates/primitives/starknet/Cargo.toml
@@ -39,6 +39,8 @@ serde_json = { version = "1.0.96", default-features = false }
 thiserror-no-std = { workspace = true }
 derive_more = { workspace = true, features = ["constructor"] }
 lazy_static = { workspace = true }
+anyhow = { workspace = true }
+
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/crates/primitives/starknet/src/crypto/commitment/mod.rs
+++ b/crates/primitives/starknet/src/crypto/commitment/mod.rs
@@ -169,10 +169,13 @@ pub fn calculate_declare_tx_hash(transaction: DeclareTransaction, chain_id: &str
 /// # Argument
 ///
 /// * `transaction` - The deploy account transaction to get the hash of.
-pub fn calculate_deploy_account_tx_hash(transaction: DeployAccountTransaction, chain_id: &str) -> Felt252Wrapper {
-    let sender_address = transaction.clone().from_deploy(chain_id).sender_address.into();
+pub fn calculate_deploy_account_tx_hash(
+    transaction: DeployAccountTransaction,
+    chain_id: &str,
+    address: [u8; 32],
+) -> Felt252Wrapper {
     calculate_transaction_hash_common::<PedersenHasher>(
-        sender_address,
+        address,
         &vec![vec![transaction.account_class_hash, transaction.salt], transaction.calldata.to_vec()].concat(),
         transaction.max_fee,
         transaction.nonce,
@@ -182,7 +185,8 @@ pub fn calculate_deploy_account_tx_hash(transaction: DeployAccountTransaction, c
     )
 }
 
-fn calculate_transaction_hash_common<T>(
+/// Computes the transaction hash using a hash funciton of type T
+pub fn calculate_transaction_hash_common<T>(
     sender_address: [u8; 32],
     calldata: &[Felt252Wrapper],
     max_fee: Felt252Wrapper,

--- a/crates/primitives/starknet/src/crypto/commitment/mod.rs
+++ b/crates/primitives/starknet/src/crypto/commitment/mod.rs
@@ -170,13 +170,10 @@ pub fn calculate_declare_tx_hash(transaction: DeclareTransaction, chain_id: &str
 ///
 /// * `transaction` - The deploy account transaction to get the hash of.
 pub fn calculate_deploy_account_tx_hash(transaction: DeployAccountTransaction, chain_id: &str) -> Felt252Wrapper {
+    let sender_address = transaction.clone().from_deploy(chain_id).sender_address.into();
     calculate_transaction_hash_common::<PedersenHasher>(
-        transaction.sender_address.into(),
-        &vec![
-            vec![transaction.account_class_hash, transaction.salt.try_into().expect("overflow from U256 to Felt252")],
-            transaction.calldata.to_vec(),
-        ]
-        .concat(),
+        sender_address,
+        &vec![vec![transaction.account_class_hash, transaction.salt], transaction.calldata.to_vec()].concat(),
         transaction.max_fee,
         transaction.nonce,
         transaction.version,

--- a/crates/primitives/starknet/src/crypto/commitment/mod.rs
+++ b/crates/primitives/starknet/src/crypto/commitment/mod.rs
@@ -185,7 +185,7 @@ pub fn calculate_deploy_account_tx_hash(
     )
 }
 
-/// Computes the transaction hash using a hash funciton of type T
+/// Computes the transaction hash using a hash function of type T
 pub fn calculate_transaction_hash_common<T>(
     sender_address: [u8; 32],
     calldata: &[Felt252Wrapper],

--- a/crates/primitives/starknet/src/tests/crypto.rs
+++ b/crates/primitives/starknet/src/tests/crypto.rs
@@ -3,7 +3,7 @@ use core::cell::RefCell;
 use std::str::FromStr;
 
 use frame_support::bounded_vec;
-use sp_core::{H256, U256};
+use sp_core::H256;
 use starknet_crypto::FieldElement;
 
 use crate::crypto::commitment::{
@@ -38,7 +38,7 @@ fn test_deploy_account_tx_hash() {
         account_class_hash: Felt252Wrapper::THREE,
         max_fee: Felt252Wrapper::ONE,
     };
-    let address = transaction.clone().from_deploy(chain_id).unwrap().sender_address.into();
+    let address = FieldElement::from(19911991_u64).to_bytes_be();
 
     assert_eq!(calculate_deploy_account_tx_hash(transaction, chain_id, address), expected_tx_hash);
 }

--- a/crates/primitives/starknet/src/tests/crypto.rs
+++ b/crates/primitives/starknet/src/tests/crypto.rs
@@ -38,7 +38,9 @@ fn test_deploy_account_tx_hash() {
         account_class_hash: Felt252Wrapper::THREE,
         max_fee: Felt252Wrapper::ONE,
     };
-    assert_eq!(calculate_deploy_account_tx_hash(transaction, chain_id), expected_tx_hash);
+    let address = transaction.clone().from_deploy(chain_id).unwrap().sender_address.into();
+
+    assert_eq!(calculate_deploy_account_tx_hash(transaction, chain_id, address), expected_tx_hash);
 }
 
 #[test]

--- a/crates/primitives/starknet/src/tests/crypto.rs
+++ b/crates/primitives/starknet/src/tests/crypto.rs
@@ -31,10 +31,9 @@ fn test_deploy_account_tx_hash() {
 
     let transaction = DeployAccountTransaction {
         version: 1,
-        sender_address: Felt252Wrapper::from(19911991_u128),
         calldata: bounded_vec!(Felt252Wrapper::ONE, Felt252Wrapper::TWO, Felt252Wrapper::THREE),
         nonce: Felt252Wrapper::ZERO,
-        salt: U256::zero(),
+        salt: Felt252Wrapper::ZERO,
         signature: bounded_vec!(),
         account_class_hash: Felt252Wrapper::THREE,
         max_fee: Felt252Wrapper::ONE,

--- a/crates/primitives/starknet/src/transaction/types.rs
+++ b/crates/primitives/starknet/src/transaction/types.rs
@@ -3,7 +3,6 @@ use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
-// use anyhow::Result;
 use blockifier::execution::entry_point::CallInfo;
 use blockifier::execution::errors::EntryPointExecutionError;
 use blockifier::state::errors::StateError;

--- a/crates/primitives/starknet/src/transaction/types.rs
+++ b/crates/primitives/starknet/src/transaction/types.rs
@@ -1,6 +1,7 @@
 use alloc::collections::BTreeMap;
 use alloc::string::String;
-use std::sync::Arc;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
 
 use anyhow::{anyhow, Result};
 use blockifier::execution::entry_point::CallInfo;
@@ -187,7 +188,6 @@ pub struct DeclareTransaction {
     pub max_fee: Felt252Wrapper,
 }
 
-// @audit
 impl DeclareTransaction {
     /// converts the transaction to a [Transaction] object
     pub fn from_declare(self, chain_id: &str) -> Transaction {
@@ -229,8 +229,6 @@ impl DeclareTransaction {
 pub struct DeployAccountTransaction {
     /// Transaction version.
     pub version: u8,
-    /// Transaction sender address.
-    // pub sender_address: ContractAddressWrapper,
     /// Transaction calldata.
     pub calldata: BoundedVec<Felt252Wrapper, MaxCalldataSize>,
     /// Account contract nonce.
@@ -249,7 +247,7 @@ impl DeployAccountTransaction {
     /// converts the transaction to a [Transaction] object
     pub fn from_deploy(self, chain_id: &str) -> Transaction {
         let salt_as_felt: StarkFelt = StarkFelt(self.salt.into());
-        let stark_felt_vec: Vec<StarkFelt> = self.calldata
+        let stark_felt_vec: Vec<StarkFelt> = self.calldata.clone()
             .into_inner()
             .into_iter()
             .map(|felt_wrapper| felt_wrapper.try_into().unwrap()) // Here, we are assuming that the conversion will not fail.
@@ -259,7 +257,6 @@ impl DeployAccountTransaction {
             ContractAddressSalt(salt_as_felt),
             ClassHash(self.account_class_hash.try_into().unwrap()),
             &Calldata(Arc::new(stark_felt_vec)),
-            // map(|obj| obj.try_into().unwrap()).collect()
             ContractAddress::default(),
         )
         .map_err(|e| anyhow!("Failed to calculate contract address: {e}"))
@@ -385,7 +382,6 @@ impl InvokeTransaction {
     }
 }
 
-// @audit
 /// Representation of a Starknet transaction.
 #[derive(
     Clone,

--- a/crates/primitives/starknet/src/transaction/types.rs
+++ b/crates/primitives/starknet/src/transaction/types.rs
@@ -1,6 +1,8 @@
 use alloc::collections::BTreeMap;
 use alloc::string::String;
+use std::sync::Arc;
 
+use anyhow::{anyhow, Result};
 use blockifier::execution::entry_point::CallInfo;
 use blockifier::execution::errors::EntryPointExecutionError;
 use blockifier::state::errors::StateError;
@@ -8,7 +10,9 @@ use blockifier::transaction::errors::TransactionExecutionError;
 use blockifier::transaction::transaction_types::TransactionType;
 use frame_support::BoundedVec;
 use sp_core::{ConstU32, U256};
-use starknet_api::transaction::Fee;
+use starknet_api::api_core::{calculate_contract_address, ClassHash, ContractAddress};
+use starknet_api::hash::StarkFelt;
+use starknet_api::transaction::{Calldata, ContractAddressSalt, Fee};
 use starknet_api::StarknetApiError;
 #[cfg(feature = "std")]
 use starknet_core::types::{
@@ -183,6 +187,7 @@ pub struct DeclareTransaction {
     pub max_fee: Felt252Wrapper,
 }
 
+// @audit
 impl DeclareTransaction {
     /// converts the transaction to a [Transaction] object
     pub fn from_declare(self, chain_id: &str) -> Transaction {
@@ -225,13 +230,13 @@ pub struct DeployAccountTransaction {
     /// Transaction version.
     pub version: u8,
     /// Transaction sender address.
-    pub sender_address: ContractAddressWrapper,
+    // pub sender_address: ContractAddressWrapper,
     /// Transaction calldata.
     pub calldata: BoundedVec<Felt252Wrapper, MaxCalldataSize>,
     /// Account contract nonce.
     pub nonce: Felt252Wrapper,
     /// Transaction salt.
-    pub salt: U256,
+    pub salt: Felt252Wrapper,
     /// Transaction signature.
     pub signature: BoundedVec<Felt252Wrapper, MaxArraySize>,
     /// Account class hash.
@@ -243,23 +248,43 @@ pub struct DeployAccountTransaction {
 impl DeployAccountTransaction {
     /// converts the transaction to a [Transaction] object
     pub fn from_deploy(self, chain_id: &str) -> Transaction {
+        let salt_as_felt: StarkFelt = StarkFelt(self.salt.into());
+        let stark_felt_vec: Vec<StarkFelt> = self.calldata
+            .into_inner()
+            .into_iter()
+            .map(|felt_wrapper| felt_wrapper.try_into().unwrap()) // Here, we are assuming that the conversion will not fail.
+            .collect();
+
+        let sender_address: ContractAddressWrapper = calculate_contract_address(
+            ContractAddressSalt(salt_as_felt),
+            ClassHash(self.account_class_hash.try_into().unwrap()),
+            &Calldata(Arc::new(stark_felt_vec)),
+            // map(|obj| obj.try_into().unwrap()).collect()
+            ContractAddress::default(),
+        )
+        .map_err(|e| anyhow!("Failed to calculate contract address: {e}"))
+        .unwrap()
+        .0
+        .0
+        .into();
+
         Transaction {
             tx_type: TxType::DeployAccount,
             version: self.version,
             hash: calculate_deploy_account_tx_hash(self.clone(), chain_id),
             signature: self.signature,
-            sender_address: self.sender_address,
+            sender_address,
             nonce: self.nonce,
             call_entrypoint: CallEntryPointWrapper::new(
                 Some(self.account_class_hash),
                 EntryPointTypeWrapper::External,
                 None,
                 self.calldata,
-                self.sender_address,
-                self.sender_address,
+                sender_address,
+                sender_address,
             ),
             contract_class: None,
-            contract_address_salt: Some(self.salt),
+            contract_address_salt: Some(self.salt.into()),
             max_fee: self.max_fee,
         }
     }
@@ -360,6 +385,7 @@ impl InvokeTransaction {
     }
 }
 
+// @audit
 /// Representation of a Starknet transaction.
 #[derive(
     Clone,
@@ -398,13 +424,14 @@ pub struct Transaction {
 impl TryFrom<Transaction> for DeployAccountTransaction {
     type Error = TransactionConversionError;
     fn try_from(value: Transaction) -> Result<Self, Self::Error> {
+        // REPLACE BY ERROR HANDLING
+        let salt_as_felt_wrapper: Felt252Wrapper = value.contract_address_salt.unwrap_or_default().try_into().unwrap();
         Ok(Self {
             version: value.version,
             signature: value.signature,
-            sender_address: value.sender_address,
             nonce: value.nonce,
             calldata: value.call_entrypoint.calldata,
-            salt: value.contract_address_salt.unwrap_or_default(),
+            salt: salt_as_felt_wrapper,
             account_class_hash: value.call_entrypoint.class_hash.ok_or(TransactionConversionError::MissingClassHash)?,
             max_fee: value.max_fee,
         })

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -344,7 +344,7 @@ impl_runtime_apis! {
             xts.into_iter().filter_map(|xt| match xt.function {
                 RuntimeCall::Starknet( invoke { transaction }) => Some(transaction.from_invoke(chain_id)),
                 RuntimeCall::Starknet( declare { transaction }) => Some(transaction.from_declare(chain_id)),
-                RuntimeCall::Starknet( deploy_account { transaction }) => Some(transaction.from_deploy(chain_id)),
+                RuntimeCall::Starknet( deploy_account { transaction }) => transaction.from_deploy(chain_id).ok(),
                 _ => None
             }).collect::<Vec<Transaction>>()
         }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix
X Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build-related changes
- Documentation content changes
- Testing
- Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The address of the future deployed account is currently calculated in the RPC when submitting a deploy account transaction. This needs to be moved to the runtime.

Resolves: #500 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- removed `sender_address` from `DeployAccountTransaction`
- updated the `from_deploy` function of `DeployAccountTransation` impl
- remove the calculation from client/rpc-core/src/utils.rs

## Other information

THIS IS A DRAFT PR. 
I NEED TO CLEAN THE CODE BEFORE MERGING.
