### PR TITLE
fix: program deserialising

### DIFF
--- a/crates/primitives/starknet/src/execution/contract_class_wrapper.rs
+++ b/crates/primitives/starknet/src/execution/contract_class_wrapper.rs
@@ -114,3 +114,27 @@ impl TryFrom<ContractClass> for ContractClassWrapper {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use blockifier::execution::contract_class::ContractClass;
+
+    use super::*;
+
+    pub fn get_contract_class(contract_content: &'static [u8]) -> ContractClass {
+        serde_json::from_slice(contract_content).unwrap()
+    }
+
+    #[test]
+    fn test_serialize_deserialize_contract_class() {
+        let contract_class: ContractClassWrapper =
+            get_contract_class(include_bytes!("../../../../../resources/account/simple/account.json"))
+                .try_into()
+                .unwrap();
+        let contract_class_serialized = serde_json::to_string(&contract_class).unwrap();
+        let contract_class_deserialized: ContractClassWrapper =
+            serde_json::from_str(&contract_class_serialized).unwrap();
+
+        assert_eq!(contract_class, contract_class_deserialized);
+    }
+}

--- a/crates/primitives/starknet/src/execution/mod.rs
+++ b/crates/primitives/starknet/src/execution/mod.rs
@@ -104,25 +104,3 @@ pub mod types {
     pub use super::felt252_wrapper::*;
     pub use super::program_wrapper::*;
 }
-
-#[cfg(test)]
-mod tests {
-    use blockifier::execution::contract_class::ContractClass;
-    use types::ContractClassWrapper;
-
-    use super::*;
-
-    pub fn get_contract_class(contract_content: &'static [u8]) -> ContractClass {
-        serde_json::from_slice(contract_content).unwrap()
-    }
-
-    #[test]
-    fn test_serialize_deserialize_bounded_tree_map() {
-        let contract_class: ContractClassWrapper =
-            get_contract_class(include_bytes!("../../../../../resources/account/simple/account.json"))
-                .try_into()
-                .unwrap();
-        let serialized_contract = serde_json::to_string(&contract_class).unwrap();
-        let _contract: ContractClassWrapper = serde_json::from_str(&serialized_contract).unwrap();
-    }
-}

--- a/crates/primitives/starknet/src/execution/mod.rs
+++ b/crates/primitives/starknet/src/execution/mod.rs
@@ -104,3 +104,25 @@ pub mod types {
     pub use super::felt252_wrapper::*;
     pub use super::program_wrapper::*;
 }
+
+#[cfg(test)]
+mod tests {
+    use blockifier::execution::contract_class::ContractClass;
+    use types::ContractClassWrapper;
+
+    use super::*;
+
+    pub fn get_contract_class(contract_content: &'static [u8]) -> ContractClass {
+        serde_json::from_slice(contract_content).unwrap()
+    }
+
+    #[test]
+    fn test_serialize_deserialize_bounded_tree_map() {
+        let contract_class: ContractClassWrapper =
+            get_contract_class(include_bytes!("../../../../../resources/account/simple/account.json"))
+                .try_into()
+                .unwrap();
+        let serialized_contract = serde_json::to_string(&contract_class).unwrap();
+        let _contract: ContractClassWrapper = serde_json::from_str(&serialized_contract).unwrap();
+    }
+}

--- a/crates/primitives/starknet/src/execution/program_wrapper.rs
+++ b/crates/primitives/starknet/src/execution/program_wrapper.rs
@@ -94,6 +94,7 @@ impl From<MaybeRelocatableWrapper> for MaybeRelocatable {
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "std", serde(into = "String"))]
+#[cfg_attr(feature = "std", serde(try_from = "String"))]
 struct StringWrapper(BoundedVec<u8, MaxStringLength>);
 
 impl From<String> for StringWrapper {

--- a/crates/primitives/starknet/src/execution/program_wrapper.rs
+++ b/crates/primitives/starknet/src/execution/program_wrapper.rs
@@ -807,7 +807,7 @@ impl From<AttributeWrapper> for Attribute {
 /// Wrapper type from [Identifier] using (substrate compatible type).
 struct IdentifierWrapper {
     pc: Option<u128>,
-    #[cfg_attr(feature = "std", serde(rename(deserialize = "type")))]
+    #[cfg_attr(feature = "std", serde(rename = "type"))]
     type_: Option<StringWrapper>,
     value: Option<Felt252Wrapper>,
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Fixes the deserialising of a `ProgramWrapper`.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix
- Testing

## What is the current behavior?
The `ProgramWrapper` cannot be deserialised and fails on the keys for the `constants` field.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?
The `ProgramWrapper` can be deserialised without failing.

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add `serde(try_from = "String")` for the `StringWrapper` structure.
- Add testing for serialise and deserialise of the `ContractClassWrapper`.

## Does this introduce a breaking change?
No