### PR TITLE
remove Hashes from BlockTransactions enum

### DIFF
--- a/crates/client/mapping-sync/src/sync_blocks.rs
+++ b/crates/client/mapping-sync/src/sync_blocks.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use mc_storage::OverrideHandle;
 use mp_digest_log::FindLogError;
-use mp_starknet::block::BlockTransactions;
 use mp_starknet::traits::hash::HasherT;
 use mp_starknet::traits::ThreadSafeCopy;
 use pallet_starknet::runtime_api::StarknetRuntimeApi;
@@ -49,14 +48,11 @@ where
                         let mapping_commitment = mc_db::MappingCommitment {
                             block_hash: substrate_block_hash,
                             starknet_block_hash: digest_starknet_block_hash.into(),
-                            starknet_transaction_hashes: match digest_starknet_block.transactions() {
-                                BlockTransactions::Full(transactions) => {
-                                    transactions.into_iter().map(|tx| H256::from(tx.hash)).collect()
-                                }
-                                BlockTransactions::Hashes(hashes) => {
-                                    hashes.into_iter().map(|hash| H256::from(*hash)).collect()
-                                }
-                            },
+                            starknet_transaction_hashes: digest_starknet_block
+                                .transactions()
+                                .into_iter()
+                                .map(|tx| H256::from(tx.hash))
+                                .collect(),
                         };
 
                         backend.mapping().write_hashes(mapping_commitment)

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -16,7 +16,6 @@ use log::{error, info};
 use mc_rpc_core::utils::{to_declare_tx, to_deploy_account_tx, to_invoke_tx, to_rpc_contract_class, to_tx};
 pub use mc_rpc_core::StarknetRpcApiServer;
 use mc_storage::OverrideHandle;
-use mp_starknet::block::BlockTransactions;
 use mp_starknet::execution::types::Felt252Wrapper;
 use mp_starknet::traits::hash::HasherT;
 use mp_starknet::traits::ThreadSafeCopy;
@@ -727,16 +726,11 @@ where
             .unwrap_or_default();
 
         let block_transactions = block.transactions();
-        match block_transactions {
-            BlockTransactions::Full(transactions) => {
-                let transaction = transactions.get(index).ok_or(StarknetRpcApiError::InvalidTxnIndex)?;
-                Ok(Transaction::try_from(transaction.clone()).map_err(|e| {
-                    error!("{:?}", e);
-                    StarknetRpcApiError::InternalServerError
-                })?)
-            }
-            BlockTransactions::Hashes(_) => Err(StarknetRpcApiError::InvalidTxnIndex.into()),
-        }
+        let transaction = block_transactions.get(index).ok_or(StarknetRpcApiError::InvalidTxnIndex)?;
+        Ok(Transaction::try_from(transaction.clone()).map_err(|e| {
+            error!("{:?}", e);
+            StarknetRpcApiError::InternalServerError
+        })?)
     }
 
     /// Get block information with full transactions given the block id
@@ -752,10 +746,7 @@ where
             .current_block(substrate_block_hash)
             .unwrap_or_default();
 
-        let transactions = match block.transactions() {
-            BlockTransactions::Full(transactions) => transactions.to_vec(),
-            BlockTransactions::Hashes(_) => vec![],
-        };
+        let transactions = block.transactions().to_vec();
 
         let block_with_txs = BlockWithTxs {
             // TODO: Get status from block
@@ -937,29 +928,21 @@ where
             .current_block(substrate_block_hash)
             .unwrap_or_default();
 
-        match block.transactions() {
-            BlockTransactions::Full(transactions) => {
-                let find_tx = transactions
-                    .into_iter()
-                    .find(|tx| tx.hash == transaction_hash.into())
-                    .map(|tx| Transaction::try_from(tx.clone()));
+        let find_tx = block
+            .transactions()
+            .into_iter()
+            .find(|tx| tx.hash == transaction_hash.into())
+            .map(|tx| Transaction::try_from(tx.clone()));
 
-                match find_tx {
-                    Some(res_tx) => match res_tx {
-                        Ok(tx) => Ok(tx),
-                        Err(e) => {
-                            error!("Error retrieving transaction: {:?}", e);
-                            Err(StarknetRpcApiError::InternalServerError.into())
-                        }
-                    },
-                    None => Err(StarknetRpcApiError::TxnHashNotFound.into()),
+        match find_tx {
+            Some(res_tx) => match res_tx {
+                Ok(tx) => Ok(tx),
+                Err(e) => {
+                    error!("Error retrieving transaction: {:?}", e);
+                    Err(StarknetRpcApiError::InternalServerError.into())
                 }
-            }
-            BlockTransactions::Hashes(_hashes) => {
-                // Only transactions hashes are not enough to return a full transaction.
-                // Consider the transaction as not found.
-                Err(StarknetRpcApiError::TxnHashNotFound.into())
-            }
+            },
+            None => Err(StarknetRpcApiError::TxnHashNotFound.into()),
         }
     }
 

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -759,8 +759,8 @@ where
             sequencer_address: block.header().sequencer_address.into(),
             transactions: block
                 .transactions()
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(Transaction::try_from)
                 .collect::<Result<Vec<_>, RPCTransactionConversionError>>()
                 .map_err(|e| {

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -725,8 +725,7 @@ where
             .current_block(substrate_block_hash)
             .unwrap_or_default();
 
-        let block_transactions = block.transactions();
-        let transaction = block_transactions.get(index).ok_or(StarknetRpcApiError::InvalidTxnIndex)?;
+        let transaction = block.transactions().get(index).ok_or(StarknetRpcApiError::InvalidTxnIndex)?;
         Ok(Transaction::try_from(transaction.clone()).map_err(|e| {
             error!("{:?}", e);
             StarknetRpcApiError::InternalServerError

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -745,8 +745,6 @@ where
             .current_block(substrate_block_hash)
             .unwrap_or_default();
 
-        let transactions = block.transactions().to_vec();
-
         let block_with_txs = BlockWithTxs {
             // TODO: Get status from block
             status: BlockStatus::AcceptedOnL2,
@@ -759,7 +757,9 @@ where
             new_root: block.header().global_state_root.into(),
             timestamp: block.header().block_timestamp,
             sequencer_address: block.header().sequencer_address.into(),
-            transactions: transactions
+            transactions: block
+                .transactions()
+                .to_vec()
                 .into_iter()
                 .map(Transaction::try_from)
                 .collect::<Result<Vec<_>, RPCTransactionConversionError>>()

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -72,7 +72,7 @@ use frame_support::pallet_prelude::*;
 use frame_support::traits::Time;
 use frame_system::pallet_prelude::*;
 use mp_digest_log::MADARA_ENGINE_ID;
-use mp_starknet::block::{Block as StarknetBlock, BlockTransactions, Header as StarknetHeader, MaxTransactions};
+use mp_starknet::block::{Block as StarknetBlock, Header as StarknetHeader, MaxTransactions};
 use mp_starknet::crypto::commitment;
 use mp_starknet::execution::types::{
     CallEntryPointWrapper, ClassHashWrapper, ContractAddressWrapper, ContractClassWrapper, EntryPointTypeWrapper,
@@ -989,7 +989,7 @@ impl<T: Config> Pallet<T> {
             ),
             // Safe because `transactions` is build from the `pending` bounded vec,
             // which has the same size limit of `MaxTransactions`
-            BlockTransactions::Full(BoundedVec::try_from(transactions).unwrap()),
+            BoundedVec::try_from(transactions).unwrap(),
             BoundedVec::try_from(receipts).unwrap(),
         );
         // Save the current block.

--- a/crates/primitives/starknet/src/block/mod.rs
+++ b/crates/primitives/starknet/src/block/mod.rs
@@ -15,32 +15,10 @@ use crate::transaction::types::{Transaction, TransactionReceiptWrapper};
 pub type MaxTransactions = ConstU32<4294967295>;
 
 /// Block Transactions
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    scale_codec::Encode,
-    scale_codec::Decode,
-    scale_info::TypeInfo,
-    scale_codec::MaxEncodedLen,
-)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-pub enum BlockTransactions {
-    /// Only hashes
-    Hashes(BoundedVec<Felt252Wrapper, MaxTransactions>),
-    /// Full transactions
-    Full(BoundedVec<Transaction, MaxTransactions>),
-}
+pub type BlockTransactions = BoundedVec<Transaction, MaxTransactions>;
 
 /// Block transaction receipts.
 pub type BlockTransactionReceipts = BoundedVec<TransactionReceiptWrapper, MaxTransactions>;
-
-impl Default for BlockTransactions {
-    fn default() -> Self {
-        Self::Full(BoundedVec::default())
-    }
-}
 
 /// Starknet block definition.
 #[derive(
@@ -96,10 +74,7 @@ impl Block {
 
     /// Return a reference to all transaction hashes
     pub fn transactions_hashes(&self) -> Vec<Felt252Wrapper> {
-        match &self.transactions {
-            BlockTransactions::Full(transactions) => transactions.into_iter().map(|tx| tx.hash).collect(),
-
-            BlockTransactions::Hashes(hashes) => hashes.to_vec(),
-        }
+        let transactions = &self.transactions;
+        transactions.into_iter().map(|tx| tx.hash).collect()
     }
 }

--- a/crates/primitives/starknet/src/tests/block.rs
+++ b/crates/primitives/starknet/src/tests/block.rs
@@ -2,7 +2,7 @@
 use core::convert::TryFrom;
 
 use frame_support::BoundedVec;
-use crate::block::{Block, BlockTransactions, Header, MaxTransactions};
+use crate::block::{Block, Header, MaxTransactions};
 use crate::execution::types::{CallEntryPointWrapper, ContractAddressWrapper};
 use crate::transaction::types::{MaxArraySize, Transaction};
 use sp_core::{Encode, H256, U256};
@@ -65,7 +65,7 @@ fn test_header_hash() {
 #[test]
 fn test_transactions() {
     let header = generate_dummy_header();
-    let transactions = BlockTransactions::Full(generate_dummy_transactions());
+    let transactions = generate_dummy_transactions();
     let block = Block::new(header, transactions.clone());
 
     assert_eq!(block.transactions(), &transactions);
@@ -75,7 +75,7 @@ fn test_transactions() {
 fn test_transactions_hashes() {
     let header = generate_dummy_header();
     let transactions = generate_dummy_transactions();
-    let block = Block::new(header, BlockTransactions::Full(transactions.clone()));
+    let block = Block::new(header, transactions.clone());
 
     let expected_hashes: Vec<H256> = transactions.iter().map(|tx| tx.hash).collect();
 
@@ -89,7 +89,7 @@ fn test_transactions_hashes_from_hashes() {
     let vec_hashes: Vec<H256> = transactions.iter().map(|tx| tx.hash).collect();
     let hashes = BoundedVec::<H256, MaxTransactions>::try_from(vec_hashes).unwrap();
 
-    let block = Block::new(header, BlockTransactions::Hashes(hashes.clone()));
+    let block = Block::new(header, hashes.clone());
 
     let expected_hashes: Vec<H256> = hashes.into_iter().collect();
 

--- a/crates/primitives/starknet/src/tests/mod.rs
+++ b/crates/primitives/starknet/src/tests/mod.rs
@@ -1,5 +1,7 @@
+pub mod block;
 pub mod crypto;
 pub mod execution;
 pub mod starknet_serde;
+pub mod state;
 pub mod transaction;
 pub mod utils;

--- a/crates/primitives/starknet/src/tests/state.rs
+++ b/crates/primitives/starknet/src/tests/state.rs
@@ -1,10 +1,11 @@
 use blockifier::execution::contract_class::ContractClass;
 use blockifier::state::errors::StateError;
 use blockifier::state::state_api::StateReader;
-use crate::state::*;
 use starknet_api::api_core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
+
+use crate::state::*;
 
 #[test]
 fn test_get_storage_at() {


### PR DESCRIPTION
### Pull Request type

Refactoring (dev)
Resolves: https://github.com/keep-starknet-strange/madara/issues/499

Now the `BoundedVec` is passed literally instead of the `BlockTransactions` enum. The only place using the new `BlockTransactions` type is `Block`. Maybe `BlockTransactions` should be removed altogether.

### Does this introduce a breaking change?

No
