### PR TITLE
fix: remove block information from tx receipt fields

### DIFF
--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -451,8 +451,6 @@ pub mod pallet {
                         transaction_hash: transaction.hash,
                         tx_type: TxType::Invoke,
                         actual_fee: actual_fee.0.into(),
-                        block_hash: Felt252Wrapper::default(), // unwrap to check.
-                        block_number: block_context.block_number.0,
                     }
                 }
                 Err(e) => {
@@ -545,8 +543,6 @@ pub mod pallet {
                         events: BoundedVec::try_from(events).map_err(|_| Error::<T>::ReachedBoundedVecLimit)?,
                         transaction_hash: transaction.hash,
                         tx_type: TxType::Declare,
-                        block_hash: Felt252Wrapper::default(),
-                        block_number: block_context.block_number.0,
                         actual_fee: actual_fee.0.into(),
                     }
                 }
@@ -635,8 +631,6 @@ pub mod pallet {
                         events: BoundedVec::try_from(events).map_err(|_| Error::<T>::ReachedBoundedVecLimit)?,
                         transaction_hash: transaction.hash,
                         tx_type: TxType::DeployAccount,
-                        block_hash: Felt252Wrapper::default(),
-                        block_number: block_context.block_number.0,
                         actual_fee: actual_fee.0.into(),
                     }
                 }

--- a/crates/pallets/starknet/src/tests/invoke_tx.rs
+++ b/crates/pallets/starknet/src/tests/invoke_tx.rs
@@ -99,8 +99,6 @@ fn given_hardcoded_contract_run_invoke_tx_then_it_works() {
             .unwrap(),
             actual_fee: Felt252Wrapper::from(52980_u128),
             tx_type: TxType::Invoke,
-            block_number: 2_u64,
-            block_hash: Felt252Wrapper::ZERO,
             events: bounded_vec![EventWrapper {
                 keys: bounded_vec!(
                     Felt252Wrapper::from_hex_be("0x0099cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9")
@@ -200,8 +198,6 @@ fn given_hardcoded_contract_run_invoke_tx_then_event_is_emitted() {
             .unwrap(),
             actual_fee: Felt252Wrapper::from(53490_u128),
             tx_type: TxType::Invoke,
-            block_number: 2_u64,
-            block_hash: Felt252Wrapper::ZERO,
             events: bounded_vec!(emitted_event, expected_fee_transfer_event),
         };
         let receipt = &pending.get(0).unwrap().1;

--- a/crates/primitives/starknet/src/transaction/mod.rs
+++ b/crates/primitives/starknet/src/transaction/mod.rs
@@ -188,8 +188,6 @@ impl TryInto<TransactionReceiptWrapper> for &TransactionReceipt {
                 TransactionOutput::L1Handler(_) => TxType::L1Handler,
                 _ => TxType::Invoke,
             },
-            block_hash: self.block_hash.0.into(),
-            block_number: self.block_number.0,
             events: BoundedVec::try_from(_events?).map_err(|_| EventError::TooManyEvents)?,
         })
     }
@@ -752,8 +750,6 @@ impl Default for TransactionReceiptWrapper {
             transaction_hash: Felt252Wrapper::default(),
             actual_fee: Felt252Wrapper::default(),
             tx_type: TxType::Invoke,
-            block_hash: Felt252Wrapper::default(),
-            block_number: 0_u64,
             events: BoundedVec::try_from(vec![EventWrapper::default(), EventWrapper::default()]).unwrap(),
         }
     }

--- a/crates/primitives/starknet/src/transaction/types.rs
+++ b/crates/primitives/starknet/src/transaction/types.rs
@@ -580,10 +580,6 @@ pub struct TransactionReceiptWrapper {
     pub actual_fee: Felt252Wrapper,
     /// Transaction type
     pub tx_type: TxType,
-    /// Block Number
-    pub block_number: u64,
-    /// Block Hash
-    pub block_hash: Felt252Wrapper,
     /// Messages sent in the transaction.
     // pub messages_sent: BoundedVec<Message, MaxArraySize>, // TODO: add messages
     /// Events emitted in the transaction.
@@ -595,20 +591,21 @@ impl TransactionReceiptWrapper {
     /// Converts a [`TransactionReceiptWrapper`] to [`RPCMaybePendingTransactionReceipt`].
     ///
     /// This conversion is done in a function and not `From` trait due to the need
-    /// to pass some arguments like the [`RPCTransactionStatus`] which is unknown
-    /// in the [`TransactionReceiptWrapper`].
+    /// to pass some arguments like the [`RPCTransactionStatus`] or the block hash and number
+    /// which are unknown in the [`TransactionReceiptWrapper`].
     ///
     /// Maybe extended later for other missing fields like messages sent to L1
     /// and the contract class for the deploy.
     pub fn into_maybe_pending_transaction_receipt(
         self,
         status: RPCTransactionStatus,
+        block_hash_and_number: (FieldElement, u64),
     ) -> RPCMaybePendingTransactionReceipt {
         let transaction_hash = self.transaction_hash.into();
         let actual_fee = self.actual_fee.into();
         let status = status;
-        let block_hash = self.block_hash.into();
-        let block_number = self.block_number;
+        let block_hash = block_hash_and_number.0;
+        let block_number = block_hash_and_number.1;
         let events = self.events.iter().map(|e| (*e).clone().into()).collect();
 
         // TODO: from where those message must be taken?

--- a/tests/tests/test-rpc/test-starknet-rpc.ts
+++ b/tests/tests/test-rpc/test-starknet-rpc.ts
@@ -856,8 +856,15 @@ describeDevMadara("Starknet RPC", (context) => {
         }
       );
 
-      const r = await providerRPC.getTransactionReceipt(b.result.hash);
+      const block_hash_and_number = await providerRPC.getBlockHashAndNumber();
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      const r: TransactionReceipt = await providerRPC.getTransactionReceipt(
+        b.result.hash
+      );
       expect(r).to.not.be.undefined;
+      expect(r.block_hash).to.be.equal(block_hash_and_number.block_hash);
+      expect(r.block_number).to.be.equal(block_hash_and_number.block_number);
     });
 
     it("should return transaction hash not found", async function () {

--- a/tests/tests/test-rpc/types.ts
+++ b/tests/tests/test-rpc/types.ts
@@ -10,6 +10,22 @@ export interface InvokeTransaction {
   sender_address: string;
 }
 
+export interface TransactionReceipt {
+  transaction_hash: string;
+  actual_fee: string;
+  status: string;
+  block_hash?: string;
+  block_number?: string;
+  type: string;
+  messages_sent: Array<MsgToL1>;
+  events: Array<string>;
+}
+
+interface MsgToL1 {
+  to_address: string;
+  payload: Array<string>;
+}
+
 export interface Block {
   status: string;
   transactions: string[];


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
`TransactionReceiptWrapper` structure contains the block hash and block number. This should not be present in the structure and provides nothing but redundant information.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Refactoring (no functional changes, no API changes)
- Testing

## What is the current behavior?
The `TransactionReceiptWrapper` structure contains a `block_hash` and a `block_number` field which provide nothing but redundant information.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #543 

## What is the new behavior?
Useless fields `block_hash` and `block_number` are removed.

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Remove fields block hash and block number.
- Update testing

## Does this introduce a breaking change?

No
