### PR TITLE
fix: serialize field element to hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4501,6 +4501,7 @@ dependencies = [
  "mp-starknet",
  "serde",
  "serde_json",
+ "serde_with",
  "sp-api",
  "sp-blockchain",
  "sp-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ clap = { version = "4.3.1", default-features = false }
 futures = { version = "0.3.28", default-features = false }
 serde = { version = "1.0.163", default-features = false }
 serde_json = { version = "1.0.96", default-features = false }
+serde_with = "2.3.3"
 bitvec = { version = "0.17.4", default-features = false }
 thiserror = "1.0.40"
 thiserror-no-std = "2.0.2"

--- a/crates/client/rpc-core/Cargo.toml
+++ b/crates/client/rpc-core/Cargo.toml
@@ -33,4 +33,5 @@ sp-core = { workspace = true }
 starknet-core = { workspace = true }
 cairo-vm = { workspace = true, default-features = false }
 sp-api = { workspace = true, default-features = true }
+serde_with = { workspace = true }
 

--- a/crates/client/rpc-core/src/lib.rs
+++ b/crates/client/rpc-core/src/lib.rs
@@ -9,9 +9,12 @@ mod tests;
 
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 pub mod utils;
 
+use starknet_core::serde::unsigned_field_element::UfeHex;
 use starknet_core::types::{
     BlockHashAndNumber, BlockId, BroadcastedDeclareTransaction, BroadcastedDeployAccountTransaction,
     BroadcastedInvokeTransaction, BroadcastedTransaction, ContractClass, DeclareTransactionResult,
@@ -19,6 +22,10 @@ use starknet_core::types::{
     InvokeTransactionResult, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs, MaybePendingTransactionReceipt,
     StateUpdate, SyncStatusType, Transaction,
 };
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct Felt(#[serde_as(as = "UfeHex")] pub FieldElement);
 
 /// Starknet rpc interface.
 #[rpc(server, namespace = "starknet")]
@@ -37,12 +44,7 @@ pub trait StarknetRpcApi {
 
     /// Get the value of the storage at the given address and key, at the given block id
     #[method(name = "getStorageAt")]
-    fn get_storage_at(
-        &self,
-        contract_address: FieldElement,
-        key: FieldElement,
-        block_id: BlockId,
-    ) -> RpcResult<FieldElement>;
+    fn get_storage_at(&self, contract_address: FieldElement, key: FieldElement, block_id: BlockId) -> RpcResult<Felt>;
 
     /// Call a contract function at a given block id
     #[method(name = "call")]
@@ -50,12 +52,12 @@ pub trait StarknetRpcApi {
 
     /// Get the contract class at a given contract address for a given block id
     #[method(name = "getClassAt")]
-    fn get_class_at(&self, contract_address: FieldElement, block_id: BlockId) -> RpcResult<ContractClass>;
+    fn get_class_at(&self, block_id: BlockId, contract_address: FieldElement) -> RpcResult<ContractClass>;
 
     /// Get the contract class hash in the given block for the contract deployed at the given
     /// address
     #[method(name = "getClassHashAt")]
-    fn get_class_hash_at(&self, contract_address: FieldElement, block_id: BlockId) -> RpcResult<FieldElement>;
+    fn get_class_hash_at(&self, block_id: BlockId, contract_address: FieldElement) -> RpcResult<Felt>;
 
     /// Get an object about the sync status, or false if the node is not syncing
     #[method(name = "syncing")]
@@ -71,7 +73,7 @@ pub trait StarknetRpcApi {
 
     /// Get the nonce associated with the given address at the given block
     #[method(name = "getNonce")]
-    fn get_nonce(&self, contract_address: FieldElement, block_id: BlockId) -> RpcResult<FieldElement>;
+    fn get_nonce(&self, block_id: BlockId, contract_address: FieldElement) -> RpcResult<Felt>;
 
     /// Get block information with full transactions given the block id
     #[method(name = "getBlockWithTxs")]

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -16,6 +16,7 @@ use log::{error, info};
 use mc_rpc_core::utils::{
     get_block_by_block_hash, to_declare_tx, to_deploy_account_tx, to_invoke_tx, to_rpc_contract_class, to_tx,
 };
+use mc_rpc_core::Felt;
 pub use mc_rpc_core::StarknetRpcApiServer;
 use mc_storage::OverrideHandle;
 use mp_starknet::execution::types::Felt252Wrapper;
@@ -311,12 +312,7 @@ where
     }
 
     /// get the storage at a given address and key and at a given block
-    fn get_storage_at(
-        &self,
-        contract_address: FieldElement,
-        key: FieldElement,
-        block_id: BlockId,
-    ) -> RpcResult<FieldElement> {
+    fn get_storage_at(&self, contract_address: FieldElement, key: FieldElement, block_id: BlockId) -> RpcResult<Felt> {
         let substrate_block_hash = self.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {
             error!("'{e}'");
             StarknetRpcApiError::BlockNotFound
@@ -340,7 +336,7 @@ where
             error!("Failed to get storage from contract: {:#?}", e);
             StarknetRpcApiError::InternalServerError
         })?;
-        Ok(value)
+        Ok(Felt(value))
     }
 
     fn call(&self, request: FunctionCall, block_id: BlockId) -> RpcResult<Vec<String>> {
@@ -367,7 +363,7 @@ where
     }
 
     /// Get the contract class at a given contract address for a given block id
-    fn get_class_at(&self, contract_address: FieldElement, block_id: BlockId) -> RpcResult<ContractClass> {
+    fn get_class_at(&self, block_id: BlockId, contract_address: FieldElement) -> RpcResult<ContractClass> {
         let substrate_block_hash = self.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {
             error!("'{e}'");
             StarknetRpcApiError::BlockNotFound
@@ -401,7 +397,7 @@ where
     /// # Returns
     ///
     /// * `class_hash` - The class hash of the given contract
-    fn get_class_hash_at(&self, contract_address: FieldElement, block_id: BlockId) -> RpcResult<FieldElement> {
+    fn get_class_hash_at(&self, block_id: BlockId, contract_address: FieldElement) -> RpcResult<Felt> {
         let substrate_block_hash = self.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {
             error!("'{e}'");
             StarknetRpcApiError::BlockNotFound
@@ -415,7 +411,7 @@ where
                 error!("Failed to retrieve contract class hash at '{contract_address}'");
                 StarknetRpcApiError::ContractNotFound
             })?;
-        Ok(class_hash.into())
+        Ok(Felt(class_hash.into()))
     }
 
     // Implementation of the `syncing` RPC Endpoint.
@@ -529,7 +525,7 @@ where
     }
 
     /// Get the nonce associated with the given address at the given block
-    fn get_nonce(&self, contract_address: FieldElement, block_id: BlockId) -> RpcResult<FieldElement> {
+    fn get_nonce(&self, block_id: BlockId, contract_address: FieldElement) -> RpcResult<Felt> {
         let substrate_block_hash = self.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {
             error!("'{e}'");
             StarknetRpcApiError::BlockNotFound
@@ -549,7 +545,7 @@ where
             StarknetRpcApiError::ContractNotFound
         })?;
 
-        Ok(nonce)
+        Ok(Felt(nonce))
     }
 
     /// Returns the chain id.

--- a/tests/tests/test-rpc/test-starknet-rpc.ts
+++ b/tests/tests/test-rpc/test-starknet-rpc.ts
@@ -109,7 +109,7 @@ describeDevMadara("Starknet RPC", (context) => {
       );
 
       expect(nonce).to.not.be.undefined;
-      expect(toHex(nonce)).to.be.equal(toHex(ARGENT_CONTRACT_NONCE.value));
+      expect(nonce).to.be.equal(toHex(ARGENT_CONTRACT_NONCE.value));
     });
   });
 
@@ -348,7 +348,7 @@ describeDevMadara("Starknet RPC", (context) => {
         "latest"
       );
       // fees were paid du to the transfer in the previous test so the value is still u128::MAX
-      expect(toHex(value)).to.be.equal("0xffffffffffffffffffffffffffffffff");
+      expect(value).to.be.equal("0xffffffffffffffffffffffffffffffff");
     });
 
     it("should return 0 if the storage slot is not set", async function () {
@@ -357,7 +357,7 @@ describeDevMadara("Starknet RPC", (context) => {
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "latest"
       );
-      expect(value).to.be.equal("0");
+      expect(value).to.be.equal("0x0");
     });
 
     it("should raise if the contract does not exist", async function () {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
The `FieldElement` structure is returned raw from the RPC, causing a serialization to a decimal string instead of a hexadecimal string. Additionally, certain endpoints did not have the `block_id` argument correctly located in the function's arguments.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?
Any RPC endpoints returning a `FieldElement` (ex: getNonce, getStorageAt,...) will return a decimal string instead of a hexadecimal string.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?
RPC endpoints previously returning a `FieldElement` now return a wrapper `Felt` (as done in starknet-rs), which allows the field element to be serialized as a hexadecimal string.

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Update `FieldElement` serialization
- Update `block_id` order in RPC functions arguments.

## Does this introduce a breaking change?
No
