### PR TITLE
Fix docker image build on amd64

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:slim-buster as builder
 RUN apt-get -y update; \
     apt-get install -y --no-install-recommends \
-        libssl-dev make clang llvm protobuf-compiler \
+        libssl-dev make clang-11 g++ llvm protobuf-compiler \
         pkg-config libz-dev zstd git; \
     apt-get autoremove -y; \
     apt-get clean; \


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- Build-related changes

## What is the current behavior?

Docker image build is KO on amd64
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?

Docker image build is OK on amd64

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add clang-11 and g++ installation in Dockerfile builder stage.

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
