### PR TITLE
feat: optimize chain id retrieval

### DIFF
--- a/crates/client/rpc-core/src/lib.rs
+++ b/crates/client/rpc-core/src/lib.rs
@@ -81,7 +81,7 @@ pub trait StarknetRpcApi {
 
     /// Get the chain id
     #[method(name = "chainId")]
-    fn chain_id(&self) -> RpcResult<String>;
+    fn chain_id(&self) -> RpcResult<Felt>;
 
     /// Add an Invoke Transaction to invoke a contract function
     #[method(name = "addInvokeTransaction")]

--- a/crates/client/storage/src/overrides/mod.rs
+++ b/crates/client/storage/src/overrides/mod.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use frame_support::{Identity, StorageHasher};
-use mp_starknet::execution::types::{ClassHashWrapper, ContractAddressWrapper, ContractClassWrapper};
+use mp_starknet::execution::types::{ClassHashWrapper, ContractAddressWrapper, ContractClassWrapper, Felt252Wrapper};
 use mp_starknet::storage::StarknetStorageSchemaVersion;
 use mp_starknet::transaction::types::EventWrapper;
 use pallet_starknet::runtime_api::StarknetRuntimeApi;
@@ -76,6 +76,8 @@ pub trait StorageOverride<B: BlockT>: Send + Sync {
     fn nonce(&self, block_hash: B::Hash, address: ContractAddressWrapper) -> Option<NonceWrapper>;
     /// Returns the events for a provided block hash.
     fn events(&self, block_hash: B::Hash) -> Option<Vec<EventWrapper>>;
+    /// Returns the storage value for a provided key and block hash.
+    fn chain_id(&self, block_hash: B::Hash) -> Option<Felt252Wrapper>;
 }
 
 /// Returns the storage prefix given the pallet module name and the storage name
@@ -180,5 +182,17 @@ where
     /// * `Some(events)` - The events for the provided block hash
     fn events(&self, block_hash: <B as BlockT>::Hash) -> Option<Vec<EventWrapper>> {
         self.client.runtime_api().events(block_hash).ok()
+    }
+
+    /// Return the chain id for a provided block hash.
+    ///
+    /// # Arguments
+    ///
+    /// * `block_hash` - The block hash
+    ///
+    /// # Returns
+    /// * `Some(chain_id)` - The chain id for the provided block hash
+    fn chain_id(&self, block_hash: <B as BlockT>::Hash) -> Option<Felt252Wrapper> {
+        self.client.runtime_api().chain_id(block_hash).ok()
     }
 }

--- a/crates/client/storage/src/overrides/schema_v1_override.rs
+++ b/crates/client/storage/src/overrides/schema_v1_override.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 
 use frame_system::EventRecord;
 use madara_runtime::{Hash, RuntimeEvent};
-use mp_starknet::execution::types::{ClassHashWrapper, ContractAddressWrapper, ContractClassWrapper};
+use mp_starknet::execution::types::{ClassHashWrapper, ContractAddressWrapper, ContractClassWrapper, Felt252Wrapper};
 use mp_starknet::storage::{
-    PALLET_STARKNET, PALLET_SYSTEM, STARKNET_CONTRACT_CLASS, STARKNET_CONTRACT_CLASS_HASH, STARKNET_NONCE,
-    SYSTEM_EVENTS,
+    PALLET_STARKNET, PALLET_SYSTEM, STARKNET_CHAIN_ID, STARKNET_CONTRACT_CLASS, STARKNET_CONTRACT_CLASS_HASH,
+    STARKNET_NONCE, SYSTEM_EVENTS,
 };
 use mp_starknet::transaction::types::EventWrapper;
 use pallet_starknet::types::NonceWrapper;
@@ -118,5 +118,10 @@ where
                 })
                 .collect()
         })
+    }
+
+    fn chain_id(&self, block_hash: <B as BlockT>::Hash) -> Option<Felt252Wrapper> {
+        let chain_id_prefix = storage_prefix_build(PALLET_STARKNET, STARKNET_CHAIN_ID);
+        self.query_storage::<Felt252Wrapper>(block_hash, &StorageKey(chain_id_prefix))
     }
 }

--- a/crates/primitives/starknet/src/execution/felt252_wrapper.rs
+++ b/crates/primitives/starknet/src/execution/felt252_wrapper.rs
@@ -68,6 +68,18 @@ impl Felt252Wrapper {
     }
 }
 
+#[cfg(feature = "std")]
+impl Felt252Wrapper {
+    /// Decodes the bytes representation in utf-8
+    ///
+    /// # Errors
+    ///
+    /// If the bytes are not valid utf-8, returns [`Felt252WrapperError`].
+    pub fn from_utf8(&self) -> Result<String, Felt252WrapperError> {
+        Ok(std::str::from_utf8(&self.0.to_bytes_be()).map_err(|_| Felt252WrapperError::InvalidCharacter)?.to_string())
+    }
+}
+
 impl Default for Felt252Wrapper {
     fn default() -> Self {
         Self(FieldElement::ZERO)

--- a/crates/primitives/starknet/src/storage/mod.rs
+++ b/crates/primitives/starknet/src/storage/mod.rs
@@ -22,6 +22,8 @@ pub const STARKNET_CONTRACT_CLASS_HASH: &[u8] = b"ContractClassHashes";
 pub const STARKNET_CONTRACT_CLASS: &[u8] = b"ContractClasses";
 /// Starknet nonce storage item.
 pub const STARKNET_NONCE: &[u8] = b"Nonces";
+/// Starknet chain id storage item.
+pub const STARKNET_CHAIN_ID: &[u8] = b"ChainId";
 
 /// The schema version for Pallet Starknet's storage.
 #[derive(Clone, Copy, Debug, Encode, Decode, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
The chain id is currently retrieved using the runtime API. This PR offloads the runtime by retrieving the chain id via the storage override.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Refactoring (no functional changes, no API changes)

## What is the current behavior?
Chain id is retrieved using the runtime API.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #541 

## What is the new behavior?
Chain id is retrieved via a storage query.

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Query chain id via the storage
- Replace helper function `chain_id_str` by `from_utf8` implementation for `Felt252Wrapper`

## Does this introduce a breaking change?
No
