### PR TITLE
fix from utf8 function for felt252

### DIFF
--- a/crates/primitives/starknet/src/execution/felt252_wrapper.rs
+++ b/crates/primitives/starknet/src/execution/felt252_wrapper.rs
@@ -76,7 +76,9 @@ impl Felt252Wrapper {
     ///
     /// If the bytes are not valid utf-8, returns [`Felt252WrapperError`].
     pub fn from_utf8(&self) -> Result<String, Felt252WrapperError> {
-        Ok(std::str::from_utf8(&self.0.to_bytes_be()).map_err(|_| Felt252WrapperError::InvalidCharacter)?.to_string())
+        let s =
+            std::str::from_utf8(&self.0.to_bytes_be()).map_err(|_| Felt252WrapperError::InvalidCharacter)?.to_string();
+        Ok(s.trim_start_matches('\0').to_string())
     }
 }
 
@@ -436,5 +438,11 @@ mod felt252_wrapper_tests {
     fn primitives_try_from_felt252() {
         let felt_u64 = Felt252Wrapper::from(4_294_967_296u64);
         assert_eq!(TryInto::<u64>::try_into(felt_u64).unwrap(), 4_294_967_296u64);
+    }
+
+    #[test]
+    fn decode_utf8() {
+        let felt = Felt252Wrapper::from_hex_be("0x534e5f474f45524c49").unwrap();
+        assert_eq!(felt.from_utf8().unwrap(), "SN_GOERLI".to_string());
     }
 }

--- a/tests/tests/test-rpc/test-starknet-rpc.ts
+++ b/tests/tests/test-rpc/test-starknet-rpc.ts
@@ -411,7 +411,7 @@ describeDevMadara("Starknet RPC", (context) => {
     });
   });
 
-  describe("chainId", async () => {
+  describe("getChainId", async () => {
     it("should return the correct value", async function () {
       const chainId = await providerRPC.getChainId();
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Update the `from_utf8` implementation for `Felt252Wrapper` in order to remove leading nul chars.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix
- Testing

## What is the current behavior?
utf-8 decoding implementation for `Felt252Wrapper` does not trim leading nul chars, leading to "SN_GOERLI" to be decoded to "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0SN_GOERLI".

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?
utf-8 encoding removes any leading nul chars from the decoded String.

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Update decoding
- Add test for decoding

## Does this introduce a breaking change?
No
