### PR TITLE
🔥 remove `pallet_utility`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4367,7 +4367,6 @@ dependencies = [
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
- "pallet-utility",
  "parity-scale-codec",
  "scale-info",
  "sp-api",
@@ -5346,22 +5345,6 @@ dependencies = [
  "sp-api",
  "sp-runtime",
  "sp-weights",
-]
-
-[[package]]
-name = "pallet-utility"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.43#a2037bdedef0aa812017efee1d0fa63d4f5fcbae"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,6 @@ pallet-transaction-payment = { default-features = false, git = "https://github.c
 pallet-transaction-payment-rpc = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
-pallet-utility = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 
 # Madara pallets
 pallet-starknet = { path = "crates/pallets/starknet", default-features = false }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -32,7 +32,6 @@ sp-version = { workspace = true }
 
 pallet-aura = { workspace = true }
 pallet-balances = { workspace = true }
-pallet-utility = { workspace = true }
 frame-support = { workspace = true }
 pallet-grandpa = { workspace = true }
 pallet-sudo = { workspace = true }
@@ -83,7 +82,6 @@ std = [
 	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
-	"pallet-utility/std",
 	# Substrate primitives dependencies
 	"sp-api/std",
 	"sp-block-builder/std",
@@ -111,7 +109,6 @@ try-runtime = [
 	"pallet-balances/try-runtime",
 	"pallet-grandpa/try-runtime",
 	"pallet-sudo/try-runtime",
-	"pallet-utility/try-runtime",
 	# Madara pallets
 	"pallet-starknet/try-runtime",
 ]
@@ -124,7 +121,6 @@ runtime-benchmarks = [
 	"pallet-balances/runtime-benchmarks",
 	"pallet-grandpa/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
-	"pallet-utility/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	# Madara pallets
 	"pallet-starknet/runtime-benchmarks",

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -71,7 +71,6 @@ construct_runtime!(
         Balances: pallet_balances,
         TransactionPayment: pallet_transaction_payment,
         Sudo: pallet_sudo,
-        Utility: pallet_utility,
         // Include Starknet pallet.
         Starknet: pallet_starknet,
     }

--- a/crates/runtime/src/pallets.rs
+++ b/crates/runtime/src/pallets.rs
@@ -188,15 +188,6 @@ parameter_types! {
     pub const TransactionLongevity: u64 = u64::MAX;
 }
 
-/// A stateless module with helpers for dispatch management which does no re-authentication.
-/// We use this to enable batch dispatches.
-impl pallet_utility::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type RuntimeCall = RuntimeCall;
-    type WeightInfo = ();
-    type PalletsOrigin = OriginCaller;
-}
-
 /// Implement the OnTimestampSet trait to override the default Aura.
 /// This is needed to support manual sealing.
 pub struct ConsensusOnTimestampSet<T>(PhantomData<T>);


### PR DESCRIPTION
Remove the `utility` pallet. We added it in the first place to be able to submit batch of extrinsics (in benchmarks). But we are not using it anymore.
Removing it reduce some unnecessary complexity and dependency.