### PR TITLE
broadcast transaction conversions refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4703,7 +4703,6 @@ dependencies = [
 name = "mp-starknet"
 version = "0.1.0-alpha"
 dependencies = [
- "anyhow",
  "bitvec 0.17.4",
  "blockifier",
  "cairo-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4703,10 +4703,12 @@ dependencies = [
 name = "mp-starknet"
 version = "0.1.0-alpha"
 dependencies = [
+ "anyhow",
  "bitvec 0.17.4",
  "blockifier",
  "cairo-vm",
  "derive_more",
+ "flate2",
  "frame-support",
  "hex",
  "lazy_static",

--- a/crates/client/rpc-core/src/utils.rs
+++ b/crates/client/rpc-core/src/utils.rs
@@ -4,7 +4,6 @@ use anyhow::{anyhow, Result};
 use base64::engine::general_purpose;
 use base64::Engine;
 use cairo_vm::types::program::Program;
-use flate2::read::GzDecoder;
 use frame_support::inherent::BlockT;
 use mp_digest_log::find_starknet_block;
 use mp_starknet::block::Block as StarknetBlock;
@@ -16,9 +15,8 @@ use sp_api::HeaderT;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::BoundedVec;
 use starknet_core::types::{
-    BroadcastedDeclareTransaction, BroadcastedDeployAccountTransaction, BroadcastedInvokeTransaction,
     BroadcastedTransaction, CompressedLegacyContractClass, ContractClass, FromByteArrayError, LegacyContractEntryPoint,
-    LegacyEntryPointsByType, StarknetError,
+    LegacyEntryPointsByType,
 };
 
 /// Returns a `ContractClass` from a `ContractClassWrapper`
@@ -65,125 +63,17 @@ pub(crate) fn encode_base64(data: &[u8]) -> String {
 /// * `Transaction` - The converted transaction
 pub fn to_tx(request: BroadcastedTransaction, chain_id: &str) -> Result<Transaction> {
     match request {
-        BroadcastedTransaction::Invoke(invoke_tx) => to_invoke_tx(invoke_tx).map(|inner| inner.from_invoke(chain_id)),
+        BroadcastedTransaction::Invoke(invoke_tx) => {
+            InvokeTransaction::try_from(invoke_tx).map(|inner| inner.from_invoke(chain_id))
+        }
         BroadcastedTransaction::Declare(declare_tx) => {
-            to_declare_tx(declare_tx).map(|inner| inner.from_declare(chain_id))
+            DeclareTransaction::try_from(declare_tx).map(|inner| inner.from_declare(chain_id))
         }
-        BroadcastedTransaction::DeployAccount(deploy_account_tx) => to_deploy_account_tx(deploy_account_tx)
-            .and_then(|inner| inner.from_deploy(chain_id).map_err(|e| anyhow!(e))),
-    }
-}
-
-/// Converts a broadcasted invoke transaction to an invoke transaction
-pub fn to_invoke_tx(tx: BroadcastedInvokeTransaction) -> Result<InvokeTransaction> {
-    match tx {
-        BroadcastedInvokeTransaction::V0(_) => Err(StarknetError::FailedToReceiveTransaction.into()),
-        BroadcastedInvokeTransaction::V1(invoke_tx_v1) => Ok(InvokeTransaction {
-            version: 1_u8,
-            signature: BoundedVec::try_from(
-                invoke_tx_v1.signature.iter().map(|x| (*x).into()).collect::<Vec<Felt252Wrapper>>(),
-            )
-            .map_err(|e| anyhow!("failed to convert signature: {:?}", e))?,
-
-            sender_address: invoke_tx_v1.sender_address.into(),
-            nonce: Felt252Wrapper::from(invoke_tx_v1.nonce),
-            calldata: BoundedVec::try_from(
-                invoke_tx_v1.calldata.iter().map(|x| (*x).into()).collect::<Vec<Felt252Wrapper>>(),
-            )
-            .map_err(|e| anyhow!("failed to convert calldata: {:?}", e))?,
-            max_fee: Felt252Wrapper::from(invoke_tx_v1.max_fee),
-        }),
-    }
-}
-
-/// Converts a broadcasted deploy account transaction to a deploy account transaction
-pub fn to_deploy_account_tx(tx: BroadcastedDeployAccountTransaction) -> Result<DeployAccountTransaction> {
-    let contract_address_salt = tx.contract_address_salt.into();
-
-    let account_class_hash = tx.class_hash;
-
-    let signature = tx
-        .signature
-        .iter()
-        .map(|f| (*f).into())
-        .collect::<Vec<Felt252Wrapper>>()
-        .try_into()
-        .map_err(|_| anyhow!("failed to bound signatures Vec<H256> by MaxArraySize"))?;
-
-    let calldata = tx
-        .constructor_calldata
-        .iter()
-        .map(|f| (*f).into())
-        .collect::<Vec<Felt252Wrapper>>()
-        .try_into()
-        .map_err(|_| anyhow!("failed to bound calldata Vec<U256> by MaxCalldataSize"))?;
-
-    let nonce = Felt252Wrapper::from(tx.nonce);
-    let max_fee = Felt252Wrapper::from(tx.max_fee);
-
-    Ok(DeployAccountTransaction {
-        version: 1_u8,
-        calldata,
-        salt: contract_address_salt,
-        signature,
-        account_class_hash: account_class_hash.into(),
-        nonce,
-        max_fee,
-    })
-}
-
-/// Converts a broadcasted declare transaction to a declare transaction
-pub fn to_declare_tx(tx: BroadcastedDeclareTransaction) -> Result<DeclareTransaction> {
-    match tx {
-        BroadcastedDeclareTransaction::V1(declare_tx_v1) => {
-            let signature = declare_tx_v1
-                .signature
-                .iter()
-                .map(|f| (*f).into())
-                .collect::<Vec<Felt252Wrapper>>()
-                .try_into()
-                .map_err(|_| anyhow!("failed to bound signatures Vec<H256> by MaxArraySize"))?;
-
-            // Create a GzipDecoder to decompress the bytes
-            let mut gz = GzDecoder::new(&declare_tx_v1.contract_class.program[..]);
-
-            // Read the decompressed bytes into a Vec<u8>
-            let mut decompressed_bytes = Vec::new();
-            std::io::Read::read_to_end(&mut gz, &mut decompressed_bytes)
-                .map_err(|_| anyhow!("Failed to decompress the contract class program"))?;
-
-            // Deserialize it then
-            let program: Program = Program::from_bytes(&decompressed_bytes, None)
-                .map_err(|_| anyhow!("Failed to deserialize the contract class program"))?;
-
-            Ok(DeclareTransaction {
-                version: 1_u8,
-                sender_address: declare_tx_v1.sender_address.into(),
-                nonce: Felt252Wrapper::from(declare_tx_v1.nonce),
-                max_fee: Felt252Wrapper::from(declare_tx_v1.max_fee),
-                signature,
-                contract_class: ContractClassWrapper {
-                    program: program.into(),
-                    entry_points_by_type: EntrypointMapWrapper::new(to_hash_map_entrypoints(
-                        declare_tx_v1.contract_class.entry_points_by_type.clone(),
-                    )),
-                },
-                compiled_class_hash: Felt252Wrapper::ZERO, // TODO: compute class hash
-            })
+        BroadcastedTransaction::DeployAccount(deploy_account_tx) => {
+            DeployAccountTransaction::try_from(deploy_account_tx)
+                .and_then(|inner| inner.from_deploy(chain_id).map_err(|e| anyhow!(e)))
         }
-        BroadcastedDeclareTransaction::V2(_) => Err(StarknetError::FailedToReceiveTransaction.into()),
     }
-}
-
-/// Returns a [HashMap<EntryPointTypeWrapper, Vec<EntryPointWrapper>>] from
-/// [LegacyEntryPointsByType]
-fn to_hash_map_entrypoints(entries: LegacyEntryPointsByType) -> HashMap<EntryPointTypeWrapper, Vec<EntryPointWrapper>> {
-    let mut entry_points_by_type = HashMap::default();
-
-    entry_points_by_type.insert(EntryPointTypeWrapper::Constructor, get_entrypoint_value(entries.constructor));
-    entry_points_by_type.insert(EntryPointTypeWrapper::External, get_entrypoint_value(entries.external));
-    entry_points_by_type.insert(EntryPointTypeWrapper::L1Handler, get_entrypoint_value(entries.l1_handler));
-    entry_points_by_type
 }
 
 /// Returns a [Result<LegacyEntryPointsByType>] (blockifier type) from a [EntrypointMapWrapper]
@@ -214,10 +104,6 @@ fn to_legacy_entry_points_by_type(entries: &EntrypointMapWrapper) -> Result<Lega
     Ok(LegacyEntryPointsByType { constructor, external, l1_handler })
 }
 
-/// Returns a [Vec<EntryPointWrapper>] from a [Vec<LegacyContractEntryPoint>]
-fn get_entrypoint_value(entries: Vec<LegacyContractEntryPoint>) -> Vec<EntryPointWrapper> {
-    entries.iter().map(|e| EntryPointWrapper::from(e.clone())).collect::<Vec<_>>()
-}
 /// Returns the current Starknet block from the block header's digest
 pub fn get_block_by_block_hash<B, C>(client: &C, block_hash: <B as BlockT>::Hash) -> Option<StarknetBlock>
 where

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -15,7 +15,7 @@ use errors::StarknetRpcApiError;
 use jsonrpsee::core::{async_trait, RpcResult};
 use log::error;
 use mc_rpc_core::utils::{
-    get_block_by_block_hash, to_declare_tx, to_deploy_account_tx, to_invoke_tx, to_rpc_contract_class, to_tx,
+    get_block_by_block_hash, to_rpc_contract_class, to_tx,
 };
 use mc_rpc_core::Felt;
 pub use mc_rpc_core::StarknetRpcApiServer;
@@ -23,7 +23,10 @@ use mc_storage::OverrideHandle;
 use mp_starknet::execution::types::Felt252Wrapper;
 use mp_starknet::traits::hash::HasherT;
 use mp_starknet::traits::ThreadSafeCopy;
-use mp_starknet::transaction::types::{RPCTransactionConversionError, Transaction as MPTransaction, TxType};
+use mp_starknet::transaction::types::{
+    DeclareTransaction, DeployAccountTransaction, InvokeTransaction, RPCTransactionConversionError,
+    Transaction as MPTransaction, TxType,
+};
 use pallet_starknet::runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_network_sync::SyncingService;
@@ -452,7 +455,7 @@ where
         invoke_transaction: BroadcastedInvokeTransaction,
     ) -> RpcResult<InvokeTransactionResult> {
         let best_block_hash = self.client.info().best_hash;
-        let invoke_tx = to_invoke_tx(invoke_transaction)?;
+        let invoke_tx = InvokeTransaction::try_from(invoke_transaction)?;
         let chain_id =
             Felt252Wrapper(self.chain_id()?.0).from_utf8().map_err(|_| StarknetRpcApiError::InternalServerError)?;
 
@@ -498,10 +501,11 @@ where
         let chain_id =
             Felt252Wrapper(self.chain_id()?.0).from_utf8().map_err(|_| StarknetRpcApiError::InternalServerError)?;
 
-        let deploy_account_transaction = to_deploy_account_tx(deploy_account_transaction).map_err(|e| {
-            error!("{e}");
-            StarknetRpcApiError::InternalServerError
-        })?;
+        let deploy_account_transaction =
+            DeployAccountTransaction::try_from(deploy_account_transaction).map_err(|e| {
+                error!("{e}");
+                StarknetRpcApiError::InternalServerError
+            })?;
 
         let transaction: MPTransaction = deploy_account_transaction.from_deploy(&chain_id).map_err(|e| {
             error!("{e}");
@@ -724,7 +728,7 @@ where
         let chain_id =
             Felt252Wrapper(self.chain_id()?.0).from_utf8().map_err(|_| StarknetRpcApiError::InternalServerError)?;
 
-        let declare_tx = to_declare_tx(declare_transaction).map_err(|e| {
+        let declare_tx = DeclareTransaction::try_from(declare_transaction).map_err(|e| {
             error!("{e}");
             StarknetRpcApiError::InternalServerError
         })?;

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -453,7 +453,10 @@ where
         invoke_transaction: BroadcastedInvokeTransaction,
     ) -> RpcResult<InvokeTransactionResult> {
         let best_block_hash = self.client.info().best_hash;
-        let invoke_tx = InvokeTransaction::try_from(invoke_transaction)?;
+        let invoke_tx = InvokeTransaction::try_from(invoke_transaction).map_err(|e| {
+            error!("{e}");
+            StarknetRpcApiError::InternalServerError
+        })?;
         let chain_id =
             Felt252Wrapper(self.chain_id()?.0).from_utf8().map_err(|_| StarknetRpcApiError::InternalServerError)?;
 
@@ -557,7 +560,10 @@ where
         let chain_id =
             Felt252Wrapper(self.chain_id()?.0).from_utf8().map_err(|_| StarknetRpcApiError::InternalServerError)?;
 
-        let tx = to_tx(request, &chain_id)?;
+        let tx = to_tx(request, &chain_id).map_err(|e| {
+            error!("{e}");
+            StarknetRpcApiError::InternalServerError
+        })?;
         let (actual_fee, gas_usage) = self
             .client
             .runtime_api()

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -14,9 +14,7 @@ use std::sync::Arc;
 use errors::StarknetRpcApiError;
 use jsonrpsee::core::{async_trait, RpcResult};
 use log::error;
-use mc_rpc_core::utils::{
-    get_block_by_block_hash, to_rpc_contract_class, to_tx,
-};
+use mc_rpc_core::utils::{get_block_by_block_hash, to_rpc_contract_class, to_tx};
 use mc_rpc_core::Felt;
 pub use mc_rpc_core::StarknetRpcApiServer;
 use mc_storage::OverrideHandle;

--- a/crates/primitives/starknet/Cargo.toml
+++ b/crates/primitives/starknet/Cargo.toml
@@ -45,7 +45,6 @@ serde_json = { version = "1.0.96", default-features = false }
 thiserror-no-std = { workspace = true }
 derive_more = { workspace = true, features = ["constructor"] }
 lazy_static = { workspace = true }
-anyhow = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -57,7 +56,6 @@ pretty_assertions = { workspace = true }
 [features]
 default = ["std"]
 std = [
-  "anyhow",
   "flate2",
   "scale-codec/std",
   "scale-info/std",

--- a/crates/primitives/starknet/Cargo.toml
+++ b/crates/primitives/starknet/Cargo.toml
@@ -45,8 +45,8 @@ serde_json = { version = "1.0.96", default-features = false }
 thiserror-no-std = { workspace = true }
 derive_more = { workspace = true, features = ["constructor"] }
 lazy_static = { workspace = true }
-# anyhow = { workspace = true }
-
+anyhow = { workspace = true, optional = true }
+flate2 = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand = "0.8.5"
@@ -57,6 +57,8 @@ pretty_assertions = { workspace = true }
 [features]
 default = ["std"]
 std = [
+  "anyhow",
+  "flate2",
   "scale-codec/std",
   "scale-info/std",
   "bitvec/std",

--- a/crates/primitives/starknet/src/transaction/mod.rs
+++ b/crates/primitives/starknet/src/transaction/mod.rs
@@ -3,6 +3,8 @@
 pub mod constants;
 /// Types related to transactions.
 pub mod types;
+/// Functions related to transaction conversions
+pub mod utils;
 
 use alloc::string::{String, ToString};
 use alloc::vec;

--- a/crates/primitives/starknet/src/transaction/utils.rs
+++ b/crates/primitives/starknet/src/transaction/utils.rs
@@ -1,0 +1,29 @@
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
+
+use frame_support::BoundedVec;
+#[cfg(feature = "std")]
+use starknet_core::types::{LegacyContractEntryPoint, LegacyEntryPointsByType};
+
+use crate::execution::types::{EntryPointTypeWrapper, EntryPointWrapper, MaxEntryPoints};
+
+/// Returns a btree map of entry point types to entrypoint from deprecated entry point by type
+#[cfg(feature = "std")]
+pub fn to_btree_map_entrypoints(
+    entries: LegacyEntryPointsByType,
+) -> BTreeMap<EntryPointTypeWrapper, BoundedVec<EntryPointWrapper, MaxEntryPoints>> {
+    let mut entry_points_by_type: BTreeMap<EntryPointTypeWrapper, BoundedVec<EntryPointWrapper, MaxEntryPoints>> =
+        BTreeMap::new();
+
+    entry_points_by_type.insert(EntryPointTypeWrapper::Constructor, get_entrypoint_value(entries.constructor));
+    entry_points_by_type.insert(EntryPointTypeWrapper::External, get_entrypoint_value(entries.external));
+    entry_points_by_type.insert(EntryPointTypeWrapper::L1Handler, get_entrypoint_value(entries.l1_handler));
+    entry_points_by_type
+}
+
+/// Returns a bounded vector of `EntryPointWrapper` from a vector of LegacyContractEntryPoint
+#[cfg(feature = "std")]
+fn get_entrypoint_value(entries: Vec<LegacyContractEntryPoint>) -> BoundedVec<EntryPointWrapper, MaxEntryPoints> {
+    // We can unwrap safely as we already checked the length of the vectors
+    BoundedVec::try_from(entries.iter().map(|e| EntryPointWrapper::from(e.clone())).collect::<Vec<_>>()).unwrap()
+}

--- a/crates/primitives/starknet/src/transaction/utils.rs
+++ b/crates/primitives/starknet/src/transaction/utils.rs
@@ -1,19 +1,18 @@
-use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
-
-use frame_support::BoundedVec;
 #[cfg(feature = "std")]
+use std::collections::HashMap;
+
 use starknet_core::types::{LegacyContractEntryPoint, LegacyEntryPointsByType};
 
-use crate::execution::types::{EntryPointTypeWrapper, EntryPointWrapper, MaxEntryPoints};
+use crate::execution::types::{EntryPointTypeWrapper, EntryPointWrapper};
 
-/// Returns a btree map of entry point types to entrypoint from deprecated entry point by type
+/// Returns a [HashMap<EntryPointTypeWrapper, Vec<EntryPointWrapper>>] from
+/// [LegacyEntryPointsByType]
 #[cfg(feature = "std")]
-pub fn to_btree_map_entrypoints(
+pub fn to_hash_map_entrypoints(
     entries: LegacyEntryPointsByType,
-) -> BTreeMap<EntryPointTypeWrapper, BoundedVec<EntryPointWrapper, MaxEntryPoints>> {
-    let mut entry_points_by_type: BTreeMap<EntryPointTypeWrapper, BoundedVec<EntryPointWrapper, MaxEntryPoints>> =
-        BTreeMap::new();
+) -> HashMap<EntryPointTypeWrapper, Vec<EntryPointWrapper>> {
+    let mut entry_points_by_type = HashMap::default();
 
     entry_points_by_type.insert(EntryPointTypeWrapper::Constructor, get_entrypoint_value(entries.constructor));
     entry_points_by_type.insert(EntryPointTypeWrapper::External, get_entrypoint_value(entries.external));
@@ -21,9 +20,8 @@ pub fn to_btree_map_entrypoints(
     entry_points_by_type
 }
 
-/// Returns a bounded vector of `EntryPointWrapper` from a vector of LegacyContractEntryPoint
+/// Returns a [Vec<EntryPointWrapper>] from a [Vec<LegacyContractEntryPoint>]
 #[cfg(feature = "std")]
-fn get_entrypoint_value(entries: Vec<LegacyContractEntryPoint>) -> BoundedVec<EntryPointWrapper, MaxEntryPoints> {
-    // We can unwrap safely as we already checked the length of the vectors
-    BoundedVec::try_from(entries.iter().map(|e| EntryPointWrapper::from(e.clone())).collect::<Vec<_>>()).unwrap()
+fn get_entrypoint_value(entries: Vec<LegacyContractEntryPoint>) -> Vec<EntryPointWrapper> {
+    entries.iter().map(|e| EntryPointWrapper::from(e.clone())).collect::<Vec<_>>()
 }

--- a/crates/primitives/starknet/src/transaction/utils.rs
+++ b/crates/primitives/starknet/src/transaction/utils.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 
+#[cfg(feature = "std")]
 use starknet_core::types::{LegacyContractEntryPoint, LegacyEntryPointsByType};
 
 use crate::execution::types::{EntryPointTypeWrapper, EntryPointWrapper};


### PR DESCRIPTION
Dev work to refactor the Broadcasted Transaction conversions to Transactions into try_from implementations on the primitive types themselves in order to be more rustlike.

# Pull Request type
- Refactoring (no functional changes, no API changes)

## What is the current behavior?
Uses functions from utils to convert Broadcast Transactions into normal transactions

Resolves: #552 

## What is the new behavior?
Removes the functions
- to_declare_tx
- to_deploy_account_tx
- to_invoke_tx

Try_from implementations added

## Does this introduce a breaking change?
No
