### PR TITLE
🔥 remove `pallet_transaction_payment`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4308,8 +4308,6 @@ dependencies = [
  "mc-storage",
  "mp-starknet",
  "pallet-starknet",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc",
  "sc-basic-authorship",
  "sc-cli",
  "sc-client-api",
@@ -4365,8 +4363,6 @@ dependencies = [
  "pallet-starknet",
  "pallet-sudo",
  "pallet-timestamp",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "scale-info",
  "sp-api",
@@ -5254,7 +5250,6 @@ dependencies = [
  "mp-digest-log",
  "mp-starknet",
  "pallet-timestamp",
- "pallet-transaction-payment",
  "parity-scale-codec",
  "pretty_assertions",
  "scale-info",
@@ -5302,50 +5297,6 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-timestamp",
-]
-
-[[package]]
-name = "pallet-transaction-payment"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.43#a2037bdedef0aa812017efee1d0fa63d4f5fcbae"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-transaction-payment-rpc"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.43#a2037bdedef0aa812017efee1d0fa63d4f5fcbae"
-dependencies = [
- "jsonrpsee",
- "pallet-transaction-payment-rpc-runtime-api",
- "parity-scale-codec",
- "sp-api",
- "sp-blockchain",
- "sp-core",
- "sp-rpc",
- "sp-runtime",
- "sp-weights",
-]
-
-[[package]]
-name = "pallet-transaction-payment-rpc-runtime-api"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.43#a2037bdedef0aa812017efee1d0fa63d4f5fcbae"
-dependencies = [
- "pallet-transaction-payment",
- "parity-scale-codec",
- "sp-api",
- "sp-runtime",
- "sp-weights",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,9 +90,6 @@ pallet-aura = { default-features = false, git = "https://github.com/paritytech/s
 pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 pallet-sudo = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 pallet-grandpa = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
-pallet-transaction-payment = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
-pallet-transaction-payment-rpc = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 
 # Madara pallets

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -48,7 +48,6 @@ sp-inherents = { workspace = true }
 sp-keyring = { workspace = true }
 sp-state-machine = { workspace = true }
 frame-system = { workspace = true }
-pallet-transaction-payment = { workspace = true }
 sp-trie = { workspace = true, features = ["default"] }
 sc-network-sync = { workspace = true }
 
@@ -64,7 +63,7 @@ sc-rpc-api = { workspace = true }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", workspace = true }
 sc-basic-authorship = { workspace = true }
 # Substrate frame dependencies
-pallet-transaction-payment-rpc = { workspace = true }
+# no substrate frame pallet dependencies for now
 
 # Substrate tools dependencies
 substrate-frame-rpc-system = { workspace = true }

--- a/crates/node/src/benchmarking.rs
+++ b/crates/node/src/benchmarking.rs
@@ -131,13 +131,12 @@ pub fn create_benchmark_extrinsic(
         )),
         frame_system::CheckNonce::<runtime::Runtime>::from(nonce),
         frame_system::CheckWeight::<runtime::Runtime>::new(),
-        pallet_transaction_payment::ChargeTransactionPayment::<runtime::Runtime>::from(0),
     );
 
     let raw_payload = runtime::SignedPayload::from_raw(
         call.clone(),
         extra.clone(),
-        ((), runtime::VERSION.spec_version, runtime::VERSION.transaction_version, genesis_hash, best_hash, (), (), ()),
+        ((), runtime::VERSION.spec_version, runtime::VERSION.transaction_version, genesis_hash, best_hash, (), ()),
     );
     let signature = raw_payload.using_encoded(|e| sender.sign(e));
 

--- a/crates/node/src/chain_spec.rs
+++ b/crates/node/src/chain_spec.rs
@@ -280,8 +280,6 @@ fn testnet_genesis(
             // Assign network admin rights.
             key: Some(root_key),
         },
-        // Provides the logic needed to handle transaction fees
-        transaction_payment: Default::default(),
         /// Starknet Genesis configuration.
         starknet: madara_runtime::pallet_starknet::GenesisConfig {
             contracts: vec![

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use futures::channel::mpsc;
 use jsonrpsee::RpcModule;
 use madara_runtime::opaque::Block;
-use madara_runtime::{AccountId, Balance, Hash, Index};
+use madara_runtime::{AccountId, Hash, Index};
 use pallet_starknet::runtime_api::StarknetRuntimeApi;
 use sc_client_api::{Backend, StorageProvider};
 use sc_consensus_manual_seal::rpc::EngineCommand;
@@ -43,7 +43,6 @@ where
     C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError> + StorageProvider<Block, BE> + 'static,
     C: Send + Sync + 'static,
     C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
-    C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
     C::Api: BlockBuilder<Block>,
     C::Api: pallet_starknet::runtime_api::StarknetRuntimeApi<Block>
         + pallet_starknet::runtime_api::ConvertTransactionRuntimeApi<Block>,
@@ -51,7 +50,6 @@ where
     BE: Backend<Block> + 'static,
 {
     use mc_rpc::{Starknet, StarknetRpcApiServer};
-    use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
     use sc_consensus_manual_seal::rpc::{ManualSeal, ManualSealApiServer};
     use substrate_frame_rpc_system::{System, SystemApiServer};
 
@@ -61,7 +59,6 @@ where
     let hasher = client.runtime_api().get_hasher(client.info().best_hash)?.into();
 
     module.merge(System::new(client.clone(), pool.clone(), deny_unsafe).into_rpc())?;
-    module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
     module.merge(
         Starknet::new(
             client,

--- a/crates/pallets/starknet/Cargo.toml
+++ b/crates/pallets/starknet/Cargo.toml
@@ -31,7 +31,6 @@ sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-api = { workspace = true }
 sp-std = { workspace = true }
-pallet-transaction-payment = { workspace = true }
 # Frame pallets
 
 # Other third party dependencies
@@ -61,7 +60,6 @@ std = [
 	"frame-benchmarking?/std",
 	"scale-info/std",
 	"pallet-timestamp/std",
-	"pallet-transaction-payment/std",
 	# Madara
 	"mp-starknet/std",
 	# Starknet

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -38,7 +38,6 @@ pallet-sudo = { workspace = true }
 frame-system = { workspace = true }
 frame-try-runtime = { workspace = true, optional = true }
 pallet-timestamp = { workspace = true }
-pallet-transaction-payment = { workspace = true }
 frame-executive = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
@@ -46,7 +45,6 @@ sp-std = { workspace = true }
 
 # Used for the node RPCs
 frame-system-rpc-runtime-api = { workspace = true }
-pallet-transaction-payment-rpc-runtime-api = { workspace = true }
 
 # Used for runtime benchmarking
 frame-benchmarking = { workspace = true, optional = true }
@@ -80,8 +78,6 @@ std = [
 	"pallet-grandpa/std",
 	"pallet-sudo/std",
 	"pallet-timestamp/std",
-	"pallet-transaction-payment-rpc-runtime-api/std",
-	"pallet-transaction-payment/std",
 	# Substrate primitives dependencies
 	"sp-api/std",
 	"sp-block-builder/std",
@@ -100,7 +96,6 @@ std = [
 ]
 try-runtime = [
 	"pallet-timestamp/try-runtime",
-	"pallet-transaction-payment/try-runtime",
 	"frame-try-runtime/try-runtime",
 	"frame-executive/try-runtime",
 	"frame-system/try-runtime",

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -7,9 +7,7 @@ pub use frame_support::weights::{IdentityFee, Weight};
 pub use frame_support::{construct_runtime, parameter_types, StorageValue};
 pub use frame_system::Call as SystemCall;
 pub use pallet_balances::Call as BalancesCall;
-use pallet_transaction_payment::Multiplier;
 use sp_runtime::create_runtime_str;
-use sp_runtime::traits::One;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
@@ -78,7 +76,6 @@ parameter_types! {
     pub BlockLength: frame_system::limits::BlockLength = frame_system::limits::BlockLength
         ::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
     pub const SS58Prefix: u8 = 42;
-    pub FeeMultiplier: Multiplier = Multiplier::one();
 }
 
 // This storage item will be used to check if we are in the manual sealing mode

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -69,7 +69,6 @@ construct_runtime!(
         Aura: pallet_aura,
         Grandpa: pallet_grandpa,
         Balances: pallet_balances,
-        TransactionPayment: pallet_transaction_payment,
         Sudo: pallet_sudo,
         // Include Starknet pallet.
         Starknet: pallet_starknet,
@@ -92,7 +91,6 @@ pub type SignedExtra = (
     frame_system::CheckEra<Runtime>,
     frame_system::CheckNonce<Runtime>,
     frame_system::CheckWeight<Runtime>,
-    pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
@@ -237,50 +235,6 @@ impl_runtime_apis! {
     impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index> for Runtime {
         fn account_nonce(account: AccountId) -> Index {
             System::account_nonce(account)
-        }
-    }
-
-    impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
-        fn query_info(
-            uxt: <Block as BlockT>::Extrinsic,
-            len: u32,
-        ) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-            TransactionPayment::query_info(uxt, len)
-        }
-        fn query_fee_details(
-            uxt: <Block as BlockT>::Extrinsic,
-            len: u32,
-        ) -> pallet_transaction_payment::FeeDetails<Balance> {
-            TransactionPayment::query_fee_details(uxt, len)
-        }
-        fn query_weight_to_fee(weight: Weight) -> Balance {
-            TransactionPayment::weight_to_fee(weight)
-        }
-        fn query_length_to_fee(length: u32) -> Balance {
-            TransactionPayment::length_to_fee(length)
-        }
-    }
-
-    impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentCallApi<Block, Balance, RuntimeCall>
-        for Runtime
-    {
-        fn query_call_info(
-            call: RuntimeCall,
-            len: u32,
-        ) -> pallet_transaction_payment::RuntimeDispatchInfo<Balance> {
-            TransactionPayment::query_call_info(call, len)
-        }
-        fn query_call_fee_details(
-            call: RuntimeCall,
-            len: u32,
-        ) -> pallet_transaction_payment::FeeDetails<Balance> {
-            TransactionPayment::query_call_fee_details(call, len)
-        }
-        fn query_weight_to_fee(weight: Weight) -> Balance {
-            TransactionPayment::weight_to_fee(weight)
-        }
-        fn query_length_to_fee(length: u32) -> Balance {
-            TransactionPayment::length_to_fee(length)
         }
     }
 

--- a/crates/runtime/src/pallets.rs
+++ b/crates/runtime/src/pallets.rs
@@ -15,7 +15,6 @@ pub use pallet_balances::Call as BalancesCall;
 /// Import the StarkNet pallet.
 pub use pallet_starknet;
 pub use pallet_timestamp::Call as TimestampCall;
-use pallet_transaction_payment::{ConstFeeMultiplier, CurrencyAdapter};
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_runtime::generic;
 use sp_runtime::traits::{AccountIdLookup, BlakeTwo256};
@@ -163,16 +162,6 @@ impl pallet_balances::Config for Runtime {
     type MaxFreezes = ();
     type HoldIdentifier = ();
     type MaxHolds = ();
-}
-
-/// Provides the logic needed to handle transaction fees
-impl pallet_transaction_payment::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type OnChargeTransaction = CurrencyAdapter<Balances, ()>;
-    type OperationalFeeMultiplier = ConstU8<5>;
-    type WeightToFee = IdentityFee<Balance>;
-    type LengthToFee = IdentityFee<Balance>;
-    type FeeMultiplierUpdate = ConstFeeMultiplier<FeeMultiplier>;
 }
 
 /// Allows executing privileged functions.


### PR DESCRIPTION
Remove unused `pallet_transaction_payment`. In previous versions we wanted to use it to handle transaction fees, but we ended up doing it manually for efficiency.
