### PR TITLE
✨ internalize block proposer logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4302,13 +4302,13 @@ dependencies = [
  "jsonrpsee",
  "log",
  "madara-runtime",
+ "mc-block-proposer",
  "mc-db",
  "mc-mapping-sync",
  "mc-rpc",
  "mc-storage",
  "mp-starknet",
  "pallet-starknet",
- "sc-basic-authorship",
  "sc-cli",
  "sc-client-api",
  "sc-consensus",
@@ -4413,6 +4413,28 @@ checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
 dependencies = [
  "autocfg",
  "rawpointer",
+]
+
+[[package]]
+name = "mc-block-proposer"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "log",
+ "parity-scale-codec",
+ "sc-block-builder",
+ "sc-client-api",
+ "sc-proposer-metrics",
+ "sc-telemetry",
+ "sc-transaction-pool-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
 ]
 
 [[package]]
@@ -6534,29 +6556,6 @@ dependencies = [
  "sp-core",
  "sp-wasm-interface",
  "thiserror",
-]
-
-[[package]]
-name = "sc-basic-authorship"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.43#a2037bdedef0aa812017efee1d0fa63d4f5fcbae"
-dependencies = [
- "futures",
- "futures-timer",
- "log",
- "parity-scale-codec",
- "sc-block-builder",
- "sc-client-api",
- "sc-proposer-metrics",
- "sc-telemetry",
- "sc-transaction-pool-api",
- "sp-api",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.43)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,8 @@ sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "polka
 sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 sc-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
+sc-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
+sc-proposer-metrics = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 
 # Substrate build & tools dependencies
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
@@ -104,6 +106,7 @@ mc-db = { path = "crates/client/db" }
 mc-storage = { path = "crates/client/storage" }
 mc-rpc = { path = "crates/client/rpc" }
 mc-rpc-core = { path = "crates/client/rpc-core" }
+mc-block-proposer = { path = "crates/client/block-proposer" }
 
 # Starknet dependencies
 # Cairo Virtual Machine

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [workspace]
 members = [
-	"crates/node",
-	"crates/runtime",
-	"crates/pallets/starknet",
-	"crates/primitives/starknet",
-	"crates/primitives/digest-log",
-	"crates/client/db",
-	"crates/client/rpc-core",
-	"crates/client/rpc",
-	"crates/client/mapping-sync",
-	"crates/client/storage",
+  "crates/node",
+  "crates/runtime",
+  "crates/pallets/starknet",
+  "crates/primitives/starknet",
+  "crates/primitives/digest-log",
+  "crates/client/db",
+  "crates/client/rpc-core",
+  "crates/client/rpc",
+  "crates/client/mapping-sync",
+  "crates/client/storage",
 ]
 [profile.release]
 panic = "unwind"
@@ -58,7 +58,7 @@ sp-trie = { version = "7.0.0", git = "https://github.com/paritytech/substrate", 
 
 # Substrate client dependencies
 sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43", features = [
-	"rocksdb",
+  "rocksdb",
 ] }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 sc-network-common = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
@@ -97,7 +97,7 @@ pallet-timestamp = { default-features = false, git = "https://github.com/parityt
 pallet-starknet = { path = "crates/pallets/starknet", default-features = false }
 
 # Madara primtitives
-mp-starknet = { path = "crates/primitives/starknet", default-features = false}
+mp-starknet = { path = "crates/primitives/starknet", default-features = false }
 mp-digest-log = { path = "crates/primitives/digest-log", default-features = false }
 
 # Madara client
@@ -115,11 +115,11 @@ starknet-crypto = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "
 starknet-core = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ca2fafada8da1af5b767af0b990787fa30ff10d2", default-features = false }
 starknet-ff = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ca2fafada8da1af5b767af0b990787fa30ff10d2", default-features = false }
 poseidon_hash = { default-features = false, package = "poseidon", git = "https://github.com/EvolveArt/poseidon-rs", branch = "feature/no-std-refractor", features = [
-	"alloc",
+  "alloc",
 ] }
 blockifier = { git = "https://github.com/tdelabro/blockifier", branch = "new-no_std-support", default-features = false }
 starknet_api = { git = "https://github.com/tdelabro/starknet-api", branch = "no_std-support", features = [
-	"testing",
+  "testing",
 ], default-features = false }
 # Other third party dependencies
 anyhow = "1.0.71"

--- a/benchmarking/scripts/starknet-erc20.yml
+++ b/benchmarking/scripts/starknet-erc20.yml
@@ -23,4 +23,4 @@ scenarios:
       - loop:
           - function: "executeERC20Transfer"
           - log: "Executed ERC20 transfer {{ nonce }}"
-        count: 100000
+        count: 20000

--- a/benchmarking/scripts/starknet-erc20.yml
+++ b/benchmarking/scripts/starknet-erc20.yml
@@ -23,4 +23,4 @@ scenarios:
       - loop:
           - function: "executeERC20Transfer"
           - log: "Executed ERC20 transfer {{ nonce }}"
-        count: 20000
+        count: 10000

--- a/crates/client/block-proposer/Cargo.toml
+++ b/crates/client/block-proposer/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "mc-block-proposer"
+version = "0.1.0"
+description = "Starknet block proposer implementation."
+authors = [
+	"Abdelhamid Bakhta <https://github.com/abdelhamidbakhta>",
+	"Substrate DevHub <https://github.com/substrate-developer-hub>",
+]
+homepage = "https://github.com/keep-starknet-strange/madara"
+edition = "2021"
+license = "MIT"
+publish = false
+repository = "https://github.com/keep-starknet-strange/madara"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.2.2" }
+futures = "0.3.21"
+futures-timer = "3.0.1"
+log = "0.4.17"
+prometheus-endpoint = { workspace = true}
+sc-block-builder = { workspace = true}
+sc-client-api = { workspace = true}
+sc-proposer-metrics = { workspace = true}
+sc-telemetry = { workspace = true}
+sc-transaction-pool-api ={ workspace = true}
+sp-api = { workspace = true}
+sp-blockchain ={ workspace = true}
+sp-consensus = { workspace = true}
+sp-core = { workspace = true}
+sp-inherents = { workspace = true}
+sp-runtime = { workspace = true}

--- a/crates/client/block-proposer/Cargo.toml
+++ b/crates/client/block-proposer/Cargo.toml
@@ -3,8 +3,8 @@ name = "mc-block-proposer"
 version = "0.1.0"
 description = "Starknet block proposer implementation."
 authors = [
-	"Abdelhamid Bakhta <https://github.com/abdelhamidbakhta>",
-	"Substrate DevHub <https://github.com/substrate-developer-hub>",
+  "Abdelhamid Bakhta <https://github.com/abdelhamidbakhta>",
+  "Substrate DevHub <https://github.com/substrate-developer-hub>",
 ]
 homepage = "https://github.com/keep-starknet-strange/madara"
 edition = "2021"
@@ -20,15 +20,15 @@ codec = { package = "parity-scale-codec", version = "3.2.2" }
 futures = "0.3.21"
 futures-timer = "3.0.1"
 log = "0.4.17"
-prometheus-endpoint = { workspace = true}
-sc-block-builder = { workspace = true}
-sc-client-api = { workspace = true}
-sc-proposer-metrics = { workspace = true}
-sc-telemetry = { workspace = true}
-sc-transaction-pool-api ={ workspace = true}
-sp-api = { workspace = true}
-sp-blockchain ={ workspace = true}
-sp-consensus = { workspace = true}
-sp-core = { workspace = true}
-sp-inherents = { workspace = true}
-sp-runtime = { workspace = true}
+prometheus-endpoint = { workspace = true }
+sc-block-builder = { workspace = true }
+sc-client-api = { workspace = true }
+sc-proposer-metrics = { workspace = true }
+sc-telemetry = { workspace = true }
+sc-transaction-pool-api = { workspace = true }
+sp-api = { workspace = true }
+sp-blockchain = { workspace = true }
+sp-consensus = { workspace = true }
+sp-core = { workspace = true }
+sp-inherents = { workspace = true }
+sp-runtime = { workspace = true }

--- a/crates/client/block-proposer/src/lib.rs
+++ b/crates/client/block-proposer/src/lib.rs
@@ -1,0 +1,444 @@
+//! Block proposer implementation.
+//! This crate implements the [`sp_consensus::Proposer`] trait.
+//! It is used to build blocks for the block authoring node.
+//! The block authoring node is the node that is responsible for building new blocks.
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time;
+
+use codec::Encode;
+use futures::channel::oneshot;
+use futures::future::{Future, FutureExt};
+use futures::{future, select};
+use log::{debug, error, info, trace, warn};
+use prometheus_endpoint::Registry as PrometheusRegistry;
+use sc_block_builder::{BlockBuilderApi, BlockBuilderProvider};
+use sc_client_api::backend;
+use sc_proposer_metrics::{EndProposingReason, MetricsLink as PrometheusMetrics};
+use sc_transaction_pool_api::{InPoolTransaction, TransactionPool};
+use sp_api::{ApiExt, ProvideRuntimeApi};
+use sp_blockchain::ApplyExtrinsicFailed::Validity;
+use sp_blockchain::Error::ApplyExtrinsicFailed;
+use sp_blockchain::HeaderBackend;
+use sp_consensus::{DisableProofRecording, EnableProofRecording, ProofRecording, Proposal};
+use sp_core::traits::SpawnNamed;
+use sp_inherents::InherentData;
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
+use sp_runtime::{Digest, Percent, SaturatedConversion};
+
+/// Default block size limit in bytes used by [`Proposer`].
+///
+/// Can be overwritten by [`ProposerFactory::set_default_block_size_limit`].
+///
+/// Be aware that there is also an upper packet size on what the networking code
+/// will accept. If the block doesn't fit in such a package, it can not be
+/// transferred to other nodes.
+pub const DEFAULT_BLOCK_SIZE_LIMIT: usize = 4 * 1024 * 1024 + 512;
+
+const DEFAULT_SOFT_DEADLINE_PERCENT: Percent = Percent::from_percent(80);
+
+/// [`Proposer`] factory.
+pub struct ProposerFactory<A, B, C, PR> {
+    spawn_handle: Box<dyn SpawnNamed>,
+    /// The client instance.
+    client: Arc<C>,
+    /// The transaction pool.
+    transaction_pool: Arc<A>,
+    /// Prometheus Link,
+    metrics: PrometheusMetrics,
+    /// The default block size limit.
+    ///
+    /// If no `block_size_limit` is passed to [`sp_consensus::Proposer::propose`], this block size
+    /// limit will be used.
+    default_block_size_limit: usize,
+    /// Soft deadline percentage of hard deadline.
+    ///
+    /// The value is used to compute soft deadline during block production.
+    /// The soft deadline indicates where we should stop attempting to add transactions
+    /// to the block, which exhaust resources. After soft deadline is reached,
+    /// we switch to a fixed-amount mode, in which after we see `MAX_SKIPPED_TRANSACTIONS`
+    /// transactions which exhaust resrouces, we will conclude that the block is full.
+    soft_deadline_percent: Percent,
+    /// When estimating the block size, should the proof be included?
+    include_proof_in_block_size_estimation: bool,
+    /// phantom member to pin the `Backend`/`ProofRecording` type.
+    _phantom: PhantomData<(B, PR)>,
+}
+
+impl<A, B, C> ProposerFactory<A, B, C, DisableProofRecording> {
+    /// Create a new proposer factory.
+    ///
+    /// Proof recording will be disabled when using proposers built by this instance to build
+    /// blocks.
+    pub fn new(
+        spawn_handle: impl SpawnNamed + 'static,
+        client: Arc<C>,
+        transaction_pool: Arc<A>,
+        prometheus: Option<&PrometheusRegistry>,
+    ) -> Self {
+        ProposerFactory {
+            spawn_handle: Box::new(spawn_handle),
+            transaction_pool,
+            metrics: PrometheusMetrics::new(prometheus),
+            default_block_size_limit: DEFAULT_BLOCK_SIZE_LIMIT,
+            soft_deadline_percent: DEFAULT_SOFT_DEADLINE_PERCENT,
+            client,
+            include_proof_in_block_size_estimation: false,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<A, B, C> ProposerFactory<A, B, C, EnableProofRecording> {
+    /// Create a new proposer factory with proof recording enabled.
+    ///
+    /// Each proposer created by this instance will record a proof while building a block.
+    ///
+    /// This will also include the proof into the estimation of the block size. This can be disabled
+    /// by calling [`ProposerFactory::disable_proof_in_block_size_estimation`].
+    pub fn with_proof_recording(
+        spawn_handle: impl SpawnNamed + 'static,
+        client: Arc<C>,
+        transaction_pool: Arc<A>,
+        prometheus: Option<&PrometheusRegistry>,
+    ) -> Self {
+        ProposerFactory {
+            client,
+            spawn_handle: Box::new(spawn_handle),
+            transaction_pool,
+            metrics: PrometheusMetrics::new(prometheus),
+            default_block_size_limit: DEFAULT_BLOCK_SIZE_LIMIT,
+            soft_deadline_percent: DEFAULT_SOFT_DEADLINE_PERCENT,
+            include_proof_in_block_size_estimation: true,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Disable the proof inclusion when estimating the block size.
+    pub fn disable_proof_in_block_size_estimation(&mut self) {
+        self.include_proof_in_block_size_estimation = false;
+    }
+}
+
+impl<A, B, C, PR> ProposerFactory<A, B, C, PR> {
+    /// Set the default block size limit in bytes.
+    ///
+    /// The default value for the block size limit is:
+    /// [`DEFAULT_BLOCK_SIZE_LIMIT`].
+    ///
+    /// If there is no block size limit passed to [`sp_consensus::Proposer::propose`], this value
+    /// will be used.
+    pub fn set_default_block_size_limit(&mut self, limit: usize) {
+        self.default_block_size_limit = limit;
+    }
+
+    /// Set soft deadline percentage.
+    ///
+    /// The value is used to compute soft deadline during block production.
+    /// The soft deadline indicates where we should stop attempting to add transactions
+    /// to the block, which exhaust resources. After soft deadline is reached,
+    /// we switch to a fixed-amount mode, in which after we see `MAX_SKIPPED_TRANSACTIONS`
+    /// transactions which exhaust resrouces, we will conclude that the block is full.
+    ///
+    /// Setting the value too low will significantly limit the amount of transactions
+    /// we try in case they exhaust resources. Setting the value too high can
+    /// potentially open a DoS vector, where many "exhaust resources" transactions
+    /// are being tried with no success, hence block producer ends up creating an empty block.
+    pub fn set_soft_deadline(&mut self, percent: Percent) {
+        self.soft_deadline_percent = percent;
+    }
+}
+
+impl<B, Block, C, A, PR> ProposerFactory<A, B, C, PR>
+where
+    A: TransactionPool<Block = Block> + 'static,
+    B: backend::Backend<Block> + Send + Sync + 'static,
+    Block: BlockT,
+    C: BlockBuilderProvider<B, Block, C> + HeaderBackend<Block> + ProvideRuntimeApi<Block> + Send + Sync + 'static,
+    C::Api: ApiExt<Block, StateBackend = backend::StateBackendFor<B, Block>> + BlockBuilderApi<Block>,
+{
+    fn init_with_now(
+        &mut self,
+        parent_header: &<Block as BlockT>::Header,
+        now: Box<dyn Fn() -> time::Instant + Send + Sync>,
+    ) -> Proposer<B, Block, C, A, PR> {
+        let parent_hash = parent_header.hash();
+
+        info!("🩸 Starting consensus session on top of parent {:?}", parent_hash);
+
+        let proposer = Proposer::<_, _, _, _, PR> {
+            spawn_handle: self.spawn_handle.clone(),
+            client: self.client.clone(),
+            parent_hash,
+            parent_number: *parent_header.number(),
+            transaction_pool: self.transaction_pool.clone(),
+            now,
+            metrics: self.metrics.clone(),
+            default_block_size_limit: self.default_block_size_limit,
+            soft_deadline_percent: self.soft_deadline_percent,
+            _phantom: PhantomData,
+            include_proof_in_block_size_estimation: self.include_proof_in_block_size_estimation,
+        };
+
+        proposer
+    }
+}
+
+impl<A, B, Block, C, PR> sp_consensus::Environment<Block> for ProposerFactory<A, B, C, PR>
+where
+    A: TransactionPool<Block = Block> + 'static,
+    B: backend::Backend<Block> + Send + Sync + 'static,
+    Block: BlockT,
+    C: BlockBuilderProvider<B, Block, C> + HeaderBackend<Block> + ProvideRuntimeApi<Block> + Send + Sync + 'static,
+    C::Api: ApiExt<Block, StateBackend = backend::StateBackendFor<B, Block>> + BlockBuilderApi<Block>,
+    PR: ProofRecording,
+{
+    type CreateProposer = future::Ready<Result<Self::Proposer, Self::Error>>;
+    type Proposer = Proposer<B, Block, C, A, PR>;
+    type Error = sp_blockchain::Error;
+
+    fn init(&mut self, parent_header: &<Block as BlockT>::Header) -> Self::CreateProposer {
+        future::ready(Ok(self.init_with_now(parent_header, Box::new(time::Instant::now))))
+    }
+}
+
+/// The proposer logic.
+pub struct Proposer<B, Block: BlockT, C, A: TransactionPool, PR> {
+    spawn_handle: Box<dyn SpawnNamed>,
+    client: Arc<C>,
+    parent_hash: Block::Hash,
+    parent_number: <<Block as BlockT>::Header as HeaderT>::Number,
+    transaction_pool: Arc<A>,
+    now: Box<dyn Fn() -> time::Instant + Send + Sync>,
+    metrics: PrometheusMetrics,
+    default_block_size_limit: usize,
+    include_proof_in_block_size_estimation: bool,
+    soft_deadline_percent: Percent,
+    _phantom: PhantomData<(B, PR)>,
+}
+
+impl<A, B, Block, C, PR> sp_consensus::Proposer<Block> for Proposer<B, Block, C, A, PR>
+where
+    A: TransactionPool<Block = Block> + 'static,
+    B: backend::Backend<Block> + Send + Sync + 'static,
+    Block: BlockT,
+    C: BlockBuilderProvider<B, Block, C> + HeaderBackend<Block> + ProvideRuntimeApi<Block> + Send + Sync + 'static,
+    C::Api: ApiExt<Block, StateBackend = backend::StateBackendFor<B, Block>> + BlockBuilderApi<Block>,
+    PR: ProofRecording,
+{
+    type Transaction = backend::TransactionFor<B, Block>;
+    type Proposal =
+        Pin<Box<dyn Future<Output = Result<Proposal<Block, Self::Transaction, PR::Proof>, Self::Error>> + Send>>;
+    type Error = sp_blockchain::Error;
+    type ProofRecording = PR;
+    type Proof = PR::Proof;
+
+    fn propose(
+        self,
+        inherent_data: InherentData,
+        inherent_digests: Digest,
+        max_duration: time::Duration,
+        block_size_limit: Option<usize>,
+    ) -> Self::Proposal {
+        let (tx, rx) = oneshot::channel();
+        let spawn_handle = self.spawn_handle.clone();
+
+        spawn_handle.spawn_blocking(
+            "madara-block-proposer",
+            None,
+            Box::pin(async move {
+                // leave some time for evaluation and block finalization (33%)
+                let deadline = (self.now)() + max_duration - max_duration / 3;
+                let res = self.propose_with(inherent_data, inherent_digests, deadline, block_size_limit).await;
+                if tx.send(res).is_err() {
+                    trace!("Could not send block production result to proposer!");
+                }
+            }),
+        );
+
+        async move { rx.await? }.boxed()
+    }
+}
+
+/// If the block is full we will attempt to push at most
+/// this number of transactions before quitting for real.
+/// It allows us to increase block utilization.
+const MAX_SKIPPED_TRANSACTIONS: usize = 8;
+
+impl<A, B, Block, C, PR> Proposer<B, Block, C, A, PR>
+where
+    A: TransactionPool<Block = Block>,
+    B: backend::Backend<Block> + Send + Sync + 'static,
+    Block: BlockT,
+    C: BlockBuilderProvider<B, Block, C> + HeaderBackend<Block> + ProvideRuntimeApi<Block> + Send + Sync + 'static,
+    C::Api: ApiExt<Block, StateBackend = backend::StateBackendFor<B, Block>> + BlockBuilderApi<Block>,
+    PR: ProofRecording,
+{
+    async fn propose_with(
+        self,
+        inherent_data: InherentData,
+        inherent_digests: Digest,
+        deadline: time::Instant,
+        block_size_limit: Option<usize>,
+    ) -> Result<Proposal<Block, backend::TransactionFor<B, Block>, PR::Proof>, sp_blockchain::Error> {
+        let propose_with_start = time::Instant::now();
+        let mut block_builder = self.client.new_block_at(self.parent_hash, inherent_digests, PR::ENABLED)?;
+        let inherents = block_builder.create_inherents(inherent_data)?;
+
+        for inherent in inherents {
+            match block_builder.push(inherent) {
+                Err(ApplyExtrinsicFailed(Validity(e))) if e.exhausted_resources() => {
+                    warn!("⚠️  Dropping non-mandatory inherent from overweight block.")
+                }
+                Err(ApplyExtrinsicFailed(Validity(e))) if e.was_mandatory() => {
+                    error!("❌️ Mandatory inherent extrinsic returned error. Block cannot be produced.");
+                    return Err(ApplyExtrinsicFailed(Validity(e)));
+                }
+                Err(e) => {
+                    warn!("❗️ Inherent extrinsic returned unexpected error: {}. Dropping.", e);
+                }
+                Ok(_) => {}
+            }
+        }
+
+        // proceed with transactions
+        // We calculate soft deadline used only in case we start skipping transactions.
+        let now = (self.now)();
+        let left = deadline.saturating_duration_since(now);
+        let left_micros: u64 = left.as_micros().saturated_into();
+        let soft_deadline = now + time::Duration::from_micros(self.soft_deadline_percent.mul_floor(left_micros));
+        let block_timer = time::Instant::now();
+        let mut skipped = 0;
+        let mut unqueue_invalid = Vec::new();
+
+        let mut t1 = self.transaction_pool.ready_at(self.parent_number).fuse();
+        let mut t2 = futures_timer::Delay::new(deadline.saturating_duration_since((self.now)()) / 8).fuse();
+
+        let mut pending_iterator = select! {
+            res = t1 => res,
+            _ = t2 => {
+                log::warn!(
+                    "Timeout fired waiting for transaction pool at block #{}. \
+                    Proceeding with production.",
+                    self.parent_number,
+                );
+                self.transaction_pool.ready()
+            },
+        };
+
+        let block_size_limit = block_size_limit.unwrap_or(self.default_block_size_limit);
+
+        debug!("Attempting to push transactions from the pool.");
+        debug!("Pool status: {:?}", self.transaction_pool.status());
+        let mut transaction_pushed = false;
+
+        let end_reason = loop {
+            let pending_tx = if let Some(pending_tx) = pending_iterator.next() {
+                pending_tx
+            } else {
+                break EndProposingReason::NoMoreTransactions;
+            };
+
+            let now = (self.now)();
+            if now > deadline {
+                debug!("Consensus deadline reached when pushing block transactions, proceeding with proposing.");
+                break EndProposingReason::HitDeadline;
+            }
+
+            let pending_tx_data = pending_tx.data().clone();
+            let pending_tx_hash = pending_tx.hash().clone();
+
+            let block_size = block_builder.estimate_block_size(self.include_proof_in_block_size_estimation);
+            if block_size + pending_tx_data.encoded_size() > block_size_limit {
+                pending_iterator.report_invalid(&pending_tx);
+                if skipped < MAX_SKIPPED_TRANSACTIONS {
+                    skipped += 1;
+                    debug!(
+                        "Transaction would overflow the block size limit, but will try {} more transactions before \
+                         quitting.",
+                        MAX_SKIPPED_TRANSACTIONS - skipped,
+                    );
+                    continue;
+                } else if now < soft_deadline {
+                    debug!(
+                        "Transaction would overflow the block size limit, but we still have time before the soft \
+                         deadline, so we will try a bit more."
+                    );
+                    continue;
+                } else {
+                    debug!("Reached block size limit, proceeding with proposing.");
+                    break EndProposingReason::HitBlockSizeLimit;
+                }
+            }
+
+            trace!("[{:?}] Pushing to the block.", pending_tx_hash);
+            match sc_block_builder::BlockBuilder::push(&mut block_builder, pending_tx_data) {
+                Ok(()) => {
+                    transaction_pushed = true;
+                    debug!("[{:?}] Pushed to the block.", pending_tx_hash);
+                }
+                Err(ApplyExtrinsicFailed(Validity(e))) if e.exhausted_resources() => {
+                    pending_iterator.report_invalid(&pending_tx);
+                    if skipped < MAX_SKIPPED_TRANSACTIONS {
+                        skipped += 1;
+                        debug!(
+                            "Block seems full, but will try {} more transactions before quitting.",
+                            MAX_SKIPPED_TRANSACTIONS - skipped,
+                        );
+                    } else if (self.now)() < soft_deadline {
+                        debug!(
+                            "Block seems full, but we still have time before the soft deadline, so we will try a bit \
+                             more before quitting."
+                        );
+                    } else {
+                        debug!("Reached block weight limit, proceeding with proposing.");
+                        break EndProposingReason::HitBlockWeightLimit;
+                    }
+                }
+                Err(e) => {
+                    pending_iterator.report_invalid(&pending_tx);
+                    debug!("[{:?}] Invalid transaction: {}", pending_tx_hash, e);
+                    unqueue_invalid.push(pending_tx_hash);
+                }
+            }
+        };
+
+        if matches!(end_reason, EndProposingReason::HitBlockSizeLimit) && !transaction_pushed {
+            warn!("Hit block size limit of `{}` without including any transaction!", block_size_limit,);
+        }
+
+        self.transaction_pool.remove_invalid(&unqueue_invalid);
+
+        // FIXME: use custom implementation of block builder and remove storage proof computation
+        let (block, storage_changes, proof) = block_builder.build()?.into_inner();
+
+        self.metrics.report(|metrics| {
+            metrics.number_of_transactions.set(block.extrinsics().len() as u64);
+            metrics.block_constructed.observe(block_timer.elapsed().as_secs_f64());
+
+            metrics.report_end_proposing_reason(end_reason);
+        });
+
+        info!(
+            "🥷 Prepared block for proposing at {} ({} ms) [hash: {:?}; parent_hash: {}; extrinsics ({})]",
+            block.header().number(),
+            block_timer.elapsed().as_millis(),
+            block.header().hash(),
+            block.header().parent_hash(),
+            block.extrinsics().len(),
+        );
+
+        // TODO: try to remove completely the storage proof computation and see if it breaks anything
+        let proof = PR::into_proof(proof).map_err(|e| sp_blockchain::Error::Application(Box::new(e)))?;
+
+        let propose_with_end = time::Instant::now();
+        self.metrics.report(|metrics| {
+            metrics
+                .create_block_proposal_time
+                .observe(propose_with_end.saturating_duration_since(propose_with_start).as_secs_f64());
+        });
+
+        Ok(Proposal { block, proof, storage_changes })
+    }
+}

--- a/crates/client/block-proposer/src/lib.rs
+++ b/crates/client/block-proposer/src/lib.rs
@@ -375,6 +375,7 @@ where
         self.transaction_pool.remove_invalid(&unqueue_invalid);
 
         // FIXME: use custom implementation of block builder and remove storage proof computation
+        // Issue: https://github.com/keep-starknet-strange/madara/issues/605
         let (block, storage_changes, proof) = block_builder.build()?.into_inner();
 
         self.metrics.report(|metrics| {

--- a/crates/client/block-proposer/src/lib.rs
+++ b/crates/client/block-proposer/src/lib.rs
@@ -35,7 +35,12 @@ use sp_runtime::{Digest, Percent, SaturatedConversion};
 /// will accept. If the block doesn't fit in such a package, it can not be
 /// transferred to other nodes.
 pub const DEFAULT_BLOCK_SIZE_LIMIT: usize = 4 * 1024 * 1024 + 512;
-
+/// Default value for `soft_deadline_percent` used by [`Proposer`].
+/// `soft_deadline_percent` value is used to compute soft deadline during block production.
+/// The soft deadline indicates where we should stop attempting to add transactions
+/// to the block, which exhaust resources. After soft deadline is reached,
+/// we switch to a fixed-amount mode, in which after we see `MAX_SKIPPED_TRANSACTIONS`
+/// transactions which exhaust resources, we will conclude that the block is full.
 const DEFAULT_SOFT_DEADLINE_PERCENT: Percent = Percent::from_percent(80);
 
 /// [`Proposer`] factory.

--- a/crates/client/block-proposer/src/lib.rs
+++ b/crates/client/block-proposer/src/lib.rs
@@ -375,7 +375,7 @@ where
         self.transaction_pool.remove_invalid(&unqueue_invalid);
 
         // FIXME: use custom implementation of block builder and remove storage proof computation
-        // Issue: https://github.com/keep-starknet-strange/madara/issues/605
+        // Issue: https://github.com/keep-starknet-strange/madara/issues/606
         let (block, storage_changes, proof) = block_builder.build()?.into_inner();
 
         self.metrics.report(|metrics| {
@@ -395,6 +395,7 @@ where
         );
 
         // TODO: try to remove completely the storage proof computation and see if it breaks anything
+        // Issue: https://github.com/keep-starknet-strange/madara/issues/606
         let proof = PR::into_proof(proof).map_err(|e| sp_blockchain::Error::Application(Box::new(e)))?;
 
         let propose_with_end = time::Instant::now();

--- a/crates/client/block-proposer/src/lib.rs
+++ b/crates/client/block-proposer/src/lib.rs
@@ -21,7 +21,7 @@ use sp_api::{ApiExt, ProvideRuntimeApi};
 use sp_blockchain::ApplyExtrinsicFailed::Validity;
 use sp_blockchain::Error::ApplyExtrinsicFailed;
 use sp_blockchain::HeaderBackend;
-use sp_consensus::{DisableProofRecording, EnableProofRecording, ProofRecording, Proposal};
+use sp_consensus::{DisableProofRecording, ProofRecording, Proposal};
 use sp_core::traits::SpawnNamed;
 use sp_inherents::InherentData;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
@@ -58,7 +58,7 @@ pub struct ProposerFactory<A, B, C, PR> {
     /// The soft deadline indicates where we should stop attempting to add transactions
     /// to the block, which exhaust resources. After soft deadline is reached,
     /// we switch to a fixed-amount mode, in which after we see `MAX_SKIPPED_TRANSACTIONS`
-    /// transactions which exhaust resrouces, we will conclude that the block is full.
+    /// transactions which exhaust resources, we will conclude that the block is full.
     soft_deadline_percent: Percent,
     /// When estimating the block size, should the proof be included?
     include_proof_in_block_size_estimation: bool,
@@ -90,37 +90,6 @@ impl<A, B, C> ProposerFactory<A, B, C, DisableProofRecording> {
     }
 }
 
-impl<A, B, C> ProposerFactory<A, B, C, EnableProofRecording> {
-    /// Create a new proposer factory with proof recording enabled.
-    ///
-    /// Each proposer created by this instance will record a proof while building a block.
-    ///
-    /// This will also include the proof into the estimation of the block size. This can be disabled
-    /// by calling [`ProposerFactory::disable_proof_in_block_size_estimation`].
-    pub fn with_proof_recording(
-        spawn_handle: impl SpawnNamed + 'static,
-        client: Arc<C>,
-        transaction_pool: Arc<A>,
-        prometheus: Option<&PrometheusRegistry>,
-    ) -> Self {
-        ProposerFactory {
-            client,
-            spawn_handle: Box::new(spawn_handle),
-            transaction_pool,
-            metrics: PrometheusMetrics::new(prometheus),
-            default_block_size_limit: DEFAULT_BLOCK_SIZE_LIMIT,
-            soft_deadline_percent: DEFAULT_SOFT_DEADLINE_PERCENT,
-            include_proof_in_block_size_estimation: true,
-            _phantom: PhantomData,
-        }
-    }
-
-    /// Disable the proof inclusion when estimating the block size.
-    pub fn disable_proof_in_block_size_estimation(&mut self) {
-        self.include_proof_in_block_size_estimation = false;
-    }
-}
-
 impl<A, B, C, PR> ProposerFactory<A, B, C, PR> {
     /// Set the default block size limit in bytes.
     ///
@@ -139,7 +108,7 @@ impl<A, B, C, PR> ProposerFactory<A, B, C, PR> {
     /// The soft deadline indicates where we should stop attempting to add transactions
     /// to the block, which exhaust resources. After soft deadline is reached,
     /// we switch to a fixed-amount mode, in which after we see `MAX_SKIPPED_TRANSACTIONS`
-    /// transactions which exhaust resrouces, we will conclude that the block is full.
+    /// transactions which exhaust resources, we will conclude that the block is full.
     ///
     /// Setting the value too low will significantly limit the amount of transactions
     /// we try in case they exhaust resources. Setting the value too high can

--- a/crates/client/db/Cargo.toml
+++ b/crates/client/db/Cargo.toml
@@ -3,8 +3,8 @@ name = "mc-db"
 version = "0.1.0"
 description = "Starknet database backend"
 authors = [
-	"Timothée Delabrouille <https://github.com/tdelabro>",
-	"Substrate DevHub <https://github.com/substrate-developer-hub>",
+  "Timothée Delabrouille <https://github.com/tdelabro>",
+  "Substrate DevHub <https://github.com/substrate-developer-hub>",
 ]
 homepage = "https://github.com/keep-starknet-strange/madara"
 edition = "2021"
@@ -24,7 +24,7 @@ sp-core = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }
 sc-client-db = { workspace = true, default-features = true }
 scale-codec = { workspace = true, default-features = true, features = [
-	"derive",
+  "derive",
 ] }
 
 

--- a/crates/client/mapping-sync/Cargo.toml
+++ b/crates/client/mapping-sync/Cargo.toml
@@ -3,8 +3,8 @@ name = "mc-mapping-sync"
 version = "0.1.0"
 description = "Mapping sync logic for Madara"
 authors = [
-	"Timothée Delabrouille <https://github.com/tdelabro>",
-	"Substrate DevHub <https://github.com/substrate-developer-hub>",
+  "Timothée Delabrouille <https://github.com/tdelabro>",
+  "Substrate DevHub <https://github.com/substrate-developer-hub>",
 ]
 homepage = "https://github.com/keep-starknet-strange/madara"
 edition = "2021"

--- a/crates/client/rpc-core/Cargo.toml
+++ b/crates/client/rpc-core/Cargo.toml
@@ -3,8 +3,8 @@ name = "mc-rpc-core"
 version = "0.1.0"
 description = "RPC trait of Starknet"
 authors = [
-	"Timothée Delabrouille <https://github.com/tdelabro>",
-	"Substrate DevHub <https://github.com/substrate-developer-hub>",
+  "Timothée Delabrouille <https://github.com/tdelabro>",
+  "Substrate DevHub <https://github.com/substrate-developer-hub>",
 ]
 homepage = "https://github.com/keep-starknet-strange/madara"
 edition = "2021"
@@ -20,7 +20,10 @@ anyhow = { workspace = true }
 base64 = { workspace = true }
 flate2 = { workspace = true }
 hex = { workspace = true, default-features = true }
-jsonrpsee = { workspace = true, features = ["server", "macros"], default-features = true }
+jsonrpsee = { workspace = true, features = [
+  "server",
+  "macros",
+], default-features = true }
 mp-starknet = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true }
@@ -34,4 +37,3 @@ starknet-core = { workspace = true }
 cairo-vm = { workspace = true, default-features = false }
 sp-api = { workspace = true, default-features = true }
 serde_with = { workspace = true }
-

--- a/crates/client/rpc/Cargo.toml
+++ b/crates/client/rpc/Cargo.toml
@@ -3,8 +3,8 @@ name = "mc-rpc"
 version = "0.1.0"
 description = "Starknet RPC compatibility layer for Substrate"
 authors = [
-	"Timothée Delabrouille <https://github.com/tdelabro>",
-	"Substrate DevHub <https://github.com/substrate-developer-hub>",
+  "Timothée Delabrouille <https://github.com/tdelabro>",
+  "Substrate DevHub <https://github.com/substrate-developer-hub>",
 ]
 homepage = "https://github.com/keep-starknet-strange/madara"
 edition = "2021"
@@ -38,12 +38,17 @@ sc-client-api = { workspace = true, default-features = true }
 sc-network-sync = { workspace = true }
 # Starknet
 starknet_api = { workspace = true, default-features = false }
-blockifier = { workspace = true, default-features = false, features = ["testing"] }
+blockifier = { workspace = true, default-features = false, features = [
+  "testing",
+] }
 starknet-core = { workspace = true }
 starknet-ff = { workspace = true }
 # Others
 hex = { workspace = true, default-features = true }
-jsonrpsee = { workspace = true, default-features = true, features = ["server", "macros"] }
+jsonrpsee = { workspace = true, default-features = true, features = [
+  "server",
+  "macros",
+] }
 log = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
 thiserror = { workspace = true }

--- a/crates/client/storage/Cargo.toml
+++ b/crates/client/storage/Cargo.toml
@@ -4,8 +4,8 @@ name = "mc-storage"
 version = "0.1.0"
 description = "Starknet storage compatibility layer for Substrate."
 authors = [
-	"Timothée Delabrouille <https://github.com/tdelabro>",
-	"Substrate DevHub <https://github.com/substrate-developer-hub>",
+  "Timothée Delabrouille <https://github.com/tdelabro>",
+  "Substrate DevHub <https://github.com/substrate-developer-hub>",
 ]
 homepage = "https://github.com/keep-starknet-strange/madara"
 edition = "2021"

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -61,7 +61,6 @@ sp-block-builder = { workspace = true }
 # Substrate client dependencies
 sc-rpc-api = { workspace = true }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", workspace = true }
-sc-basic-authorship = { workspace = true }
 # Substrate frame dependencies
 # no substrate frame pallet dependencies for now
 
@@ -72,11 +71,13 @@ frame-benchmarking = { workspace = true }
 frame-benchmarking-cli = { workspace = true }
 
 # Starknet
+# FIXME: declare those dependencies on workspace level
 madara-runtime = { path = "../runtime" }
 mc-db = { path = "../client/db" }
 mc-rpc = { path = "../client/rpc" }
 mc-storage = { path = "../client/storage" }
 mc-mapping-sync = { path = "../client/mapping-sync" }
+mc-block-proposer = {workspace = true}
 pallet-starknet = { path = "../pallets/starknet" }
 mp-starknet = { workspace = true }
 blockifier = { workspace = true }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -3,8 +3,8 @@ name = "madara"
 version = "0.1.0-alpha"
 description = "Madara node."
 authors = [
-	"Abdelhamid Bakhta <@keep-starknet-strange>",
-	"Substrate DevHub <https://github.com/substrate-developer-hub>",
+  "Abdelhamid Bakhta <@keep-starknet-strange>",
+  "Substrate DevHub <https://github.com/substrate-developer-hub>",
 ]
 homepage = "https://github.com/keep-starknet-strange/madara"
 edition = "2021"
@@ -72,12 +72,13 @@ frame-benchmarking-cli = { workspace = true }
 
 # Starknet
 # FIXME: declare those dependencies on workspace level
+# Issue: https://github.com/keep-starknet-strange/madara/issues/605
 madara-runtime = { path = "../runtime" }
 mc-db = { path = "../client/db" }
 mc-rpc = { path = "../client/rpc" }
 mc-storage = { path = "../client/storage" }
 mc-mapping-sync = { path = "../client/mapping-sync" }
-mc-block-proposer = {workspace = true}
+mc-block-proposer = { workspace = true }
 pallet-starknet = { path = "../pallets/starknet" }
 mp-starknet = { workspace = true }
 blockifier = { workspace = true }
@@ -96,9 +97,9 @@ substrate-build-script-utils = { workspace = true }
 default = []
 # Dependencies that are only required if runtime benchmarking should be build.
 runtime-benchmarks = [
-	"madara-runtime/runtime-benchmarks",
-	"frame-benchmarking/runtime-benchmarks",
-	"frame-benchmarking-cli/runtime-benchmarks",
+  "madara-runtime/runtime-benchmarks",
+  "frame-benchmarking/runtime-benchmarks",
+  "frame-benchmarking-cli/runtime-benchmarks",
 ]
 # Enable features that allow the runtime to be tried and debugged. Name might be subject to change
 # in the near future.

--- a/crates/pallets/starknet/Cargo.toml
+++ b/crates/pallets/starknet/Cargo.toml
@@ -17,8 +17,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 mp-starknet = { workspace = true, default-features = false }
 mp-digest-log = { workspace = true, default-features = false }
 
-starknet-crypto = { workspace = true, default-features = false, features = ["alloc"] }
-blockifier = { workspace = true, default-features = false, features = ["testing"] }
+starknet-crypto = { workspace = true, default-features = false, features = [
+  "alloc",
+] }
+blockifier = { workspace = true, default-features = false, features = [
+  "testing",
+] }
 starknet_api = { workspace = true, default-features = false }
 
 # Substrate frame
@@ -36,7 +40,9 @@ sp-std = { workspace = true }
 # Other third party dependencies
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-scale-codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
+scale-codec = { package = "parity-scale-codec", workspace = true, features = [
+  "derive",
+] }
 scale-info = { workspace = true, features = ["derive"] }
 log = { workspace = true }
 hex = { workspace = true }
@@ -52,21 +58,21 @@ starknet-core = { workspace = true, default-features = false }
 [features]
 default = ["std"]
 std = [
-	# Substrate
-	"frame-support/std",
-	"frame-system/std",
-	"sp-io/std",
-	"sp-runtime/std",
-	"frame-benchmarking?/std",
-	"scale-info/std",
-	"pallet-timestamp/std",
-	# Madara
-	"mp-starknet/std",
-	# Starknet
-	"starknet-crypto/std",
-	"blockifier/std",
-	# Other third party dependencies
-	"scale-codec/std",
+  # Substrate
+  "frame-support/std",
+  "frame-system/std",
+  "sp-io/std",
+  "sp-runtime/std",
+  "frame-benchmarking?/std",
+  "scale-info/std",
+  "pallet-timestamp/std",
+  # Madara
+  "mp-starknet/std",
+  # Starknet
+  "starknet-crypto/std",
+  "blockifier/std",
+  # Other third party dependencies
+  "scale-codec/std",
 ]
 runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks"]
 try-runtime = ["frame-support/try-runtime"]

--- a/crates/primitives/starknet/Cargo.toml
+++ b/crates/primitives/starknet/Cargo.toml
@@ -18,11 +18,17 @@ sp-std = { workspace = true }
 sp-runtime = { workspace = true }
 
 # Starknet
-starknet-crypto = { workspace = true, default-features = false, features = ["alloc"] }
-starknet-ff = { workspace = true, default-features = false, features = ["alloc"] }
+starknet-crypto = { workspace = true, default-features = false, features = [
+  "alloc",
+] }
+starknet-ff = { workspace = true, default-features = false, features = [
+  "alloc",
+] }
 starknet-core = { workspace = true, optional = true }
 poseidon_hash = { workspace = true, default-features = false }
-blockifier = { workspace = true, default-features = false, features = ["testing"] }
+blockifier = { workspace = true, default-features = false, features = [
+  "testing",
+] }
 starknet_api = { workspace = true, default-features = false }
 cairo-vm = { workspace = true }
 
@@ -30,8 +36,8 @@ cairo-vm = { workspace = true }
 bitvec = { workspace = true, features = ["alloc"] }
 hex = { version = "0.4.3", default-features = false }
 scale-codec = { package = "parity-scale-codec", workspace = true, features = [
-	"derive",
-	"max-encoded-len",
+  "derive",
+  "max-encoded-len",
 ] }
 scale-info = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
@@ -51,21 +57,21 @@ pretty_assertions = "1.3.0"
 [features]
 default = ["std"]
 std = [
-	"scale-codec/std",
-	"scale-info/std",
-	"bitvec/std",
-	# Starknet
-	"starknet-crypto/std",
-	"starknet-ff/std",
-	"starknet-ff/serde",
-	"starknet-core",
-	"blockifier/std",
-	"starknet_api/std",
-	"poseidon_hash/std",
-	# Substrate
-	"frame-support/std",
-	"sp-core/std",
-	"sp-std/std",
-	"sp-runtime/std",
-	"thiserror-no-std/std",
+  "scale-codec/std",
+  "scale-info/std",
+  "bitvec/std",
+  # Starknet
+  "starknet-crypto/std",
+  "starknet-ff/std",
+  "starknet-ff/serde",
+  "starknet-core",
+  "blockifier/std",
+  "starknet_api/std",
+  "poseidon_hash/std",
+  # Substrate
+  "frame-support/std",
+  "sp-core/std",
+  "sp-std/std",
+  "sp-runtime/std",
+  "thiserror-no-std/std",
 ]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -3,8 +3,8 @@ name = "madara-runtime"
 version = "0.1.0-alpha"
 description = "Madara runtime."
 authors = [
-	"Abdelhamid Bakhta <@abdelhamidbakhta>",
-	"Substrate DevHub <https://github.com/substrate-developer-hub>",
+  "Abdelhamid Bakhta <@abdelhamidbakhta>",
+  "Substrate DevHub <https://github.com/substrate-developer-hub>",
 ]
 homepage = "https://github.com/keep-starknet-strange/madara"
 edition = "2021"
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 scale-codec = { package = "parity-scale-codec", workspace = true, features = [
-	"derive",
+  "derive",
 ] }
 scale-info = { workspace = true, features = ["derive"] }
 
@@ -60,59 +60,59 @@ substrate-wasm-builder = { workspace = true }
 
 [features]
 std = [
-	# Madara pallets
-	"pallet-starknet/std",
-	# Frame dependencies
-	"frame-try-runtime?/std",
-	"frame-system-benchmarking?/std",
-	"frame-benchmarking?/std",
-	"frame-executive/std",
-	"frame-support/std",
-	"frame-system-rpc-runtime-api/std",
-	"frame-system/std",
-	"frame-try-runtime/std",
-	# Frame pallets dependencies
-	"pallet-aura/std",
-	"pallet-grandpa/std",
-	"pallet-sudo/std",
-	"pallet-timestamp/std",
-	# Substrate primitives dependencies
-	"sp-api/std",
-	"sp-block-builder/std",
-	"sp-consensus-aura/std",
-	"sp-core/std",
-	"sp-inherents/std",
-	"sp-offchain/std",
-	"sp-runtime/std",
-	"sp-session/std",
-	"sp-std/std",
-	"sp-transaction-pool/std",
-	"sp-version/std",
-	# 3rd party dependencies
-	"scale-codec/std",
-	"scale-info/std",
+  # Madara pallets
+  "pallet-starknet/std",
+  # Frame dependencies
+  "frame-try-runtime?/std",
+  "frame-system-benchmarking?/std",
+  "frame-benchmarking?/std",
+  "frame-executive/std",
+  "frame-support/std",
+  "frame-system-rpc-runtime-api/std",
+  "frame-system/std",
+  "frame-try-runtime/std",
+  # Frame pallets dependencies
+  "pallet-aura/std",
+  "pallet-grandpa/std",
+  "pallet-sudo/std",
+  "pallet-timestamp/std",
+  # Substrate primitives dependencies
+  "sp-api/std",
+  "sp-block-builder/std",
+  "sp-consensus-aura/std",
+  "sp-core/std",
+  "sp-inherents/std",
+  "sp-offchain/std",
+  "sp-runtime/std",
+  "sp-session/std",
+  "sp-std/std",
+  "sp-transaction-pool/std",
+  "sp-version/std",
+  # 3rd party dependencies
+  "scale-codec/std",
+  "scale-info/std",
 ]
 try-runtime = [
-	"pallet-timestamp/try-runtime",
-	"frame-try-runtime/try-runtime",
-	"frame-executive/try-runtime",
-	"frame-system/try-runtime",
-	"frame-support/try-runtime",
-	"pallet-aura/try-runtime",
-	"pallet-grandpa/try-runtime",
-	"pallet-sudo/try-runtime",
-	# Madara pallets
-	"pallet-starknet/try-runtime",
+  "pallet-timestamp/try-runtime",
+  "frame-try-runtime/try-runtime",
+  "frame-executive/try-runtime",
+  "frame-system/try-runtime",
+  "frame-support/try-runtime",
+  "pallet-aura/try-runtime",
+  "pallet-grandpa/try-runtime",
+  "pallet-sudo/try-runtime",
+  # Madara pallets
+  "pallet-starknet/try-runtime",
 ]
 default = ["std"]
 runtime-benchmarks = [
-	"frame-benchmarking/runtime-benchmarks",
-	"frame-support/runtime-benchmarks",
-	"frame-system-benchmarking/runtime-benchmarks",
-	"frame-system/runtime-benchmarks",
-	"pallet-grandpa/runtime-benchmarks",
-	"pallet-timestamp/runtime-benchmarks",
-	"sp-runtime/runtime-benchmarks",
-	# Madara pallets
-	"pallet-starknet/runtime-benchmarks",
+  "frame-benchmarking/runtime-benchmarks",
+  "frame-support/runtime-benchmarks",
+  "frame-system-benchmarking/runtime-benchmarks",
+  "frame-system/runtime-benchmarks",
+  "pallet-grandpa/runtime-benchmarks",
+  "pallet-timestamp/runtime-benchmarks",
+  "sp-runtime/runtime-benchmarks",
+  # Madara pallets
+  "pallet-starknet/runtime-benchmarks",
 ]


### PR DESCRIPTION
Extract the code from [subtrate basic authorship](https://github.com/paritytech/substrate/tree/master/client/basic-authorship) and integrate it in Madara client.

Changes summary:
- create new crate `mc-block-proposer` in `crates/client/block-proposer`
- adapt `Proposer` implementation logic
    - remove hashing of extrinsics to log information on the proposed block (performance optimization and less verbose logging)
    - remove unneeded telemetry reports
    - remove `include_proof_in_estimation` field