### PR TITLE
fix: use `UnixTime` instead of `Time`

### DIFF
--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -71,7 +71,7 @@ use blockifier::block_context::BlockContext;
 use blockifier::execution::entry_point::{CallInfo, ExecutionResources};
 use blockifier_state_adapter::BlockifierStateAdapter;
 use frame_support::pallet_prelude::*;
-use frame_support::traits::Time;
+use frame_support::traits::UnixTime;
 use frame_system::pallet_prelude::*;
 use mp_digest_log::MADARA_ENGINE_ID;
 use mp_starknet::block::{Block as StarknetBlock, Header as StarknetHeader, MaxTransactions};
@@ -139,7 +139,7 @@ pub mod pallet {
         /// The hashing function to use.
         type SystemHash: HasherT + DefaultHasher + CryptoHasherT;
         /// The time idk what.
-        type TimestampProvider: Time;
+        type TimestampProvider: UnixTime;
         /// A configuration for base priority of unsigned transactions.
         ///
         /// This is exposed so that it can be tuned for particular runtime, when
@@ -891,7 +891,7 @@ impl<T: Config> Pallet<T> {
     /// The current block timestamp.
     #[inline(always)]
     pub fn block_timestamp() -> u64 {
-        T::TimestampProvider::now().unique_saturated_into()
+        T::TimestampProvider::now().as_secs()
     }
 
     /// Get the number of transactions in the block.

--- a/crates/pallets/starknet/src/tests/current_block.rs
+++ b/crates/pallets/starknet/src/tests/current_block.rs
@@ -15,7 +15,7 @@ fn given_normal_conditions_when_current_block_then_returns_correct_block() {
         let current_block = Starknet::current_block();
 
         let expected_current_block = StarknetHeader {
-            block_timestamp: 12_000,
+            block_timestamp: 12,
             block_number: U256::from(2),
             parent_block_hash: Felt252Wrapper::from_hex_be(
                 "0x01243efd82a868d20c15c273d185467feb4addc129fb767353fa684e186d3f98",


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- Bugfix


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #564

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Change the `TimestampProvider` to use `UnixTime`
- Update test to expect new behaviour


## Does this introduce a breaking change?

Maybe, @abdelhamidbakhta wdyt?
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
