### PR TITLE
fix: add pool futures to pending transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4491,6 +4491,7 @@ dependencies = [
  "rstest",
  "sc-client-api",
  "sc-network-sync",
+ "sc-transaction-pool",
  "sc-transaction-pool-api",
  "serde_json",
  "sp-api",

--- a/crates/client/rpc/Cargo.toml
+++ b/crates/client/rpc/Cargo.toml
@@ -30,6 +30,7 @@ frame-system = { workspace = true }
 sp-runtime = { workspace = true, default-features = true }
 sp-core = { workspace = true, default-features = true }
 sp-api = { workspace = true, default-features = true }
+sc-transaction-pool = { workspace = true }
 sc-transaction-pool-api = { workspace = true }
 sp-arithmetic = { workspace = true, default-features = true }
 sp-blockchain = { workspace = true, default-features = true }

--- a/crates/client/rpc/src/events/mod.rs
+++ b/crates/client/rpc/src/events/mod.rs
@@ -14,6 +14,7 @@ use mp_starknet::traits::ThreadSafeCopy;
 use mp_starknet::transaction::types::EventWrapper;
 use pallet_starknet::runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
 use sc_client_api::backend::{Backend, StorageProvider};
+use sc_transaction_pool::ChainApi;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::Block as BlockT;
@@ -24,7 +25,7 @@ use crate::errors::StarknetRpcApiError;
 use crate::types::RpcEventFilter;
 use crate::{EmittedEvent, Starknet};
 
-impl<B, BE, C, P, H> Starknet<B, BE, C, P, H>
+impl<A: ChainApi, B, BE, C, P, H> Starknet<A, B, BE, C, P, H>
 where
     B: BlockT,
     C: HeaderBackend<B> + StorageProvider<B, BE> + 'static,

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -644,7 +644,7 @@ where
             self.graph.validated_pool().ready().map(|tx| tx.data().clone()).collect();
 
         let mut transactions_future: Vec<<B as BlockT>::Extrinsic> =
-            self.graph.validated_pool().futures().into_iter().map(|tx| tx.1).collect();
+            self.graph.validated_pool().futures().into_iter().map(|(_hash, extrinsic)| extrinsic).collect();
 
         transactions.append(&mut transactions_ready);
         transactions.append(&mut transactions_future);

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -16,6 +16,7 @@ use pallet_starknet::runtime_api::StarknetRuntimeApi;
 use sc_client_api::{Backend, StorageProvider};
 use sc_consensus_manual_seal::rpc::EngineCommand;
 pub use sc_rpc_api::DenyUnsafe;
+use sc_transaction_pool::{ChainApi, Pool};
 use sc_transaction_pool_api::TransactionPool;
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
@@ -23,11 +24,13 @@ use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 pub use starknet::StarknetDeps;
 
 /// Full client dependencies.
-pub struct FullDeps<C, P> {
+pub struct FullDeps<A: ChainApi, C, P> {
     /// The client instance to use.
     pub client: Arc<C>,
     /// Transaction pool instance.
     pub pool: Arc<P>,
+    /// Extrinsic pool graph instance.
+    pub graph: Arc<Pool<A>>,
     /// Whether to deny unsafe calls
     pub deny_unsafe: DenyUnsafe,
     /// Manual seal command sink
@@ -37,8 +40,11 @@ pub struct FullDeps<C, P> {
 }
 
 /// Instantiate all full RPC extensions.
-pub fn create_full<C, P, BE>(deps: FullDeps<C, P>) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>>
+pub fn create_full<A, C, P, BE>(
+    deps: FullDeps<A, C, P>,
+) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>>
 where
+    A: ChainApi<Block = Block> + 'static,
     C: ProvideRuntimeApi<Block>,
     C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError> + StorageProvider<Block, BE> + 'static,
     C: Send + Sync + 'static,
@@ -54,7 +60,7 @@ where
     use substrate_frame_rpc_system::{System, SystemApiServer};
 
     let mut module = RpcModule::new(());
-    let FullDeps { client, pool, deny_unsafe, starknet: starknet_params, command_sink } = deps;
+    let FullDeps { client, pool, deny_unsafe, starknet: starknet_params, command_sink, graph } = deps;
 
     let hasher = client.runtime_api().get_hasher(client.info().best_hash)?.into();
 
@@ -65,6 +71,7 @@ where
             starknet_params.madara_backend,
             starknet_params.overrides,
             pool,
+            graph,
             starknet_params.sync_service,
             starknet_params.starting_block,
             hasher,

--- a/crates/node/src/service.rs
+++ b/crates/node/src/service.rs
@@ -297,11 +297,13 @@ pub fn new_full(config: Configuration, sealing: Option<Sealing>) -> Result<TaskM
     let rpc_extensions_builder = {
         let client = client.clone();
         let pool = transaction_pool.clone();
+        let graph = transaction_pool.pool().clone();
 
         Box::new(move |deny_unsafe, _| {
             let deps = crate::rpc::FullDeps {
                 client: client.clone(),
                 pool: pool.clone(),
+                graph: graph.clone(),
                 deny_unsafe,
                 starknet: starknet_rpc_params.clone(),
                 command_sink: if sealing.is_some() { Some(command_sink.clone()) } else { None },

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -834,12 +834,9 @@ impl<T: Config> Pallet<T> {
         let mut state: BlockifierStateAdapter<T> = BlockifierStateAdapter::<T>::default();
         let mut execution_resources = ExecutionResources::default();
         let block_context = Self::get_block_context();
-        transaction.validate_account_tx(&mut state, &mut execution_resources, &block_context, &tx_type).map_err(
-            |_err| {
-                log::info!("{:?}", _err);
-                TransactionValidityError::Invalid(InvalidTransaction::BadProof)
-            },
-        )?;
+        transaction
+            .validate_account_tx(&mut state, &mut execution_resources, &block_context, &tx_type)
+            .map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::BadProof))?;
 
         Ok(())
     }

--- a/crates/pallets/starknet/src/tests/invoke_tx.rs
+++ b/crates/pallets/starknet/src/tests/invoke_tx.rs
@@ -10,8 +10,9 @@ use mp_starknet::transaction::types::{
 };
 use sp_core::H256;
 use sp_runtime::traits::ValidateUnsigned;
-use sp_runtime::transaction_validity::{TransactionSource, TransactionValidityError};
+use sp_runtime::transaction_validity::{TransactionSource, TransactionValidityError, ValidTransaction};
 use starknet_core::utils::get_selector_from_name;
+use starknet_crypto::FieldElement;
 
 use super::constants::{BLOCKIFIER_ACCOUNT_ADDRESS, TEST_CONTRACT_ADDRESS};
 use super::mock::*;
@@ -436,5 +437,58 @@ fn test_verify_tx_longevity() {
             Starknet::validate_unsigned(TransactionSource::InBlock, &crate::Call::invoke { transaction });
 
         assert!(validate_result.unwrap().longevity == TransactionLongevity::get());
+    });
+}
+
+#[test]
+fn test_verify_no_require_tag() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(0);
+        run_to_block(2);
+
+        let json_content: &str = include_str!("../../../../../resources/transactions/invoke.json");
+        let transaction: InvokeTransaction =
+            transaction_from_json(json_content, &[]).expect("Failed to create Transaction from JSON").into();
+
+        let validate_result = Starknet::validate_unsigned(
+            TransactionSource::InBlock,
+            &crate::Call::invoke { transaction: transaction.clone() },
+        );
+
+        let valid_transaction_expected = ValidTransaction::with_tag_prefix("starknet")
+            .priority(u64::MAX - (TryInto::<u64>::try_into(transaction.nonce)).unwrap())
+            .and_provides((transaction.sender_address, transaction.nonce))
+            .longevity(TransactionLongevity::get())
+            .propagate(true)
+            .build();
+
+        assert_eq!(validate_result.unwrap(), valid_transaction_expected.unwrap())
+    });
+}
+
+#[test]
+fn test_verify_require_tag() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(0);
+        run_to_block(2);
+
+        let json_content: &str = include_str!("../../../../../resources/transactions/invoke_nonce.json");
+        let transaction: InvokeTransaction =
+            transaction_from_json(json_content, &[]).expect("Failed to create Transaction from JSON").into();
+
+        let validate_result = Starknet::validate_unsigned(
+            TransactionSource::InBlock,
+            &crate::Call::invoke { transaction: transaction.clone() },
+        );
+
+        let valid_transaction_expected = ValidTransaction::with_tag_prefix("starknet")
+            .priority(u64::MAX - (TryInto::<u64>::try_into(transaction.nonce)).unwrap())
+            .and_provides((transaction.sender_address, transaction.nonce))
+            .longevity(TransactionLongevity::get())
+            .propagate(true)
+            .and_requires((transaction.sender_address, Felt252Wrapper(transaction.nonce.0 - FieldElement::ONE)))
+            .build();
+
+        assert_eq!(validate_result.unwrap(), valid_transaction_expected.unwrap())
     });
 }

--- a/crates/pallets/starknet/src/tests/l1_message.rs
+++ b/crates/pallets/starknet/src/tests/l1_message.rs
@@ -1,6 +1,6 @@
 use frame_support::assert_err;
 use mp_starknet::execution::types::{ContractClassWrapper, Felt252Wrapper};
-use mp_starknet::transaction::types::DeclareTransaction;
+use mp_starknet::transaction::types::{DeclareTransaction, Transaction, TxType};
 use sp_runtime::traits::ValidateUnsigned;
 use sp_runtime::transaction_validity::TransactionSource;
 
@@ -38,7 +38,7 @@ fn test_verify_tx_longevity() {
         System::set_block_number(0);
         run_to_block(2);
 
-        let transaction = crate::Transaction::default();
+        let transaction = Transaction { tx_type: TxType::L1Handler, ..Transaction::default() };
 
         let validate_result =
             Starknet::validate_unsigned(TransactionSource::InBlock, &crate::Call::consume_l1_message { transaction });

--- a/tests/tests/test-rpc/test-starknet-rpc.ts
+++ b/tests/tests/test-rpc/test-starknet-rpc.ts
@@ -868,7 +868,7 @@ describeDevMadara("Starknet RPC", (context) => {
     });
 
     it("should return transactions from the ready and future queues", async function () {
-      const transactionOffset = 1_000;
+      const transactionNonceOffset = 1_000;
       // ready transaction
       await rpcTransfer(
         providerRPC,
@@ -877,10 +877,10 @@ describeDevMadara("Starknet RPC", (context) => {
         MINT_AMOUNT
       );
       // future transaction
-      // add a high number to the nonce to make sure the transaction is not ready
+      // add a high number to the nonce to make sure the transaction is added to the future queue
       await rpcTransfer(
         providerRPC,
-        { value: ARGENT_CONTRACT_NONCE.value + transactionOffset },
+        { value: ARGENT_CONTRACT_NONCE.value + transactionNonceOffset },
         ARGENT_CONTRACT_ADDRESS,
         MINT_AMOUNT
       );
@@ -902,7 +902,7 @@ describeDevMadara("Starknet RPC", (context) => {
       });
       expect(txs[1]).to.include({
         type: "INVOKE",
-        nonce: toHex(ARGENT_CONTRACT_NONCE.value + transactionOffset),
+        nonce: toHex(ARGENT_CONTRACT_NONCE.value + transactionNonceOffset),
       });
 
       await jumpBlocks(context, 10);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Update the `pendingTransactions` endpoint in order to include transactions that are currently in the `future` pool.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?
The `pendingTransactions` endpoint will only return the transactions that have been placed in the `ready` queue, missing the transactions from the `future` queue (see [docs](https://docs.substrate.io/learn/transaction-lifecycle/#validating-and-queuing-transactions)).

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?
The rpc endpoint returns all transactions from the pool, in `ready` or `future` queue.

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added the pool graph instance to the Starknet RPC structure in order to gain access to the `future` transaction queue

## Does this introduce a breaking change?
No