### PR TITLE
bugfix: starkcet faucet not working

### DIFF
--- a/docs/faucet-setup.md
+++ b/docs/faucet-setup.md
@@ -1,0 +1,136 @@
+# Madara Faucet
+
+You can have a custom faucet for your app chains!
+
+<figure class="video_container">
+  <video controls="true" allowfullscreen="true" poster="videos/starkcet_demo.mp4">
+    <source src="videos/starkcet_demo.mp4" type="video/mp4">
+  </video>
+</figure>
+
+### Setting up your Madara faucet
+
+Follow the steps below to setup a faucet for your local build
+
+### Madara Run
+
+Run an instance of your madara node locally
+
+```bash
+cargo run --release -- --dev
+```
+
+`--dev`: enforces a development environment needed to make testing easier for your node. If you're running this without `--dev`, make sure to add 
+   1. `--rpc-cors="*"` or `--rpc-cors="<backend_origin>"` to allow the backend to communicate with your node
+   2. `--force-authoring` if you're the only node on your chain. This flag forces Madara to create blocks even if they are no peers. 
+
+### Faucet backend and frontend
+
+Madara has currently integrated the Starkcet faucet which provides an easy to use frontend and backend for your local build. You can start the frontend and backend using Docker like this
+
+```bash
+cd infra/starknet-stack/
+docker-compose up -d starkcet-front starkcet-back
+```
+
+Use `docker ps` to check if your containers are running. You should find two containers with the following names
+
+1. `starknet-stack-starkcet-front-1`
+2. `starknet-stack-starkcet-back-1`
+
+If you see these containers, congrats, your faucet is now running 🎉
+
+### Interacting with your faucet
+
+1. Go to http://localhost:3000
+2. Enter your wallet address
+3. Click Get Tokens
+4. Done!
+
+If you're clicking on `Get Tokens` repeatedly, ensure that the previous block was added so that the new request to get tokens is sent with the correct nonce.
+
+
+### Building your own faucet
+
+If you have a use case where you need to customize your faucet or you need to get faucet funds using code, you can achieve this by simply transferring funds from any of the genesis accounts using RPC calls. The genesis account private key for address `0x2` is available in `crates/pallets/starknet/src/tests/constants.rs`.
+
+Things to keep in mind:
+
+1. Madara doesn't support version `0x100000000000000000000000000000001` for `estimateFee` which is the default version used by starknetjs. This causes the `starknet_estimateFee` RPC call to fail with the following error
+
+    ```bash
+    Failed to parse JSON-RPC params as object: Invalid params in the call: unknown variant `0x100000000000000000000000000000001`, expected `0x0` or `0x1` at line 1 column 603
+    ```
+    An issue has been created for this which can be tracked [here](https://github.com/keep-starknet-strange/madara/issues/646).
+
+    In order to fix this, we manually change the version to `0x1` for `estimateFee` and then invoke the transaction.
+2. Account `0x1` on Madara doesn't support multicall so `account.execute` from starknetjs fails. You can either invoke the transfer transaction as shown [here](https://github.com/keep-starknet-strange/madara/blob/c916046adf9d7ea52131442090fae654ba6b234d/tests/util/starknet.ts#L241) or use an account like `0x2` which is based on Argent and supports multicall. 
+
+**Example code for collecting tokens from `0x2` using starknetjs**
+
+```javascript
+import * as starknet from 'starknet';
+
+const eth_address =
+    '0x040e59c2c182a58fb0a74349bfa4769cbbcba32547591dd3fb1def8623997d01';
+const provider = new starknet.RpcProvider({
+    nodeUrl: 'http://localhost:9944',
+});
+const starkKeyPair = starknet.ec.getKeyPair(
+    '0x00c1cf1490de1352865301bb8705143f3ef938f97fdf892f1090dcb5ac7bcd1d'
+);
+const address = '0x2';
+
+async function transfer(to) {
+    const nonce = await provider.getNonceForAddress(address);
+    const chainId = await provider.getChainId();
+
+    const calldata = starknet.transaction.fromCallsToExecuteCalldata([
+        {
+            contractAddress: eth_address,
+            entrypoint: 'transfer',
+            calldata: starknet.stark.compileCalldata({
+                recipient: to,
+                amount: {
+                    type: 'struct',
+                    low: '1000000',
+                    high: '0',
+                },
+            }),
+        },
+    ]);
+    const maxFee = '0x11111111111';
+    const version = '0x1';
+    const txnHash = starknet.hash.calculateTransactionHash(
+        address,
+        version,
+        calldata,
+        maxFee,
+        chainId,
+        nonce
+    );
+    const signature = starknet.ec.sign(starkKeyPair, txnHash);
+    const invocationCall = {
+        signature,
+        contractAddress: address,
+        calldata,
+    };
+    const invocationDetails = {
+        maxFee,
+        nonce,
+        version,
+    };
+
+    // if estimating fees passes without failures, the txn should go through
+    const estimateFee = await provider.getEstimateFee(
+        invocationCall,
+        invocationDetails
+    );
+    console.log('Estimate fee - ', estimateFee);
+
+    const tx = await provider.invokeFunction(invocationCall, invocationDetails);
+    console.log(tx.transaction_hash);
+}
+
+transfer('0x11');
+```

--- a/docs/faucet-setup.md
+++ b/docs/faucet-setup.md
@@ -1,4 +1,4 @@
-# Madara Faucet
+## Madara Faucet
 
 You can have a custom faucet for your app chains!
 

--- a/docs/faucet-setup.md
+++ b/docs/faucet-setup.md
@@ -24,9 +24,9 @@ cargo run --release -- --dev
 your node. If you're running this without `--dev`, make sure to add
 
 1. `--rpc-cors="*"` or `--rpc-cors="<backend_origin>"` to allow the backend to
-    communicate with your node
+   communicate with your node
 2. `--force-authoring` if you're the only node on your chain. This flag forces
-    Madara to create blocks even if they are no peers.
+   Madara to create blocks even if they are no peers.
 
 ### Faucet backend and frontend
 

--- a/docs/faucet-setup.md
+++ b/docs/faucet-setup.md
@@ -23,9 +23,9 @@ cargo run --release -- --dev
 `--dev`: enforces a development environment needed to make testing easier for
 your node. If you're running this without `--dev`, make sure to add
 
-1.  `--rpc-cors="*"` or `--rpc-cors="<backend_origin>"` to allow the backend to
+1. `--rpc-cors="*"` or `--rpc-cors="<backend_origin>"` to allow the backend to
     communicate with your node
-2.  `--force-authoring` if you're the only node on your chain. This flag forces
+2. `--force-authoring` if you're the only node on your chain. This flag forces
     Madara to create blocks even if they are no peers.
 
 ### Faucet backend and frontend
@@ -49,7 +49,7 @@ If you see these containers, congrats, your faucet is now running 🎉
 
 ### Interacting with your faucet
 
-1. Go to http://localhost:3000
+1. Go to <http://localhost:3000>
 2. Enter your wallet address
 3. Click Get Tokens
 4. Done!

--- a/docs/faucet-setup.md
+++ b/docs/faucet-setup.md
@@ -20,20 +20,27 @@ Run an instance of your madara node locally
 cargo run --release -- --dev
 ```
 
-`--dev`: enforces a development environment needed to make testing easier for your node. If you're running this without `--dev`, make sure to add 
-   1. `--rpc-cors="*"` or `--rpc-cors="<backend_origin>"` to allow the backend to communicate with your node
-   2. `--force-authoring` if you're the only node on your chain. This flag forces Madara to create blocks even if they are no peers. 
+`--dev`: enforces a development environment needed to make testing easier for
+your node. If you're running this without `--dev`, make sure to add
+
+1.  `--rpc-cors="*"` or `--rpc-cors="<backend_origin>"` to allow the backend to
+    communicate with your node
+2.  `--force-authoring` if you're the only node on your chain. This flag forces
+    Madara to create blocks even if they are no peers.
 
 ### Faucet backend and frontend
 
-Madara has currently integrated the Starkcet faucet which provides an easy to use frontend and backend for your local build. You can start the frontend and backend using Docker like this
+Madara has currently integrated the Starkcet faucet which provides an easy to
+use frontend and backend for your local build. You can start the frontend and
+backend using Docker like this
 
 ```bash
 cd infra/starknet-stack/
 docker-compose up -d starkcet-front starkcet-back
 ```
 
-Use `docker ps` to check if your containers are running. You should find two containers with the following names
+Use `docker ps` to check if your containers are running. You should find two
+containers with the following names
 
 1. `starknet-stack-starkcet-front-1`
 2. `starknet-stack-starkcet-back-1`
@@ -47,90 +54,103 @@ If you see these containers, congrats, your faucet is now running 🎉
 3. Click Get Tokens
 4. Done!
 
-If you're clicking on `Get Tokens` repeatedly, ensure that the previous block was added so that the new request to get tokens is sent with the correct nonce.
-
+If you're clicking on `Get Tokens` repeatedly, ensure that the previous block
+was added so that the new request to get tokens is sent with the correct nonce.
 
 ### Building your own faucet
 
-If you have a use case where you need to customize your faucet or you need to get faucet funds using code, you can achieve this by simply transferring funds from any of the genesis accounts using RPC calls. The genesis account private key for address `0x2` is available in `crates/pallets/starknet/src/tests/constants.rs`.
+If you have a use case where you need to customize your faucet or you need to
+get faucet funds using code, you can achieve this by simply transferring funds
+from any of the genesis accounts using RPC calls. The genesis account private
+key for address `0x2` is available in
+`crates/pallets/starknet/src/tests/constants.rs`.
 
 Things to keep in mind:
 
-1. Madara doesn't support version `0x100000000000000000000000000000001` for `estimateFee` which is the default version used by starknetjs. This causes the `starknet_estimateFee` RPC call to fail with the following error
+1. Madara doesn't support version `0x100000000000000000000000000000001` for
+   `estimateFee` which is the default version used by starknetjs. This causes
+   the `starknet_estimateFee` RPC call to fail with the following error
 
-    ```bash
-    Failed to parse JSON-RPC params as object: Invalid params in the call: unknown variant `0x100000000000000000000000000000001`, expected `0x0` or `0x1` at line 1 column 603
-    ```
-    An issue has been created for this which can be tracked [here](https://github.com/keep-starknet-strange/madara/issues/646).
+   ```bash
+   Failed to parse JSON-RPC params as object: Invalid params in the call: unknown variant `0x100000000000000000000000000000001`, expected `0x0` or `0x1` at line 1 column 603
+   ```
 
-    In order to fix this, we manually change the version to `0x1` for `estimateFee` and then invoke the transaction.
-2. Account `0x1` on Madara doesn't support multicall so `account.execute` from starknetjs fails. You can either invoke the transfer transaction as shown [here](https://github.com/keep-starknet-strange/madara/blob/c916046adf9d7ea52131442090fae654ba6b234d/tests/util/starknet.ts#L241) or use an account like `0x2` which is based on Argent and supports multicall. 
+   An issue has been created for this which can be tracked
+   [here](https://github.com/keep-starknet-strange/madara/issues/646).
+
+   In order to fix this, we manually change the version to `0x1` for
+   `estimateFee` and then invoke the transaction.
+
+2. Account `0x1` on Madara doesn't support multicall so `account.execute` from
+   starknetjs fails. You can either invoke the transfer transaction as shown
+   [here](https://github.com/keep-starknet-strange/madara/blob/c916046adf9d7ea52131442090fae654ba6b234d/tests/util/starknet.ts#L241)
+   or use an account like `0x2` which is based on Argent and supports multicall.
 
 **Example code for collecting tokens from `0x2` using starknetjs**
 
 ```javascript
-import * as starknet from 'starknet';
+import * as starknet from "starknet";
 
 const eth_address =
-    '0x040e59c2c182a58fb0a74349bfa4769cbbcba32547591dd3fb1def8623997d01';
+  "0x040e59c2c182a58fb0a74349bfa4769cbbcba32547591dd3fb1def8623997d01";
 const provider = new starknet.RpcProvider({
-    nodeUrl: 'http://localhost:9944',
+  nodeUrl: "http://localhost:9944",
 });
 const starkKeyPair = starknet.ec.getKeyPair(
-    '0x00c1cf1490de1352865301bb8705143f3ef938f97fdf892f1090dcb5ac7bcd1d'
+  "0x00c1cf1490de1352865301bb8705143f3ef938f97fdf892f1090dcb5ac7bcd1d"
 );
-const address = '0x2';
+const address = "0x2";
 
 async function transfer(to) {
-    const nonce = await provider.getNonceForAddress(address);
-    const chainId = await provider.getChainId();
+  const nonce = await provider.getNonceForAddress(address);
+  const chainId = await provider.getChainId();
 
-    const calldata = starknet.transaction.fromCallsToExecuteCalldata([
-        {
-            contractAddress: eth_address,
-            entrypoint: 'transfer',
-            calldata: starknet.stark.compileCalldata({
-                recipient: to,
-                amount: {
-                    type: 'struct',
-                    low: '1000000',
-                    high: '0',
-                },
-            }),
+  const calldata = starknet.transaction.fromCallsToExecuteCalldata([
+    {
+      contractAddress: eth_address,
+      entrypoint: "transfer",
+      calldata: starknet.stark.compileCalldata({
+        recipient: to,
+        amount: {
+          type: "struct",
+          low: "1000000",
+          high: "0",
         },
-    ]);
-    const maxFee = '0x11111111111';
-    const version = '0x1';
-    const txnHash = starknet.hash.calculateTransactionHash(
-        address,
-        version,
-        calldata,
-        maxFee,
-        chainId,
-        nonce
-    );
-    const signature = starknet.ec.sign(starkKeyPair, txnHash);
-    const invocationCall = {
-        signature,
-        contractAddress: address,
-        calldata,
-    };
-    const invocationDetails = {
-        maxFee,
-        nonce,
-        version,
-    };
+      }),
+    },
+  ]);
+  const maxFee = "0x11111111111";
+  const version = "0x1";
+  const txnHash = starknet.hash.calculateTransactionHash(
+    address,
+    version,
+    calldata,
+    maxFee,
+    chainId,
+    nonce
+  );
+  const signature = starknet.ec.sign(starkKeyPair, txnHash);
+  const invocationCall = {
+    signature,
+    contractAddress: address,
+    calldata,
+  };
+  const invocationDetails = {
+    maxFee,
+    nonce,
+    version,
+  };
 
-    // if estimating fees passes without failures, the txn should go through
-    const estimateFee = await provider.getEstimateFee(
-        invocationCall,
-        invocationDetails
-    );
-    console.log('Estimate fee - ', estimateFee);
+  // if estimating fees passes without failures, the txn should go through
+  const estimateFee = await provider.getEstimateFee(
+    invocationCall,
+    invocationDetails
+  );
+  console.log("Estimate fee - ", estimateFee);
 
-    const tx = await provider.invokeFunction(invocationCall, invocationDetails);
-    console.log(tx.transaction_hash);
+  const tx = await provider.invokeFunction(invocationCall, invocationDetails);
+  console.log(tx.transaction_hash);
 }
 
-transfer('0x11');
+transfer("0x11");
 ```

--- a/infra/starknet-stack/docker-compose.yml
+++ b/infra/starknet-stack/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - starkcet-back
     networks:
       - faucet
-      
+
   starkcet-back:
     image: ghcr.io/zizou0x/starkcet-backend:latest
     environment:

--- a/infra/starknet-stack/docker-compose.yml
+++ b/infra/starknet-stack/docker-compose.yml
@@ -30,14 +30,14 @@ services:
       - starkcet-back
     networks:
       - faucet
-
+      
   starkcet-back:
     image: ghcr.io/zizou0x/starkcet-backend:latest
     environment:
-      - PRIVATE_KEY=
-      - STARKNET_ACCOUNT_ADDRESS=
-      - TOKEN_ADDRESS=0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-      - RPC_URL=https://alpha4.starknet.io
+      - PRIVATE_KEY=0x00c1cf1490de1352865301bb8705143f3ef938f97fdf892f1090dcb5ac7bcd1d
+      - STARKNET_ACCOUNT_ADDRESS=0x2
+      - TOKEN_ADDRESS=0x040e59c2c182a58fb0a74349bfa4769cbbcba32547591dd3fb1def8623997d01
+      - RPC_URL=http://host.docker.internal:9944
       - AMOUNT_TRANSFERED=1000000000000000
     networks:
       - faucet


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

- Bugfix
- Documentation content changes

## What is the current behavior?

The Starkcet faucet fails to interact with Madara and collect faucet funds.

Resolves: #579 

## What is the new behavior?

- Madara doesn't support `0x100000000000000000000000000000001` version for estimateFee. The issue can be tracker [here](https://github.com/keep-starknet-strange/madara/issues/646). So we need to manually change the version to `0x1` when estimating fees.
- Docs have been added giving instructions on how to use the faucet 

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

No
