### PR TITLE
refacto(mp-digest-log): replace thiserror by a manual impl for FindLo…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4697,7 +4697,6 @@ dependencies = [
  "mp-starknet",
  "parity-scale-codec",
  "sp-runtime",
- "thiserror-no-std",
 ]
 
 [[package]]

--- a/crates/primitives/digest-log/Cargo.toml
+++ b/crates/primitives/digest-log/Cargo.toml
@@ -12,7 +12,6 @@ mp-starknet = { workspace = true }
 scale-codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 # Substrate
 sp-runtime = { workspace = true }
-thiserror-no-std = { workspace = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/crates/primitives/digest-log/src/error.rs
+++ b/crates/primitives/digest-log/src/error.rs
@@ -1,14 +1,23 @@
-use thiserror_no_std::Error;
 /// Error that may occur while searching a Madara \[Log\] in the \[Digest\]
 ///
 /// As for now only one single Madara \[Log\] is expected per \[Digest\].
 /// No more, no less.
-#[derive(Clone, Debug, Error)]
+#[derive(Clone, Debug)]
 pub enum FindLogError {
     /// There was no Madara \[Log\] in the \[Digest\]
-    #[error("Madara log not found")]
     NotLog,
     /// There was multiple Madara \[Log\] in the \[Digest\]
-    #[error("Multiple Madara logs found")]
     MultipleLogs,
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for FindLogError {}
+
+impl core::fmt::Display for FindLogError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            FindLogError::NotLog => write!(f, "Madara log not found"),
+            FindLogError::MultipleLogs => write!(f, "Multiple Madara logs found"),
+        }
+    }
 }


### PR DESCRIPTION
Fixes this error:

```shell
$ cargo build --package madara --bin madara
   Compiling mp-digest-log v0.1.0-alpha (/Users/clementwalter/Documents/madara/crates/primitives/digest-log)
error[E0433]: failed to resolve: use of undeclared crate or module `std`
  --> crates/primitives/digest-log/src/error.rs:10:1
   |
10 | pub enum FindLogError {
   | ^^^ use of undeclared crate or module `std`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `mp-digest-log` due to previous error
```

thiserror-no-std has some problems sometimes