### PR TITLE
feat: Configurable compiler version in ProgramWrapper

### DIFF
--- a/crates/primitives/starknet/src/execution/contract_class_wrapper.rs
+++ b/crates/primitives/starknet/src/execution/contract_class_wrapper.rs
@@ -154,12 +154,13 @@ pub struct ProgramWrapper {
 
 impl From<Program> for ProgramWrapper {
     fn from(value: Program) -> Self {
+        // Defaulting to the latest compiler version if none is configured.
+        let compiler_version = option_env!("COMPILER_VERSION").unwrap_or("0.11.2");
         Self {
             shared_program_data: value.shared_program_data,
             constants: value.constants,
             reference_manager: value.reference_manager,
-            // Defaulting to the latest compiler version.
-            compiler_version: "0.11.2".to_string(),
+            compiler_version: compiler_version.to_string(),
             main_scope: "__main__".to_string(),
         }
     }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,6 +45,12 @@ to build the node without launching it:
 cargo build --release
 ```
 
+You can optionally specify the compiler version for the build:
+
+```sh
+COMPILER_VERSION=0.12.0 cargo build --release
+```
+
 ### Using Nix (optional, only for degens)
 
 Install [nix](https://nixos.org/) and optionally


### PR DESCRIPTION
We want to make the default compiler version easily configurable in the ProgramWrapper conversion

# Pull Request type
Please add the labels corresponding to the type of changes your PR introduces:

- Refactoring (no functional changes, no API changes)
- Other (please describe): Enhancement

## What is the current behavior?
Hardcoded value of 0.11.2
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #670 

## What is the new behavior?
Compiler version can be specified when building Madara

For example:
`COMPILER_VERSION=0.12.0 cargo build`

## Does this introduce a breaking change?
No
