### PR TITLE
feat: add support at rpc to check for already declared class 🚀

### DIFF
--- a/crates/client/rpc/src/errors.rs
+++ b/crates/client/rpc/src/errors.rs
@@ -18,6 +18,8 @@ pub enum StarknetRpcApiError {
     InvalidTxnIndex = 27,
     #[error("Class hash not found")]
     ClassHashNotFound = 28,
+    #[error("Class already declared")]
+    ClassAlreadyDeclared = 51,
     #[error("Requested page size is too big")]
     PageSizeTooBig = 31,
     #[error("There are no blocks")]

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -742,6 +742,17 @@ where
             error!("{e}");
             StarknetRpcApiError::InternalServerError
         })?;
+
+        let current_block_hash = self.client.info().best_hash;
+        let contract_class = self
+            .overrides
+            .for_block_hash(self.client.as_ref(), current_block_hash)
+            .contract_class_by_class_hash(current_block_hash, declare_tx.compiled_class_hash);
+        if let Some(contract_class) = contract_class {
+            error!("Contract class already exists: {:?}", contract_class);
+            return Err(StarknetRpcApiError::ClassAlreadyDeclared.into());
+        }
+
         let transaction: MPTransaction = declare_tx.clone().from_declare(chain_id);
         let extrinsic = self
             .client

--- a/tests/tests/constants.ts
+++ b/tests/tests/constants.ts
@@ -55,6 +55,9 @@ export const UDC_CLASS_HASH = "0x90000";
 export const ERC20_CONTRACT: CompiledContract = json.parse(
   fs.readFileSync("../cairo-contracts/build/ERC20.json").toString("ascii")
 );
+export const ERC721_CONTRACT: CompiledContract = json.parse(
+  fs.readFileSync("../cairo-contracts/build/ERC721.json").toString("ascii")
+);
 export const TEST_CONTRACT: CompiledContract = json.parse(
   fs.readFileSync("../cairo-contracts/build/test.json").toString("ascii")
 );

--- a/tests/tests/test-rpc/test-starknet-rpc.ts
+++ b/tests/tests/test-rpc/test-starknet-rpc.ts
@@ -33,6 +33,7 @@ import {
   ARGENT_CONTRACT_ADDRESS,
   ARGENT_PROXY_CLASS_HASH,
   CHAIN_ID_STARKNET_TESTNET,
+  ERC721_CONTRACT,
   ERC20_CONTRACT,
   FEE_TOKEN_ADDRESS,
   MINT_AMOUNT,
@@ -737,6 +738,8 @@ describeDevMadara("Starknet RPC", (context) => {
         ARGENT_CONTRACT_ADDRESS,
         keyPair
       );
+      // computed via: starkli class-hash ./cairo-contracts/build/ERC20.json
+      // the above command should be used at project root
       const classHash =
         "0x372ee6669dc86563007245ed7343d5180b96221ce28f44408cff2898038dbd4";
       const res = await account.declare(
@@ -761,6 +764,30 @@ describeDevMadara("Starknet RPC", (context) => {
       //   stark.compressProgram(ERC20_CONTRACT.program)
       // );
       expect(res.class_hash).to.be.eq(classHash);
+    });
+
+    it("should fail to declare duplicate class", async function () {
+      const keyPair = ec.getKeyPair(SIGNER_PRIVATE);
+      const account = new Account(
+        providerRPC,
+        ARGENT_CONTRACT_ADDRESS,
+        keyPair
+      );
+
+      // computed via: starkli class-hash ./cairo-contracts/build/ERC20.json
+      // the above command should be used at project root
+      const classHash =
+        "0x372ee6669dc86563007245ed7343d5180b96221ce28f44408cff2898038dbd4";
+
+      await expect(
+        account.declare(
+          {
+            classHash: classHash,
+            contract: ERC20_CONTRACT,
+          },
+          { nonce: ARGENT_CONTRACT_NONCE.value, version: 1, maxFee: "123456" }
+        )
+      ).to.be.rejectedWith("51: Class already declared");
     });
   });
 
@@ -800,12 +827,15 @@ describeDevMadara("Starknet RPC", (context) => {
         ARGENT_CONTRACT_ADDRESS,
         keyPair
       );
+
+      // computed via: starkli class-hash ./cairo-contracts/build/ERC721.json
+      // the above command should be used at project root
       const classHash =
-        "0x372ee6669dc86563007245ed7343d5180b96221ce28f44408cff2898038dbd4";
+        "0x077cc28ed3c661419fda16bf120fb81f1f8f28617f5543b05a86d63b0926bbf4";
       await account.declare(
         {
           classHash: classHash,
-          contract: ERC20_CONTRACT,
+          contract: ERC721_CONTRACT,
         },
         { nonce: ARGENT_CONTRACT_NONCE.value, version: 1, maxFee: "123456" }
       );


### PR DESCRIPTION
Add support for checking at RPC to look for already declared classes, and not proceed if they exist.

# Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- Feature

## What is the current behavior?

The current sequencer behavior is to proceed with all declare class calls without checking if the class is already declared or not. 

According to the s[pec](https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_write_api.json#L146), this should result in an error.

Resolves: #663 

## What is the new behavior?

- checks whether the class already exists or not
- if exists, returns the error code according the spec
- a test has also been included to check this behavior for RPC

## Does this introduce a breaking change?

no
