### PR TITLE
feat: add erc721 `mint` benchmarks

### DIFF
--- a/benchmarking/package.json
+++ b/benchmarking/package.json
@@ -9,14 +9,16 @@
     "test:execution": "artillery run -e local ./scripts/cairo-execution.yml --output reports/report.json",
     "test:storage": "artillery run -e local ./scripts/cairo-storage.yml --output reports/report-storage.json",
     "test:transfer": "artillery run -e local ./scripts/starknet-erc20.yml --output reports/report-transfer.json",
+    "test:erc721mint": "artillery run -e local ./scripts/starknet-erc721.yml --output reports/report-erc721mint.json",
     "report": "artillery report --output reports/report reports/report-transfer.json",
-    "metrics": "node scripts/metrics.js",
     "check": "node scripts/final-check.js",
-    "test": "npm run test:transfer && npm run metrics && npm run check",
+    "test:erc721-mint": "wait-on tcp:9944 && npm run test:erc721mint && node scripts/metrics.js --type erc721 && npm run check",
+    "test:erc20-transfer": "wait-on tcp:9944 && npm run test:transfer && node scripts/metrics.js --type erc20 && npm run check",
     "chain:dev": "../scripts/run_node.sh",
     "chain:dev-error": "../scripts/run_node.sh error",
-    "test:wait": "wait-on tcp:9944 && npm run test",
-    "test:ci": "concurrently -k --success 'command-1' 'npm run chain:dev-error' 'npm run test:wait'"
+    "test:ci:erc20": "concurrently -k --success 'command-1' 'npm run chain:dev-error' 'npm run test:erc20-transfer'",
+    "test:ci:erc721": "concurrently -k --success 'command-1' 'npm run chain:dev-error' 'npm run test:erc721-mint'",
+    "test:ci": "npm run test:ci:erc20 && npm run test:ci:erc721 && node ./scripts/combine-metrics.js"
   },
   "keywords": [
     "madara",

--- a/benchmarking/scripts/combine-metrics.js
+++ b/benchmarking/scripts/combine-metrics.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+
+// the scripts takes metrics_erc20.json and metrics_erc721.json and combines them into one file metrics.json
+// this allows both metrics to be shown on the same page
+
+function main() {
+  const fileNames = [
+    "reports/metrics_erc20.json",
+    "reports/metrics_erc721.json",
+  ];
+  const finalOutput = [];
+  fileNames.forEach((fileName) => {
+    const jsonString = fs.readFileSync(fileName);
+    const metrics = JSON.parse(jsonString);
+    metrics.forEach((metric) => finalOutput.push(metric));
+  });
+
+  fs.writeFileSync("reports/metrics.json", JSON.stringify(finalOutput));
+}
+
+try {
+  main();
+} catch (err) {
+  console.log(err);
+  process.exit(-1);
+}

--- a/benchmarking/scripts/starknet-erc721.yml
+++ b/benchmarking/scripts/starknet-erc721.yml
@@ -1,0 +1,25 @@
+# Copyright 2021-2022 Dwellir AB authors & contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config:
+  processor: "./functions.js"
+  environments:
+    local:
+      target: "ws://127.0.0.1:9944"
+      phases:
+        - duration: 4
+          arrivalCount: 1 # Number of users
+          name: Users Connection
+        - pause: 60
+          name: Performance Testing
+  variables:
+    nonce: 0
+  engines:
+    substrate: {}
+scenarios:
+  - engine: substrate
+    name: starknet_mint
+    flow:
+      - loop:
+          - function: "executeERC721Mint"
+        count: 10000


### PR DESCRIPTION
add erc721 `mint` benchmarks for Madara

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Feature

## What is the current behavior?

Currently, we only have benchmarks for erc20, and benchmarks for ERC721 `mint` aren't present.

Resolves: #502  #692 

## What is the new behavior?

benchmarks for ERC721 have been added.

## Does this introduce a breaking change?

No

## Other Information

- The code has been refactored in a way, that it requires no changes on the GitHub workflow side of the thing, as it still makes available the "test:ci" npm script, and outputs the benchmark to the same "benchmarking/report/metrics.json" file.

- The same file metrics.json will now have data to render benchmarks for both ERC20 `transfers` and ERC721 `mints`.