### PR TITLE
Chore: cleanup of eslint warning on typescript tests

### DIFF
--- a/tests/tests/test-rpc/test-starknet-rpc.ts
+++ b/tests/tests/test-rpc/test-starknet-rpc.ts
@@ -10,8 +10,6 @@ import {
   ec,
   hash,
   validateAndParseAddress,
-  RPC,
-  stark,
   json,
   encode,
   CompressedProgram,
@@ -306,6 +304,7 @@ describeDevMadara("Starknet RPC", (context) => {
       expect(contract_class.entry_points_by_type).to.deep.equal(
         ERC20_CONTRACT.entry_points_by_type
       );
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const program = json.parse(
         encode.arrayBufferToString(decompressProgram(contract_class.program))
       );
@@ -953,6 +952,7 @@ describeDevMadara("Starknet RPC", (context) => {
       const readyExtrinsics =
         await context.polkadotApi.rpc.author.pendingExtrinsics();
       const readyTxs = readyExtrinsics.map((pending) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const obj: any = pending.toHuman();
         return {
           type: obj.method.method.toUpperCase(),


### PR DESCRIPTION
Currently, there are ESLINT warnings generating noise on PRs.

We have some pending typescript tests which is why the imports removed and unused code were there in the first place. We should temporarily silence these warnings to avoid so much noise on open PRs.

# Pull Request type
Please add the labels corresponding to the type of changes your PR introduces:
- Other (please describe): Eslint fix

## What is the current behavior?
Warning on open PRs

## What is the new behavior?
No more warnings. 
Once we implement the missing tests
We can import `RPC, stark` and also remove the 307 line.

## Does this introduce a breaking change?
No

## Other information
![telegram-cloud-photo-size-1-4940593854202097363-y](https://github.com/keep-starknet-strange/madara/assets/58019353/799a8e37-d956-4c64-b3b1-cd7f95ca2443)
