### PR TITLE
fix: remove dev flag used previously

### DIFF
--- a/crates/node/src/command.rs
+++ b/crates/node/src/command.rs
@@ -201,7 +201,6 @@ pub fn run() -> sc_cli::Result<()> {
                     cli.run.run_cmd.shared_params.chain = Some(madara_path + "/chain-specs/testnet-sharingan-raw.json");
                 }
 
-                cli.run.run_cmd.shared_params.dev = true;
                 cli.run.run_cmd.rpc_external = true;
                 cli.run.run_cmd.rpc_methods = RpcMethods::Unsafe;
             }


### PR DESCRIPTION
Dev flag adds node as authorities with `alice` key
