### PR TITLE
fix: running madara with dev flag

### DIFF
--- a/crates/node/src/command.rs
+++ b/crates/node/src/command.rs
@@ -184,33 +184,36 @@ pub fn run() -> sc_cli::Result<()> {
             runner.sync_run(|config| cmd.run::<Block>(&config))
         }
         None => {
-            let madara_path = if cli.run.madara_path.is_some() {
-                cli.run.madara_path.clone().unwrap().to_str().unwrap().to_string()
-            } else {
-                let home_path = std::env::var("HOME").unwrap_or(std::env::var("USERPROFILE").unwrap_or(".".into()));
-                format!("{}/.madara", home_path)
-            };
-
-            cli.run.run_cmd.network_params.node_key_params.node_key_file =
-                Some((madara_path.clone() + "/p2p-key.ed25519").into());
-            cli.run.run_cmd.shared_params.base_path = Some((madara_path.clone()).into());
-
-            if cli.run.testnet.is_some() {
-                copy_chain_spec(madara_path.clone());
-
-                match cli.run.testnet {
-                    Some(Testnet::Local) => {
-                        cli.run.run_cmd.shared_params.chain = Some(madara_path + "/chain-specs/local-raw.json");
-                    }
-                    Some(Testnet::Sharingan) => {
-                        cli.run.run_cmd.shared_params.chain =
-                            Some(madara_path + "/chain-specs/testnet-sharingan-raw.json");
-                    }
-                    None => {}
+            // when using the --dev flag, every future config should be ignored
+            if !cli.run.run_cmd.shared_params.dev {
+                let madara_path = if cli.run.madara_path.is_some() {
+                    cli.run.madara_path.clone().unwrap().to_str().unwrap().to_string()
+                } else {
+                    let home_path = std::env::var("HOME").unwrap_or(std::env::var("USERPROFILE").unwrap_or(".".into()));
+                    format!("{}/.madara", home_path)
                 };
 
-                cli.run.run_cmd.rpc_external = true;
-                cli.run.run_cmd.rpc_methods = RpcMethods::Unsafe;
+                cli.run.run_cmd.network_params.node_key_params.node_key_file =
+                    Some((madara_path.clone() + "/p2p-key.ed25519").into());
+                cli.run.run_cmd.shared_params.base_path = Some((madara_path.clone()).into());
+
+                if cli.run.testnet.is_some() {
+                    copy_chain_spec(madara_path.clone());
+
+                    match cli.run.testnet {
+                        Some(Testnet::Local) => {
+                            cli.run.run_cmd.shared_params.chain = Some(madara_path + "/chain-specs/local-raw.json");
+                        }
+                        Some(Testnet::Sharingan) => {
+                            cli.run.run_cmd.shared_params.chain =
+                                Some(madara_path + "/chain-specs/testnet-sharingan-raw.json");
+                        }
+                        None => {}
+                    };
+
+                    cli.run.run_cmd.rpc_external = true;
+                    cli.run.run_cmd.rpc_methods = RpcMethods::Unsafe;
+                }
             }
 
             let runner = cli.create_runner(&cli.run.run_cmd)?;


### PR DESCRIPTION
If `--dev` flag is specified, ignore madara usual cache folder