### PR TITLE
dev: re-order metrics, put all ERC20 data first, and then ERC721 mints data

### DIFF
--- a/dev/bench/index.html
+++ b/dev/bench/index.html
@@ -292,19 +292,26 @@
             graphsElem.className = "benchmark-graphs";
             setElem.appendChild(graphsElem);
 
-            for (const [benchName, benches] of [...benchSet.entries()].sort(
-              ([keyA], [keyB]) => {
-                const lowerCaseKeyA = keyA.toLowerCase();
-                const lowerCaseKeyB = keyB.toLowerCase();
+            console.log("benchSet",benchSet);
+            window.benchset = benchSet;
 
-                if (lowerCaseKeyA.includes("tps")) {
-                  return -1; // keyA comes first
-                } else if (lowerCaseKeyB.includes("tps")) {
-                  return 1; // keyB comes first
-                }
-                return 0; // maintain the original order
-              }
-            )) {
+            // ordering of the graphs via the benchmark name
+            let order  = {
+              "Average TPS": 0,
+              "Average Extrinsics per block": 1,
+              "Average TPS (ERC721 mints)": 2,
+              "Average Extrinsics per block (ERC721 mints)": 3,
+            }
+
+            const entries = [];
+            // sort the entries by the order
+            [...benchSet.entries()].forEach((e)=>{
+              const [benchname] = e;
+              entries[order[benchname]] = e;
+            })
+
+            for (const [benchName, benches] of entries)
+              {
               renderGraph(graphsElem, benchName, benches);
             }
           }


### PR DESCRIPTION
change the ordering of benchmark data on the website, show ERC20 data first, and then ERC721 data.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Feature

## What is the current behavior?

The benchmark data for both ERC20 and ERC721 is mixed, i.e. we are ordering data only per the metric.

Resolves: #791 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- data is now ordered in a way, that firstly all ERC20 benchmarks are show, and then ERC721.

## Does this introduce a breaking change?

No
