### PR TITLE
feat: store sierra class in runtime when using declare v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,7 +847,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "starknet-crypto",
+ "starknet-crypto 0.5.1",
  "starknet_api",
  "strum",
  "strum_macros",
@@ -1410,7 +1410,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.7",
  "sha3",
- "starknet-crypto",
+ "starknet-crypto 0.5.1",
  "thiserror",
  "thiserror-no-std",
 ]
@@ -2650,33 +2650,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethbloom"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-dependencies = [
- "crunchy",
- "fixed-hash",
- "impl-rlp",
- "impl-serde",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "ethbloom",
- "fixed-hash",
- "impl-rlp",
- "impl-serde",
- "primitive-types",
- "uint",
-]
-
-[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3802,15 +3775,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
  "parity-scale-codec",
-]
-
-[[package]]
-name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp",
 ]
 
 [[package]]
@@ -5411,7 +5375,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "starknet-core",
- "starknet-crypto",
+ "starknet-crypto 0.6.0",
  "starknet-ff",
  "starknet_api",
  "thiserror-no-std",
@@ -6109,7 +6073,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "starknet-core",
- "starknet-crypto",
+ "starknet-crypto 0.6.0",
  "starknet_api",
  "test-case",
 ]
@@ -6646,7 +6610,6 @@ checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "impl-rlp",
  "impl-serde",
  "scale-info",
  "uint",
@@ -7154,16 +7117,6 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
-]
-
-[[package]]
-name = "rlp"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
-dependencies = [
- "bytes",
- "rustc-hex",
 ]
 
 [[package]]
@@ -8693,6 +8646,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json_pythonic"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62212da9872ca2a0cad0093191ee33753eddff9266cbbc1b4a602d13a3a768db"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9717,21 +9681,20 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starknet-core"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3347c627060a9236167e91887363e9d3027c3863bff03aa88dbdcc6a6c94090b"
+checksum = "57e758b2966915b7ef9457e5d32e9c2017ec1e391996999cd6821db7e6b8f169"
 dependencies = [
  "base64 0.21.2",
- "ethereum-types",
  "flate2",
  "hex",
  "serde",
  "serde_json",
+ "serde_json_pythonic",
  "serde_with",
  "sha3",
- "starknet-crypto",
+ "starknet-crypto 0.6.0",
  "starknet-ff",
- "thiserror",
 ]
 
 [[package]]
@@ -9749,18 +9712,38 @@ dependencies = [
  "rfc6979 0.4.0",
  "sha2 0.10.7",
  "starknet-crypto-codegen",
- "starknet-curve",
+ "starknet-curve 0.3.0",
+ "starknet-ff",
+ "zeroize",
+]
+
+[[package]]
+name = "starknet-crypto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbb308033b5c60c5677645f7ba3b012b4e3e81f773480d27fb5f342d50621e6"
+dependencies = [
+ "crypto-bigint 0.5.2",
+ "hex",
+ "hmac 0.12.1",
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.15",
+ "rfc6979 0.4.0",
+ "sha2 0.10.7",
+ "starknet-crypto-codegen",
+ "starknet-curve 0.4.0",
  "starknet-ff",
  "zeroize",
 ]
 
 [[package]]
 name = "starknet-crypto-codegen"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6dc88f1f470d9de1001ffbb90d2344c9dd1a615f5467daf0574e2975dfd9ebd"
+checksum = "af6527b845423542c8a16e060ea1bc43f67229848e7cd4c4d80be994a84220ce"
 dependencies = [
- "starknet-curve",
+ "starknet-curve 0.4.0",
  "starknet-ff",
  "syn 2.0.22",
 ]
@@ -9770,6 +9753,15 @@ name = "starknet-curve"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252610baff59e4c4332ce3569f7469c5d3f9b415a2240d698fb238b2b4fc0942"
+dependencies = [
+ "starknet-ff",
+]
+
+[[package]]
+name = "starknet-curve"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68a0d87ae56572abf83ddbfd44259a7c90dbeeee1629a1ffe223e7f9a8f3052"
 dependencies = [
  "starknet-ff",
 ]
@@ -9803,7 +9795,7 @@ dependencies = [
  "primitive-types",
  "serde",
  "serde_json",
- "starknet-crypto",
+ "starknet-crypto 0.5.1",
  "thiserror-no-std",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,8 +122,8 @@ cairo-vm = { git = "https://github.com/keep-starknet-strange/cairo-rs", branch =
   "cairo-1-hints",
   "parity-scale-codec",
 ] }
-starknet-crypto = { version = "0.5.1", default-features = false }
-starknet-core = { version = "0.3.0", default-features = false }
+starknet-crypto = { version = "0.6.0", default-features = false }
+starknet-core = { version = "0.4.0", default-features = false }
 starknet-ff = { version = "0.3.4", default-features = false }
 
 blockifier = { git = "https://github.com/keep-starknet-strange/blockifier", branch = "no_std-support", default-features = false, features = [

--- a/crates/client/rpc-core/src/tests.rs
+++ b/crates/client/rpc-core/src/tests.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use mp_starknet::transaction::types::{BroadcastedTransactionConversionErrorWrapper, DeclareTransaction, MaxArraySize};
+use mp_starknet::transaction::types::{BroadcastedTransactionConversionError, DeclareTransaction, MaxArraySize};
 use sp_core::TypedGet;
 use starknet_core::types::contract::legacy::LegacyContractClass;
 use starknet_core::types::contract::SierraClass;
@@ -81,7 +81,7 @@ fn test_try_into_declare_transaction_v1_max_signature() {
 
     let input: BroadcastedDeclareTransaction = BroadcastedDeclareTransaction::V1(txn);
     let output_result: Result<DeclareTransaction, _> = to_declare_transaction(input);
-    assert!(matches!(output_result.unwrap_err(), BroadcastedTransactionConversionErrorWrapper::SignatureBoundError));
+    assert!(matches!(output_result.unwrap_err(), BroadcastedTransactionConversionError::VecTooBigForBound));
 }
 
 #[test]
@@ -108,7 +108,7 @@ fn test_try_into_declare_transaction_v1_bad_gzip() {
     let output_result: Result<DeclareTransaction, _> = to_declare_transaction(input);
     assert!(matches!(
         output_result.unwrap_err(),
-        BroadcastedTransactionConversionErrorWrapper::ContractClassProgramDecompressionError
+        BroadcastedTransactionConversionError::ContractClassProgramDecompression
     ));
 }
 
@@ -147,7 +147,7 @@ fn test_try_into_declare_transaction_v2_with_incorrect_compiled_class_hash() {
     let input: BroadcastedDeclareTransaction = BroadcastedDeclareTransaction::V2(txn);
     let output_result: Result<DeclareTransaction, _> = to_declare_transaction(input);
 
-    assert!(matches!(output_result.unwrap_err(), BroadcastedTransactionConversionErrorWrapper::CompiledClassHashError));
+    assert!(matches!(output_result.unwrap_err(), BroadcastedTransactionConversionError::InvalidCompiledClassHash));
 }
 
 fn get_compressed_legacy_contract_class() -> CompressedLegacyContractClass {

--- a/crates/pallets/starknet/src/blockifier_state_adapter.rs
+++ b/crates/pallets/starknet/src/blockifier_state_adapter.rs
@@ -79,7 +79,7 @@ impl<T: Config> StateReader for BlockifierStateAdapter<T> {
 
     fn get_compiled_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<ContractClass> {
         let wrapped_class_hash: ClassHashWrapper = class_hash.0.into();
-        Pallet::<T>::contract_class_by_class_hash(wrapped_class_hash)
+        Pallet::<T>::casm_contract_class_by_class_hash(wrapped_class_hash)
             .ok_or(StateError::UndeclaredClassHash(*class_hash))
     }
 
@@ -171,7 +171,7 @@ impl<T: Config> State for BlockifierStateAdapter<T> {
     fn set_contract_class(&mut self, class_hash: &ClassHash, contract_class: ContractClass) -> StateResult<()> {
         let class_hash: ClassHashWrapper = class_hash.0.into();
 
-        crate::ContractClasses::<T>::insert(class_hash, contract_class);
+        crate::CasmContractClasses::<T>::insert(class_hash, contract_class);
 
         // Update state tries if enabled in the runtime configuration
         if T::EnableStateRoot::get() {

--- a/crates/pallets/starknet/src/runtime_api.rs
+++ b/crates/pallets/starknet/src/runtime_api.rs
@@ -7,7 +7,9 @@
 
 use blockifier::execution::contract_class::ContractClass;
 use mp_starknet::crypto::hash::Hasher;
-use mp_starknet::execution::types::{ClassHashWrapper, ContractAddressWrapper, Felt252Wrapper, StorageKeyWrapper};
+use mp_starknet::execution::types::{
+    ClassHashWrapper, ContractAddressWrapper, Felt252Wrapper, SierraContractClass, StorageKeyWrapper,
+};
 use mp_starknet::transaction::types::{EventWrapper, Transaction, TxType};
 use sp_api::BlockT;
 pub extern crate alloc;
@@ -37,6 +39,8 @@ sp_api::decl_runtime_apis! {
         fn estimate_fee(transaction: Transaction) -> Result<(u64, u64), DispatchError>;
         /// Returns the hasher used by the runtime.
         fn get_hasher() -> Hasher;
+        // Returns the sierra program for the given class hash
+        fn get_sierra_program_by_class_hash(class_hash: ClassHashWrapper) -> Option<SierraContractClass>;
         /// Filters extrinsic transactions to return only Starknet transactions
         ///
         /// To support runtime upgrades, the client must be unaware of the specific extrinsic

--- a/crates/pallets/starknet/src/tests/deploy_account_tx.rs
+++ b/crates/pallets/starknet/src/tests/deploy_account_tx.rs
@@ -1,6 +1,6 @@
 use frame_support::{assert_err, assert_ok, bounded_vec, BoundedVec};
 use mp_starknet::execution::types::Felt252Wrapper;
-use mp_starknet::transaction::types::{DeployAccountTransaction, EventWrapper};
+use mp_starknet::transaction::types::{DeployAccountTransaction, EventWrapper, Transaction};
 use sp_runtime::traits::ValidateUnsigned;
 use sp_runtime::transaction_validity::TransactionSource;
 
@@ -184,7 +184,7 @@ fn given_contract_run_deploy_account_openzeppelin_tx_works() {
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
         };
-        let mp_transaction = transaction.clone().from_deploy(get_chain_id()).unwrap();
+        let mp_transaction: Transaction = (transaction.clone(), get_chain_id()).try_into().unwrap();
 
         let tx_hash = mp_transaction.hash;
         transaction.signature = sign_message_hash(tx_hash);
@@ -226,7 +226,7 @@ fn given_contract_run_deploy_account_openzeppelin_with_incorrect_signature_then_
             signature: bounded_vec!(Felt252Wrapper::ONE, Felt252Wrapper::ONE),
         };
 
-        let address = transaction.clone().from_deploy(get_chain_id()).unwrap().sender_address;
+        let address = TryInto::<Transaction>::try_into((transaction.clone(), get_chain_id())).unwrap().sender_address;
         set_signer(address, AccountType::V0(AccountTypeV0Inner::Openzeppelin));
 
         assert_err!(
@@ -264,7 +264,7 @@ fn given_contract_run_deploy_account_argent_tx_works() {
             signature: bounded_vec!(),
         };
 
-        let mp_transaction = transaction.clone().from_deploy(get_chain_id()).unwrap();
+        let mp_transaction: Transaction = (transaction.clone(), get_chain_id()).try_into().unwrap();
 
         let tx_hash = mp_transaction.hash;
         transaction.signature = sign_message_hash(tx_hash);
@@ -306,7 +306,7 @@ fn given_contract_run_deploy_account_argent_with_incorrect_signature_then_it_fai
             signature: bounded_vec!(Felt252Wrapper::ONE, Felt252Wrapper::ONE),
         };
 
-        let address = transaction.clone().from_deploy(get_chain_id()).unwrap().sender_address;
+        let address = TryInto::<Transaction>::try_into((transaction.clone(), get_chain_id())).unwrap().sender_address;
         set_signer(address, AccountType::V0(AccountTypeV0Inner::Argent));
 
         assert_err!(
@@ -354,7 +354,7 @@ fn given_contract_run_deploy_account_braavos_tx_works() {
             signature: signatures.try_into().unwrap(),
         };
 
-        let address = transaction.clone().from_deploy(get_chain_id()).unwrap().sender_address;
+        let address = TryInto::<Transaction>::try_into((transaction.clone(), get_chain_id())).unwrap().sender_address;
         set_infinite_tokens(address);
         set_signer(address, AccountType::V0(AccountTypeV0Inner::Braavos));
 

--- a/crates/pallets/starknet/src/tests/l1_message.rs
+++ b/crates/pallets/starknet/src/tests/l1_message.rs
@@ -30,6 +30,7 @@ fn given_contract_l1_message_fails_sender_not_deployed() {
             signature: Default::default(),
             max_fee: Default::default(),
             class_hash: Default::default(),
+            sierra_contract: None,
         };
 
         assert_err!(Starknet::declare(none_origin, transaction), Error::<MockRuntime>::AccountNotDeployed);

--- a/crates/pallets/starknet/src/tests/mod.rs
+++ b/crates/pallets/starknet/src/tests/mod.rs
@@ -36,15 +36,18 @@ pub fn get_invoke_dummy() -> Transaction {
         Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000019").unwrap(), /* calldata[0] */
     );
 
-    InvokeTransaction {
-        version: 1,
-        sender_address,
-        calldata,
-        nonce,
-        signature,
-        max_fee: Felt252Wrapper::from(u128::MAX),
-    }
-    .from_invoke(Starknet::chain_id())
+    (
+        InvokeTransaction {
+            version: 1,
+            sender_address,
+            calldata,
+            nonce,
+            signature,
+            max_fee: Felt252Wrapper::from(u128::MAX),
+        },
+        Starknet::chain_id(),
+    )
+        .into()
 }
 
 // ref: https://github.com/argentlabs/argent-contracts-starknet/blob/develop/contracts/account/ArgentAccount.cairo
@@ -66,15 +69,18 @@ fn get_invoke_argent_dummy() -> Transaction {
         Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000019").unwrap(), /* calldata[0] */
     );
 
-    InvokeTransaction {
-        version: 1,
-        sender_address,
-        calldata,
-        nonce,
-        signature,
-        max_fee: Felt252Wrapper::from(u128::MAX),
-    }
-    .from_invoke(Starknet::chain_id())
+    (
+        InvokeTransaction {
+            version: 1,
+            sender_address,
+            calldata,
+            nonce,
+            signature,
+            max_fee: Felt252Wrapper::from(u128::MAX),
+        },
+        Starknet::chain_id(),
+    )
+        .into()
 }
 
 // ref: https://github.com/myBraavos/braavos-account-cairo/blob/develop/src/account/Account.cairo
@@ -96,15 +102,18 @@ fn get_invoke_braavos_dummy() -> Transaction {
         Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000019").unwrap(), /* calldata[0] */
     );
 
-    InvokeTransaction {
-        version: 1,
-        sender_address,
-        calldata,
-        nonce,
-        signature,
-        max_fee: Felt252Wrapper::from(u128::MAX),
-    }
-    .from_invoke(Starknet::chain_id())
+    (
+        InvokeTransaction {
+            version: 1,
+            sender_address,
+            calldata,
+            nonce,
+            signature,
+            max_fee: Felt252Wrapper::from(u128::MAX),
+        },
+        Starknet::chain_id(),
+    )
+        .into()
 }
 
 // ref: https://github.com/OpenZeppelin/cairo-contracts/blob/main/src/openzeppelin/token/erc20/IERC20.cairo
@@ -122,15 +131,18 @@ fn get_invoke_emit_event_dummy() -> Transaction {
         Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000000").unwrap(), /* amount */
     );
 
-    InvokeTransaction {
-        version: 1,
-        sender_address,
-        calldata,
-        nonce,
-        signature,
-        max_fee: Felt252Wrapper::from(u128::MAX),
-    }
-    .from_invoke(Starknet::chain_id())
+    (
+        InvokeTransaction {
+            version: 1,
+            sender_address,
+            calldata,
+            nonce,
+            signature,
+            max_fee: Felt252Wrapper::from(u128::MAX),
+        },
+        Starknet::chain_id(),
+    )
+        .into()
 }
 
 // ref: https://github.com/tdelabro/blockifier/blob/no_std-support/crates/blockifier/feature_contracts/account_without_validations.cairo
@@ -148,15 +160,18 @@ fn get_invoke_nonce_dummy() -> Transaction {
         Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000019").unwrap(), /* calldata[0] */
     );
 
-    InvokeTransaction {
-        version: 1,
-        sender_address,
-        calldata,
-        nonce,
-        signature,
-        max_fee: Felt252Wrapper::from(u128::MAX),
-    }
-    .from_invoke(Starknet::chain_id())
+    (
+        InvokeTransaction {
+            version: 1,
+            sender_address,
+            calldata,
+            nonce,
+            signature,
+            max_fee: Felt252Wrapper::from(u128::MAX),
+        },
+        Starknet::chain_id(),
+    )
+        .into()
 }
 
 // ref: https://github.com/keep-starknet-strange/madara/blob/main/cairo-contracts/src/accounts/NoValidateAccount.cairo
@@ -172,15 +187,18 @@ fn get_storage_read_write_dummy() -> Transaction {
         Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000001").unwrap(), /* calldata[1] */
     );
 
-    let mut tx = InvokeTransaction {
-        version: 1,
-        sender_address,
-        calldata,
-        nonce,
-        signature,
-        max_fee: Felt252Wrapper::from(u128::MAX),
-    }
-    .from_invoke(Starknet::chain_id());
+    let mut tx: Transaction = (
+        InvokeTransaction {
+            version: 1,
+            sender_address,
+            calldata,
+            nonce,
+            signature,
+            max_fee: Felt252Wrapper::from(u128::MAX),
+        },
+        Starknet::chain_id(),
+    )
+        .into();
 
     tx.contract_class = Some(get_contract_class("NoValidateAccount.json", 0));
 
@@ -206,13 +224,16 @@ fn get_invoke_openzeppelin_dummy() -> Transaction {
         Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000019").unwrap(), /* calldata[0] */
     );
 
-    InvokeTransaction {
-        version: 1,
-        sender_address,
-        calldata,
-        nonce,
-        signature,
-        max_fee: Felt252Wrapper::from(u128::MAX),
-    }
-    .from_invoke(Starknet::chain_id())
+    (
+        InvokeTransaction {
+            version: 1,
+            sender_address,
+            calldata,
+            nonce,
+            signature,
+            max_fee: Felt252Wrapper::from(u128::MAX),
+        },
+        Starknet::chain_id(),
+    )
+        .into()
 }

--- a/crates/primitives/starknet/Cargo.toml
+++ b/crates/primitives/starknet/Cargo.toml
@@ -26,7 +26,7 @@ blockifier = { workspace = true, default-features = false, features = [
 cairo-lang-casm = { workspace = true, default-features = false }
 cairo-lang-casm-contract-class = { workspace = true }
 cairo-vm = { workspace = true }
-starknet-core = { workspace = true, optional = true }
+starknet-core = { workspace = true }
 starknet-crypto = { workspace = true, default-features = false, features = [
   "alloc",
 ] }
@@ -69,7 +69,7 @@ std = [
   "starknet-crypto/std",
   "starknet-ff/std",
   "starknet-ff/serde",
-  "starknet-core",
+  "starknet-core/std",
   "blockifier/std",
   "starknet_api/std",
   # Substrate

--- a/crates/primitives/starknet/src/execution/entrypoint_wrapper.rs
+++ b/crates/primitives/starknet/src/execution/entrypoint_wrapper.rs
@@ -5,7 +5,6 @@ use starknet_api::api_core::EntryPointSelector;
 use starknet_api::deprecated_contract_class::{EntryPoint, EntryPointOffset, EntryPointType};
 use starknet_api::hash::StarkFelt;
 use starknet_api::StarknetApiError;
-use starknet_ff::{FieldElement, FromByteArrayError};
 use thiserror_no_std::Error;
 
 use crate::scale_codec::{Decode, Encode, Error, Input, MaxEncodedLen, Output};
@@ -123,6 +122,7 @@ pub enum EntryPointExecutionErrorWrapper {
 #[cfg(feature = "std")]
 mod reexport_std_types {
     use starknet_core::types::LegacyContractEntryPoint;
+    use starknet_ff::{FieldElement, FromByteArrayError};
 
     use super::*;
     impl From<LegacyContractEntryPoint> for EntryPointWrapper {

--- a/crates/primitives/starknet/src/execution/mod.rs
+++ b/crates/primitives/starknet/src/execution/mod.rs
@@ -1,18 +1,13 @@
 //! Starknet execution functionality.
 
-use alloc::collections::BTreeMap;
-
-use frame_support::BoundedBTreeMap;
-use serde::de::Error as DeserializationError;
-use serde::{Deserialize, Deserializer, Serializer};
-use sp_core::Get;
-
 /// Call Entrypoint Wrapper related types
 pub mod call_entrypoint_wrapper;
 /// Entrypoint Wrapper related types
 pub mod entrypoint_wrapper;
 /// Felt252Wrapper type
 pub mod felt252_wrapper;
+/// SierraClass type;
+pub mod sierra_contract_class;
 
 /// All the types related to the execution of a transaction.
 pub mod types {
@@ -31,13 +26,17 @@ pub mod types {
     pub use super::call_entrypoint_wrapper::*;
     pub use super::entrypoint_wrapper::*;
     pub use super::felt252_wrapper::*;
+    pub use super::sierra_contract_class::*;
 }
 
 #[cfg(feature = "std")]
 mod reexport_private_types {
-    use frame_support::Serialize;
+    use alloc::collections::BTreeMap;
 
-    use super::*;
+    use frame_support::{BoundedBTreeMap, Serialize};
+    use serde::de::Error as DeserializationError;
+    use serde::{Deserialize, Deserializer, Serializer};
+    use sp_core::Get;
 
     /// Serialization of [BoundedBTreeMap].
     /// This is needed for the genesis config.

--- a/crates/primitives/starknet/src/execution/sierra_contract_class.rs
+++ b/crates/primitives/starknet/src/execution/sierra_contract_class.rs
@@ -1,0 +1,98 @@
+use scale_codec::{Decode, Encode};
+use sp_std::vec::Vec;
+use starknet_core::types::FlattenedSierraClass;
+
+use crate::execution::felt252_wrapper::Felt252Wrapper;
+
+// SierraClass is used in the runtime instead of `starknet-core::FlattenedSierraClass`.
+// It should  have the exact same memory representation
+
+/// A sierra Starknet contract class.
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, scale_info::TypeInfo)]
+pub struct SierraContractClass {
+    /// The list of sierra instructions of which the program consists
+    pub sierra_program: Vec<Felt252Wrapper>,
+    /// The version of the contract class object. Currently, the Starknet os supports version 0.1.0
+    pub contract_class_version: Vec<u8>,
+    /// Entry points by type
+    pub entry_points_by_type: EntryPointsByType,
+    /// The class abi, as supplied by the user declaring the class
+    pub abi: Vec<u8>,
+}
+
+/// The contract entrypoints, grouped by types
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, scale_info::TypeInfo)]
+pub struct EntryPointsByType {
+    /// Constructor
+    pub constructor: Vec<SierraEntryPoint>,
+    /// External
+    pub external: Vec<SierraEntryPoint>,
+    /// L1 handler
+    pub l1_handler: Vec<SierraEntryPoint>,
+}
+
+/// A Sierra entrypoint
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, scale_info::TypeInfo)]
+pub struct SierraEntryPoint {
+    /// A unique identifier of the entry point (function) in the program
+    pub selector: Felt252Wrapper,
+    /// The index of the function in the program
+    pub function_idx: u64,
+}
+
+// O(0) type conversion conversion
+
+impl From<FlattenedSierraClass> for SierraContractClass {
+    fn from(value: FlattenedSierraClass) -> Self {
+        unsafe { core::mem::transmute(value) }
+    }
+}
+
+impl From<SierraContractClass> for FlattenedSierraClass {
+    fn from(value: SierraContractClass) -> Self {
+        unsafe { core::mem::transmute(value) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use starknet_core::types::{
+        EntryPointsByType as FlattenedEntryPointsByType, FlattenedSierraClass,
+        SierraEntryPoint as FlattenedSierraEntryPoint,
+    };
+    use starknet_crypto::FieldElement;
+
+    use super::SierraContractClass;
+
+    #[test]
+    fn from_into_ok() {
+        let original = FlattenedSierraClass {
+            sierra_program: vec![FieldElement::ZERO, FieldElement::ONE, FieldElement::MAX],
+            contract_class_version: "0.1.0".to_string(),
+            entry_points_by_type: FlattenedEntryPointsByType {
+                constructor: vec![
+                    FlattenedSierraEntryPoint { selector: FieldElement::ZERO, function_idx: 0 },
+                    FlattenedSierraEntryPoint { selector: FieldElement::ONE, function_idx: 1 },
+                    FlattenedSierraEntryPoint { selector: FieldElement::MAX, function_idx: u64::MAX },
+                ],
+                external: vec![
+                    FlattenedSierraEntryPoint { selector: FieldElement::MAX, function_idx: u64::MAX },
+                    FlattenedSierraEntryPoint { selector: FieldElement::ZERO, function_idx: 0 },
+                    FlattenedSierraEntryPoint { selector: FieldElement::ONE, function_idx: 1 },
+                ],
+                l1_handler: vec![
+                    FlattenedSierraEntryPoint { selector: FieldElement::ONE, function_idx: 1 },
+                    FlattenedSierraEntryPoint { selector: FieldElement::MAX, function_idx: u64::MAX },
+                    FlattenedSierraEntryPoint { selector: FieldElement::ZERO, function_idx: 0 },
+                ],
+            },
+            abi: "some_abi".to_string(),
+        };
+
+        let primitive_type: SierraContractClass = original.into();
+
+        let cairo_rs_type: FlattenedSierraClass = primitive_type.clone().into();
+
+        assert_eq!(primitive_type, cairo_rs_type.into());
+    }
+}

--- a/crates/primitives/starknet/src/sequencer_address/mod.rs
+++ b/crates/primitives/starknet/src/sequencer_address/mod.rs
@@ -1,5 +1,3 @@
-use core::array::TryFromSliceError;
-
 use scale_codec::{Decode, Encode};
 use sp_inherents::{InherentData, InherentIdentifier, IsFatalError};
 use thiserror_no_std::Error;
@@ -45,11 +43,6 @@ impl SequencerAddressInherentData for InherentData {
     }
 }
 
-/// Helper function to convert storage value.
-fn slice_to_arr(slice: &[u8]) -> Result<[u8; 32], TryFromSliceError> {
-    slice.try_into()
-}
-
 #[cfg(feature = "std")]
 mod reexport_std_types {
     use super::*;
@@ -89,7 +82,7 @@ mod reexport_std_types {
     impl TryFrom<Vec<u8>> for InherentDataProvider {
         type Error = InherentError;
         fn try_from(storage_val: Vec<u8>) -> Result<Self, InherentError> {
-            match slice_to_arr(&storage_val) {
+            match storage_val.try_into() {
                 Ok(addr) => Ok(InherentDataProvider { sequencer_address: addr }),
                 Err(_) => Err(InherentError::WrongAddressFormat),
             }

--- a/crates/primitives/starknet/src/storage/mod.rs
+++ b/crates/primitives/starknet/src/storage/mod.rs
@@ -18,8 +18,10 @@ pub const PALLET_STARKNET: &[u8] = b"Starknet";
 pub const STARKNET_CURRENT_BLOCK: &[u8] = b"CurrentBlock";
 /// Starknet contract class hash storage item.
 pub const STARKNET_CONTRACT_CLASS_HASH: &[u8] = b"ContractClassHashes";
-/// Starknet contract class storage item.
-pub const STARKNET_CONTRACT_CLASS: &[u8] = b"ContractClasses";
+/// Starknet Casm contract class storage item.
+pub const STARKNET_CASM_CONTRACT_CLASS: &[u8] = b"CasmContractClasses";
+/// Starknet Sierra contract class storage item.
+pub const STARKNET_SIERRA_CONTRACT_CLASS: &[u8] = b"SierraContractClasses";
 /// Starknet nonce storage item.
 pub const STARKNET_NONCE: &[u8] = b"Nonces";
 /// Starknet chain id storage item.

--- a/crates/primitives/starknet/src/tests/crypto.rs
+++ b/crates/primitives/starknet/src/tests/crypto.rs
@@ -62,6 +62,7 @@ fn test_declare_tx_hash() {
         // Arbitrary choice to pick v1 vs v0.
         contract_class: ContractClass::from(ContractClassV1::default()),
         compiled_class_hash: None,
+        sierra_contract: None,
     };
     assert_eq!(calculate_declare_tx_hash(transaction, chain_id), expected_tx_hash);
 }

--- a/crates/primitives/starknet/src/tests/transaction.rs
+++ b/crates/primitives/starknet/src/tests/transaction.rs
@@ -21,8 +21,8 @@ use crate::execution::call_entrypoint_wrapper::{CallEntryPointWrapper, MaxCallda
 use crate::execution::types::{ContractAddressWrapper, Felt252Wrapper};
 use crate::transaction::constants;
 use crate::transaction::types::{
-    BroadcastedTransactionConversionErrorWrapper, DeployAccountTransaction, EventError, EventWrapper,
-    InvokeTransaction, MaxArraySize, Transaction, TransactionReceiptWrapper, TxType,
+    BroadcastedTransactionConversionError, DeployAccountTransaction, EventError, EventWrapper, InvokeTransaction,
+    MaxArraySize, Transaction, TransactionReceiptWrapper, TxType,
 };
 
 #[test]
@@ -388,10 +388,10 @@ fn test_try_into_deploy_account_transaction() {
     pretty_assertions::assert_eq!(max_len.0, max_len.1);
 
     let array_outbound = get_try_into_and_expected_value(max_array_size + 1, max_calldata_size);
-    assert!(matches!(array_outbound.unwrap_err(), BroadcastedTransactionConversionErrorWrapper::SignatureBoundError));
+    assert!(matches!(array_outbound.unwrap_err(), BroadcastedTransactionConversionError::VecTooBigForBound));
 
     let calldata_outbound = get_try_into_and_expected_value(max_array_size, max_calldata_size + 1);
-    assert!(matches!(calldata_outbound.unwrap_err(), BroadcastedTransactionConversionErrorWrapper::CalldataBoundError));
+    assert!(matches!(calldata_outbound.unwrap_err(), BroadcastedTransactionConversionError::VecTooBigForBound));
 }
 
 #[test]
@@ -411,7 +411,7 @@ fn test_try_invoke_txn_from_broadcasted_invoke_txn_v0() {
     assert!(invoke_txn.is_err());
     assert!(matches!(
         invoke_txn.unwrap_err(),
-        BroadcastedTransactionConversionErrorWrapper::StarknetError(StarknetError::FailedToReceiveTransaction)
+        BroadcastedTransactionConversionError::StarknetError(StarknetError::FailedToReceiveTransaction)
     ))
 }
 
@@ -457,7 +457,7 @@ fn test_try_invoke_txn_from_broadcasted_invoke_txn_v1_max_sig_size() {
     let invoke_txn = InvokeTransaction::try_from(broadcasted_invoke_txn);
 
     assert!(invoke_txn.is_err());
-    assert!(matches!(invoke_txn.unwrap_err(), BroadcastedTransactionConversionErrorWrapper::SignatureConversionError));
+    assert!(matches!(invoke_txn.unwrap_err(), BroadcastedTransactionConversionError::SignatureConversion));
 }
 
 #[test]
@@ -476,7 +476,7 @@ fn test_try_invoke_txn_from_broadcasted_invoke_txn_v1_max_calldata_size() {
     let invoke_txn = InvokeTransaction::try_from(broadcasted_invoke_txn);
 
     assert!(invoke_txn.is_err());
-    assert!(matches!(invoke_txn.unwrap_err(), BroadcastedTransactionConversionErrorWrapper::CalldataConversionError));
+    assert!(matches!(invoke_txn.unwrap_err(), BroadcastedTransactionConversionError::CalldataConversion));
 }
 
 // This helper methods either returns result of `TryInto::try_into()` and expected result or the
@@ -484,7 +484,7 @@ fn test_try_invoke_txn_from_broadcasted_invoke_txn_v1_max_calldata_size() {
 fn get_try_into_and_expected_value(
     array_size: usize,
     calldata_size: usize,
-) -> Result<(DeployAccountTransaction, DeployAccountTransaction), BroadcastedTransactionConversionErrorWrapper> {
+) -> Result<(DeployAccountTransaction, DeployAccountTransaction), BroadcastedTransactionConversionError> {
     let signature: Vec<FieldElement> = vec![FieldElement::default(); array_size];
     let constructor_calldata: Vec<FieldElement> = vec![FieldElement::default(); calldata_size];
 

--- a/crates/primitives/starknet/src/transaction/utils.rs
+++ b/crates/primitives/starknet/src/transaction/utils.rs
@@ -1,14 +1,11 @@
-use alloc::vec::Vec;
-
-use crate::execution::types::{EntryPointTypeWrapper, EntryPointWrapper};
-
 #[cfg(feature = "std")]
 mod reexport_std_types {
+    use alloc::vec::Vec;
     use std::collections::HashMap;
 
     use starknet_core::types::{LegacyContractEntryPoint, LegacyEntryPointsByType};
 
-    use super::*;
+    use crate::execution::types::{EntryPointTypeWrapper, EntryPointWrapper};
     /// Returns a [HashMap<EntryPointTypeWrapper, Vec<EntryPointWrapper>>] from
     /// [LegacyEntryPointsByType]
     pub fn to_hash_map_entrypoints(


### PR DESCRIPTION


# Current behaviour

using declare_v2, the sierra program is not used


## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- the sierra program is now stored in the runtime
- it is returned when calling the get_class rpc method

## Does this introduce a breaking change?

No

