### PR TITLE
added `is_query` to handle estimate fee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,7 +414,7 @@ dependencies = [
  "num-traits 0.2.15",
  "rusticata-macros",
  "thiserror",
- "time 0.3.22",
+ "time 0.3.23",
 ]
 
 [[package]]
@@ -421,7 +430,7 @@ dependencies = [
  "num-traits 0.2.15",
  "rusticata-macros",
  "thiserror",
- "time 0.3.22",
+ "time 0.3.23",
 ]
 
 [[package]]
@@ -467,9 +476,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-channel"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -490,7 +499,7 @@ dependencies = [
  "log",
  "parking",
  "polling",
- "rustix 0.37.20",
+ "rustix 0.37.23",
  "slab",
  "socket2 0.4.9",
  "waker-fn",
@@ -518,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.69"
+version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2d0f03b3640e3a630367e40c468cb7f309529c708ed1d88597047b0e7c6ef7"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -537,7 +546,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.9",
+ "pin-project-lite 0.2.10",
 ]
 
 [[package]]
@@ -565,16 +574,16 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
- "addr2line",
+ "addr2line 0.20.0",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.6.2",
- "object",
+ "miniz_oxide",
+ "object 0.31.1",
  "rustc-demangle",
 ]
 
@@ -673,7 +682,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "prettyplease 0.2.9",
+ "prettyplease 0.2.10",
  "proc-macro2",
  "quote",
  "regex",
@@ -738,7 +747,7 @@ checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.4",
- "constant_time_eq",
+ "constant_time_eq 0.2.6",
 ]
 
 [[package]]
@@ -749,20 +758,20 @@ checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.4",
- "constant_time_eq",
+ "constant_time_eq 0.2.6",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729b71f35bd3fa1a4c86b85d32c8b9069ea7fe14f7a53cfabb65f62d4265b888"
+checksum = "199c42ab6972d92c9f8995f086273d25c42fc0f7b2a1fcefba465c1352d25ba5"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.4",
  "cc",
  "cfg-if",
- "constant_time_eq",
+ "constant_time_eq 0.3.0",
 ]
 
 [[package]]
@@ -823,12 +832,12 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 [[package]]
 name = "blockifier"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/blockifier?branch=no_std-support#15c81976e72f76ab7b5b19e68b597f9ae583dcd8"
+source = "git+https://github.com/apoorvsadana/blockifier?branch=dev/query_tx_version#929abf006fb46db55caf877bf88550a89e9984e7"
 dependencies = [
- "cairo-felt",
- "cairo-lang-casm",
- "cairo-lang-casm-contract-class",
- "cairo-lang-utils",
+ "cairo-felt 0.6.0 (git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version)",
+ "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-casm-contract-class 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "cairo-lang-vm-utils",
  "cairo-vm",
  "derive_more",
@@ -847,7 +856,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "starknet-crypto 0.5.1",
+ "starknet-crypto",
  "starknet_api",
  "strum",
  "strum_macros",
@@ -874,9 +883,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
  "serde",
@@ -941,7 +950,7 @@ dependencies = [
 [[package]]
 name = "cairo-felt"
 version = "0.6.0"
-source = "git+https://github.com/keep-starknet-strange/cairo-rs?branch=no_std-support-with-cairo-1#3f406f4a335fd3a0bf22237e493be5a9947efa7d"
+source = "git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version#d3e99729afc5c586ee88b68033908146d6361177"
 dependencies = [
  "lazy_static",
  "num-bigint",
@@ -952,11 +961,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-felt"
+version = "0.6.0"
+source = "git+https://github.com/keep-starknet-strange/cairo-rs.git?branch=no_std-support-with-cairo-1#3f406f4a335fd3a0bf22237e493be5a9947efa7d"
+dependencies = [
+ "lazy_static",
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.15",
+ "serde",
+]
+
+[[package]]
+name = "cairo-lang-casm"
+version = "2.0.0-rc2"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+dependencies = [
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "hashbrown 0.14.0",
+ "indoc",
+ "num-bigint",
+ "num-traits 0.2.15",
+ "parity-scale-codec",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
 name = "cairo-lang-casm"
 version = "2.0.0-rc2"
 source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support)",
  "hashbrown 0.14.0",
  "indoc",
  "num-bigint",
@@ -969,10 +1005,21 @@ dependencies = [
 [[package]]
 name = "cairo-lang-casm-contract-class"
 version = "2.0.0-rc2"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+dependencies = [
+ "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "num-bigint",
+ "serde",
+]
+
+[[package]]
+name = "cairo-lang-casm-contract-class"
+version = "2.0.0-rc2"
 source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
- "cairo-lang-casm",
- "cairo-lang-utils",
+ "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support)",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support)",
  "num-bigint",
  "serde",
 ]
@@ -980,7 +1027,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-compiler"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -994,7 +1041,7 @@ dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-sierra-generator",
  "cairo-lang-syntax",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "log",
  "salsa",
  "smol_str",
@@ -1004,22 +1051,22 @@ dependencies = [
 [[package]]
 name = "cairo-lang-debug"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
  "cairo-lang-parser",
  "cairo-lang-syntax",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "indexmap 2.0.0",
  "itertools",
  "salsa",
@@ -1029,10 +1076,10 @@ dependencies = [
 [[package]]
 name = "cairo-lang-diagnostics"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "cairo-lang-filesystem",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "itertools",
  "salsa",
 ]
@@ -1040,9 +1087,9 @@ dependencies = [
 [[package]]
 name = "cairo-lang-eq-solver"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "good_lp",
  "indexmap 2.0.0",
  "itertools",
@@ -1051,10 +1098,10 @@ dependencies = [
 [[package]]
 name = "cairo-lang-filesystem"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "cairo-lang-debug",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "path-clean",
  "salsa",
  "serde",
@@ -1064,7 +1111,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-lowering"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1074,7 +1121,7 @@ dependencies = [
  "cairo-lang-proc-macros",
  "cairo-lang-semantic",
  "cairo-lang-syntax",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "id-arena",
  "indexmap 2.0.0",
  "itertools",
@@ -1088,13 +1135,13 @@ dependencies = [
 [[package]]
 name = "cairo-lang-parser"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
  "cairo-lang-syntax",
  "cairo-lang-syntax-codegen",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "colored",
  "itertools",
  "log",
@@ -1108,7 +1155,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-plugins"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -1116,7 +1163,7 @@ dependencies = [
  "cairo-lang-parser",
  "cairo-lang-semantic",
  "cairo-lang-syntax",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "indoc",
  "itertools",
  "num-bigint",
@@ -1127,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-proc-macros"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -1137,10 +1184,10 @@ dependencies = [
 [[package]]
 name = "cairo-lang-project"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "cairo-lang-filesystem",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "serde",
  "smol_str",
  "thiserror",
@@ -1150,7 +1197,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-semantic"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1159,7 +1206,7 @@ dependencies = [
  "cairo-lang-parser",
  "cairo-lang-proc-macros",
  "cairo-lang-syntax",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "id-arena",
  "itertools",
  "log",
@@ -1172,9 +1219,9 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "const-fnv1a-hash",
  "convert_case",
  "derivative",
@@ -1194,12 +1241,12 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-ap-change"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "itertools",
  "thiserror",
 ]
@@ -1207,12 +1254,12 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-gas"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "itertools",
  "thiserror",
 ]
@@ -1220,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-generator"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1233,7 +1280,7 @@ dependencies = [
  "cairo-lang-semantic",
  "cairo-lang-sierra",
  "cairo-lang-syntax",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "id-arena",
  "indexmap 2.0.0",
  "itertools",
@@ -1245,16 +1292,16 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-to-casm"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "assert_matches",
- "cairo-felt",
- "cairo-lang-casm",
+ "cairo-felt 0.6.0 (git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version)",
+ "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "cairo-lang-sierra",
  "cairo-lang-sierra-ap-change",
  "cairo-lang-sierra-gas",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "indoc",
  "itertools",
  "log",
@@ -1266,21 +1313,21 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-type-size"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "cairo-lang-sierra",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
 ]
 
 [[package]]
 name = "cairo-lang-starknet"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "anyhow",
- "cairo-felt",
- "cairo-lang-casm",
- "cairo-lang-casm-contract-class",
+ "cairo-felt 0.6.0 (git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version)",
+ "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-casm-contract-class 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "cairo-lang-compiler",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -1295,7 +1342,7 @@ dependencies = [
  "cairo-lang-sierra-generator",
  "cairo-lang-sierra-to-casm",
  "cairo-lang-syntax",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "convert_case",
  "genco",
  "indoc",
@@ -1315,11 +1362,11 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "num-bigint",
  "num-traits 0.2.15",
  "salsa",
@@ -1331,7 +1378,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax-codegen"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "genco",
  "xshell",
@@ -1340,9 +1387,25 @@ dependencies = [
 [[package]]
 name = "cairo-lang-utils"
 version = "2.0.0-rc2"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+dependencies = [
+ "cairo-felt 0.6.0 (git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version)",
+ "hashbrown 0.14.0",
+ "indexmap 2.0.0",
+ "itertools",
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.15",
+ "parity-scale-codec",
+ "serde",
+]
+
+[[package]]
+name = "cairo-lang-utils"
+version = "2.0.0-rc2"
 source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
- "cairo-felt",
+ "cairo-felt 0.6.0 (git+https://github.com/keep-starknet-strange/cairo-rs.git?branch=no_std-support-with-cairo-1)",
  "hashbrown 0.14.0",
  "indexmap 2.0.0",
  "itertools",
@@ -1356,13 +1419,13 @@ dependencies = [
 [[package]]
 name = "cairo-lang-vm-utils"
 version = "2.0.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
+source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
 dependencies = [
  "ark-ff",
  "ark-std 0.3.0",
- "cairo-felt",
- "cairo-lang-casm",
- "cairo-lang-utils",
+ "cairo-felt 0.6.0 (git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version)",
+ "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "cairo-vm",
  "hashbrown 0.14.0",
  "num-bigint",
@@ -1373,7 +1436,7 @@ dependencies = [
 [[package]]
 name = "cairo-take_until_unbalanced"
 version = "0.29.0"
-source = "git+https://github.com/keep-starknet-strange/cairo-rs?branch=no_std-support-with-cairo-1#3f406f4a335fd3a0bf22237e493be5a9947efa7d"
+source = "git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version#d3e99729afc5c586ee88b68033908146d6361177"
 dependencies = [
  "nom",
 ]
@@ -1381,16 +1444,16 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "0.6.0"
-source = "git+https://github.com/keep-starknet-strange/cairo-rs?branch=no_std-support-with-cairo-1#3f406f4a335fd3a0bf22237e493be5a9947efa7d"
+source = "git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version#d3e99729afc5c586ee88b68033908146d6361177"
 dependencies = [
  "anyhow",
  "ark-ff",
  "ark-std 0.3.0",
  "bincode 2.0.0-rc.2",
  "bitvec",
- "cairo-felt",
- "cairo-lang-casm",
- "cairo-lang-casm-contract-class",
+ "cairo-felt 0.6.0 (git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version)",
+ "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-casm-contract-class 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "cairo-take_until_unbalanced",
  "generic-array 0.14.7",
  "hashbrown 0.13.2",
@@ -1410,7 +1473,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.7",
  "sha3",
- "starknet-crypto 0.5.1",
+ "starknet-crypto",
  "thiserror",
  "thiserror-no-std",
 ]
@@ -1658,13 +1721,13 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
-version = "2.0.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
 dependencies = [
- "atty",
+ "is-terminal",
  "lazy_static",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1708,15 +1771,21 @@ checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
 
 [[package]]
 name = "const-oid"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
 name = "constant_time_eq"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "convert_case"
@@ -1763,9 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -2056,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.97"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88abab2f5abbe4c56e8f1fb431b784d710b709888f35755a160e62e33fe38e8"
+checksum = "e928d50d5858b744d1ea920b790641129c347a770d1530c3a85b77705a5ee031"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -2068,9 +2137,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.97"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0c11acd0e63bae27dcd2afced407063312771212b7a823b4fd72d633be30fb"
+checksum = "8332ba63f8a8040ca479de693150129067304a3496674477fff6d0c372cc34ae"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -2083,15 +2152,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.97"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3816ed957c008ccd4728485511e3d9aaf7db419aa321e3d2c5a2f3411e36c8"
+checksum = "5966a5a87b6e9bb342f5fab7170a93c77096efe199872afffc4b477cfeb86957"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.97"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26acccf6f445af85ea056362561a24ef56cdc15fcc685f03aec50b9c702cb6d"
+checksum = "81b2dab6991c7ab1572fea8cb049db819b1aeea1e2dac74c0869f244d9f21a7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2207,9 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
+checksum = "0c7ed52955ce76b1554f509074bb357d3fb8ac9b51288a65a3fd480d1dfba946"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -2425,9 +2494,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dtoa"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65d09067bfacaa79114679b279d7f5885b53295b1e2cfb4e79c8e4bd3d633169"
+checksum = "519b83cd10f5f6e969625a409f735182bea5558cd8b64c655806ceaae36f1999"
 
 [[package]]
 name = "dyn-clonable"
@@ -2474,7 +2543,7 @@ version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
 dependencies = [
- "der 0.7.6",
+ "der 0.7.7",
  "digest 0.10.7",
  "elliptic-curve 0.13.5",
  "rfc6979 0.4.0",
@@ -2614,9 +2683,9 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -2787,7 +2856,7 @@ checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
  "libz-sys",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -3095,11 +3164,11 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7672706608ecb74ab2e055c68327ffc25ae4cac1e12349204fd5fb0f3487cce2"
+checksum = "2eeb4ed9e12f43b7fa0baae3f9cdda28352770132ef2e09a23760c29cae8bd47"
 dependencies = [
- "rustix 0.37.20",
+ "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
 
@@ -3169,7 +3238,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.9",
+ "pin-project-lite 0.2.10",
  "waker-fn",
 ]
 
@@ -3226,7 +3295,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.9",
+ "pin-project-lite 0.2.10",
  "pin-utils",
  "slab",
 ]
@@ -3502,18 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -3606,7 +3666,7 @@ checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
  "http",
- "pin-project-lite 0.2.9",
+ "pin-project-lite 0.2.10",
 ]
 
 [[package]]
@@ -3649,7 +3709,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite 0.2.9",
+ "pin-project-lite 0.2.10",
  "socket2 0.4.9",
  "tokio",
  "tower-service",
@@ -3833,9 +3893,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2cb48b81b1dc9f39676bf99f5499babfec7cd8fe14307f7b3d747208fb5690"
+checksum = "761cde40c27e2a9877f8c928fd248b7eec9dd48623dd514b256858ca593fbba7"
 
 [[package]]
 name = "inout"
@@ -3889,7 +3949,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -3920,13 +3980,12 @@ checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix 0.37.20",
+ "hermit-abi 0.3.2",
+ "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
 
@@ -3941,9 +4000,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "jobserver"
@@ -4350,7 +4409,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "lru 0.10.0",
+ "lru 0.10.1",
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
@@ -4737,9 +4796,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
 dependencies = [
  "cc",
 ]
@@ -4761,9 +4820,9 @@ dependencies = [
 
 [[package]]
 name = "linregress"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475015a7f8f017edb28d2e69813be23500ad4b32cfe3421c4148efc97324ee52"
+checksum = "4de0b5f52a9f84544d268f5fabb71b38962d6aa3c6600b8bcd27d44ccf9c9c45"
 dependencies = [
  "nalgebra",
 ]
@@ -4779,6 +4838,12 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
@@ -4816,9 +4881,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
+checksum = "718e8fae447df0c7e1ba7f5189829e63fd536945c8988d61444c19039f16b670"
 dependencies = [
  "hashbrown 0.13.2",
 ]
@@ -4972,7 +5037,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -5099,10 +5164,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "blockifier",
- "cairo-lang-casm",
- "cairo-lang-casm-contract-class",
+ "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-casm-contract-class 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "cairo-lang-starknet",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "cairo-vm",
  "flate2",
  "frame-support",
@@ -5191,7 +5256,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
 dependencies = [
- "rustix 0.37.20",
+ "rustix 0.37.23",
 ]
 
 [[package]]
@@ -5275,15 +5340,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
@@ -5346,8 +5402,8 @@ dependencies = [
  "async-trait",
  "bitvec",
  "blockifier",
- "cairo-lang-casm",
- "cairo-lang-casm-contract-class",
+ "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-casm-contract-class 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
  "cairo-vm",
  "derive_more",
  "flate2",
@@ -5365,7 +5421,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "starknet-core",
- "starknet-crypto 0.6.0",
+ "starknet-crypto",
  "starknet-ff",
  "starknet_api",
  "thiserror-no-std",
@@ -5468,9 +5524,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d47bba83f9e2006d117a9a33af1524e655516b8919caac694427a6fb1e511"
+checksum = "307ed9b18cc2423f29e83f84fd23a8e73628727990181f18641a8b5dc2ab1caa"
 dependencies = [
  "approx",
  "matrixmultiply 0.3.7",
@@ -5484,9 +5540,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra-macros"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d232c68884c0c99810a5a4d333ef7e47689cfd0edc85efc9e54e1e6bf5212766"
+checksum = "91761aed67d03ad966ef783ae962ef9bbaca728d2dd7ceb7939ec110fffad998"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5732,11 +5788,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 
@@ -5755,6 +5811,15 @@ dependencies = [
  "crc32fast",
  "hashbrown 0.13.2",
  "indexmap 1.9.3",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
  "memchr",
 ]
 
@@ -6054,7 +6119,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "starknet-core",
- "starknet-crypto 0.6.0",
+ "starknet-crypto",
  "starknet_api",
  "test-case",
 ]
@@ -6114,9 +6179,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.1"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2287753623c76f953acd29d15d8100bcab84d29db78fb6f352adb3c53e83b967"
+checksum = "756d439303e94fae44f288ba881ad29670c65b0c4b0e05674ca81061bb65f2c5"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -6129,9 +6194,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.1"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b6937b5e67bfba3351b87b040d48352a2fcb6ad72f81855412ce97b45c8f110"
+checksum = "9d884d78fcf214d70b1e239fcd1c6e5e95aa3be1881918da2e488cc946c7a476"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6202,7 +6267,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -6213,9 +6278,9 @@ checksum = "7924d1d0ad836f665c9065e26d016c673ece3993f30d340068b16f282afc1156"
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
 
 [[package]]
 name = "path-clean"
@@ -6378,18 +6443,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6404,9 +6469,9 @@ checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -6430,7 +6495,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.6",
+ "der 0.7.7",
  "spki 0.7.2",
 ]
 
@@ -6464,7 +6529,7 @@ dependencies = [
  "concurrent-queue",
  "libc",
  "log",
- "pin-project-lite 0.2.9",
+ "pin-project-lite 0.2.10",
  "windows-sys 0.48.0",
 ]
 
@@ -6505,9 +6570,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
+checksum = "d220334a184db82b31b83f5ff093e3315280fb2b6bbc032022b2304a509aab7a"
 
 [[package]]
 name = "ppv-lite86"
@@ -6573,9 +6638,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
+checksum = "92139198957b410250d43fad93e630d956499a625c527eda65175c8680f83387"
 dependencies = [
  "proc-macro2",
  "syn 2.0.25",
@@ -6641,9 +6706,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -6807,9 +6872,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -6936,7 +7001,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.22",
+ "time 0.3.23",
  "x509-parser 0.13.2",
  "yasna",
 ]
@@ -6949,7 +7014,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.22",
+ "time 0.3.23",
  "yasna",
 ]
 
@@ -6984,18 +7049,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43faa91b1c8b36841ee70e97188a869d37ae21759da6846d4be66de5bf7b12c"
+checksum = "1641819477c319ef452a075ac34a4be92eb9ba09f6841f62d594d50fdcf0bf6b"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
+checksum = "68bf53dad9b6086826722cdc99140793afd9f62faa14a1ad07eb4f955e7a7216"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7016,13 +7081,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick 1.0.2",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.3.2",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -7035,6 +7101,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
+dependencies = [
+ "aho-corasick 1.0.2",
+ "memchr",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7042,9 +7119,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "relative-path"
@@ -7233,9 +7310,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.14"
+version = "0.36.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e4d67015953998ad0eb82887a0eb0129e18a7e2f3b7b0f6c422fddcd503d62"
+checksum = "c37f1bd5ef1b5422177b7646cba67430579cfe2ace80f284fee876bca52ad941"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -7247,15 +7324,28 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.3",
  "windows-sys 0.48.0",
 ]
 
@@ -7307,9 +7397,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
 
 [[package]]
 name = "rw-stream-sink"
@@ -7324,9 +7414,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "safe_arch"
@@ -7769,7 +7859,7 @@ dependencies = [
  "libc",
  "log",
  "once_cell",
- "rustix 0.36.14",
+ "rustix 0.36.15",
  "sc-allocator",
  "sc-executor-common",
  "sp-runtime-interface",
@@ -8402,11 +8492,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8446,9 +8536,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+checksum = "764cad9e7e1ca5fe15b552859ff5d96a314e6ed2934f2260168cd5dfa5891409"
 
 [[package]]
 name = "sct"
@@ -8503,7 +8593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
 dependencies = [
  "base16ct 0.2.0",
- "der 0.7.6",
+ "der 0.7.7",
  "generic-array 0.14.7",
  "pkcs8 0.10.2",
  "subtle",
@@ -8595,9 +8685,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
+checksum = "5a16be4fe5320ade08736447e3198294a5ea9a6d44dde6f35f0a5e06859c427a"
 dependencies = [
  "serde",
 ]
@@ -8657,7 +8747,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.22",
+ "time 0.3.23",
 ]
 
 [[package]]
@@ -8822,9 +8912,9 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "smol_str"
@@ -9623,7 +9713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
- "der 0.7.6",
+ "der 0.7.7",
 ]
 
 [[package]]
@@ -9639,9 +9729,9 @@ dependencies = [
 
 [[package]]
 name = "ss58-registry"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47a8ad42e5fc72d5b1eb104a5546937eaf39843499948bb666d6e93c62423b"
+checksum = "bfc443bad666016e012538782d9e3006213a7db43e9fb1dda91657dc06a6fa08"
 dependencies = [
  "Inflector",
  "num-format",
@@ -9661,8 +9751,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "starknet-core"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e758b2966915b7ef9457e5d32e9c2017ec1e391996999cd6821db7e6b8f169"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?branch=dev/query_tx_version#73151f51215acb26b2cdc79336f80bbee4fad3f4"
 dependencies = [
  "base64 0.21.2",
  "flate2",
@@ -9672,35 +9761,14 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with",
  "sha3",
- "starknet-crypto 0.6.0",
+ "starknet-crypto",
  "starknet-ff",
-]
-
-[[package]]
-name = "starknet-crypto"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693e6362f150f9276e429a910481fb7f3bcb8d6aa643743f587cfece0b374874"
-dependencies = [
- "crypto-bigint 0.5.2",
- "hex",
- "hmac 0.12.1",
- "num-bigint",
- "num-integer",
- "num-traits 0.2.15",
- "rfc6979 0.4.0",
- "sha2 0.10.7",
- "starknet-crypto-codegen",
- "starknet-curve 0.3.0",
- "starknet-ff",
- "zeroize",
 ]
 
 [[package]]
 name = "starknet-crypto"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dbb308033b5c60c5677645f7ba3b012b4e3e81f773480d27fb5f342d50621e6"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?branch=dev/query_tx_version#73151f51215acb26b2cdc79336f80bbee4fad3f4"
 dependencies = [
  "crypto-bigint 0.5.2",
  "hex",
@@ -9711,7 +9779,7 @@ dependencies = [
  "rfc6979 0.4.0",
  "sha2 0.10.7",
  "starknet-crypto-codegen",
- "starknet-curve 0.4.0",
+ "starknet-curve",
  "starknet-ff",
  "zeroize",
 ]
@@ -9719,28 +9787,17 @@ dependencies = [
 [[package]]
 name = "starknet-crypto-codegen"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6527b845423542c8a16e060ea1bc43f67229848e7cd4c4d80be994a84220ce"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?branch=dev/query_tx_version#73151f51215acb26b2cdc79336f80bbee4fad3f4"
 dependencies = [
- "starknet-curve 0.4.0",
+ "starknet-curve",
  "starknet-ff",
  "syn 2.0.25",
 ]
 
 [[package]]
 name = "starknet-curve"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252610baff59e4c4332ce3569f7469c5d3f9b415a2240d698fb238b2b4fc0942"
-dependencies = [
- "starknet-ff",
-]
-
-[[package]]
-name = "starknet-curve"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68a0d87ae56572abf83ddbfd44259a7c90dbeeee1629a1ffe223e7f9a8f3052"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?branch=dev/query_tx_version#73151f51215acb26b2cdc79336f80bbee4fad3f4"
 dependencies = [
  "starknet-ff",
 ]
@@ -9748,8 +9805,7 @@ dependencies = [
 [[package]]
 name = "starknet-ff"
 version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2cb1d9c0a50380cddab99cb202c6bfb3332728a2769bd0ca2ee80b0b390dd4"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?branch=dev/query_tx_version#73151f51215acb26b2cdc79336f80bbee4fad3f4"
 dependencies = [
  "ark-ff",
  "bigdecimal",
@@ -9762,9 +9818,9 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/starknet-api?branch=no_std-support#6a48e7c8636685b80515c6ab666c1ae9d01278a2"
+source = "git+https://github.com/apoorvsadana/starknet-api-madara?branch=dev/query_tx_version#b9984b0a0c9f5419edb009c7f90f46c9c492ab11"
 dependencies = [
- "cairo-lang-casm-contract-class",
+ "cairo-lang-casm-contract-class 2.0.0-rc2 (git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support)",
  "derive_more",
  "hashbrown 0.13.2",
  "hex",
@@ -9772,9 +9828,10 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "primitive-types",
+ "scale-info",
  "serde",
  "serde_json",
- "starknet-crypto 0.5.1",
+ "starknet-crypto",
  "thiserror-no-std",
 ]
 
@@ -10043,7 +10100,7 @@ dependencies = [
  "sp-maybe-compressed-blob",
  "strum",
  "tempfile",
- "toml 0.7.5",
+ "toml 0.7.6",
  "walkdir",
  "wasm-opt",
 ]
@@ -10126,9 +10183,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.8"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1c7f239eb94671427157bd93b3694320f3668d4e1eff08c7285366fd777fac"
+checksum = "df8e77cb757a61f51b947ec4a7e3646efd825b73561db1c232a8ccb639e611a0"
 
 [[package]]
 name = "tempfile"
@@ -10140,7 +10197,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.20",
+ "rustix 0.37.23",
  "windows-sys 0.48.0",
 ]
 
@@ -10207,18 +10264,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10293,9 +10350,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "itoa",
  "serde",
@@ -10311,9 +10368,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
 dependencies = [
  "time-core",
 ]
@@ -10373,9 +10430,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.0"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374442f06ee49c3a28a8fc9f01a2596fed7559c6b99b31279c3261778e77d84f"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
  "backtrace",
@@ -10384,7 +10441,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "parking_lot 0.12.1",
- "pin-project-lite 0.2.9",
+ "pin-project-lite 0.2.10",
  "signal-hook-registry",
  "socket2 0.4.9",
  "tokio-macros",
@@ -10431,7 +10488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.9",
+ "pin-project-lite 0.2.10",
  "tokio",
  "tokio-util",
 ]
@@ -10446,7 +10503,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
- "pin-project-lite 0.2.9",
+ "pin-project-lite 0.2.10",
  "tokio",
  "tracing",
 ]
@@ -10471,9 +10528,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebafdf5ad1220cb59e7d17cf4d2c72015297b75b19a10472f99b89225089240"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -10492,9 +10549,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.11"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
+checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -10527,7 +10584,7 @@ dependencies = [
  "http",
  "http-body",
  "http-range-header",
- "pin-project-lite 0.2.9",
+ "pin-project-lite 0.2.10",
  "tower-layer",
  "tower-service",
 ]
@@ -10552,7 +10609,7 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
- "pin-project-lite 0.2.9",
+ "pin-project-lite 0.2.10",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -10788,9 +10845,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "uint"
@@ -10821,9 +10878,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-normalization"
@@ -11177,7 +11234,7 @@ dependencies = [
  "indexmap 1.9.3",
  "libc",
  "log",
- "object",
+ "object 0.30.4",
  "once_cell",
  "paste",
  "psm",
@@ -11214,7 +11271,7 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix 0.36.14",
+ "rustix 0.36.15",
  "serde",
  "sha2 0.10.7",
  "toml 0.5.11",
@@ -11236,7 +11293,7 @@ dependencies = [
  "cranelift-wasm",
  "gimli",
  "log",
- "object",
+ "object 0.30.4",
  "target-lexicon",
  "thiserror",
  "wasmparser",
@@ -11254,7 +11311,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-native",
  "gimli",
- "object",
+ "object 0.30.4",
  "target-lexicon",
  "wasmtime-environ",
 ]
@@ -11270,7 +11327,7 @@ dependencies = [
  "gimli",
  "indexmap 1.9.3",
  "log",
- "object",
+ "object 0.30.4",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -11284,14 +11341,14 @@ version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de48df552cfca1c9b750002d3e07b45772dd033b0b206d5c0968496abf31244"
 dependencies = [
- "addr2line",
+ "addr2line 0.19.0",
  "anyhow",
  "bincode 1.3.3",
  "cfg-if",
  "cpp_demangle",
  "gimli",
  "log",
- "object",
+ "object 0.30.4",
  "rustc-demangle",
  "serde",
  "target-lexicon",
@@ -11308,9 +11365,9 @@ version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e0554b84c15a27d76281d06838aed94e13a77d7bf604bbbaf548aa20eb93846"
 dependencies = [
- "object",
+ "object 0.30.4",
  "once_cell",
- "rustix 0.36.14",
+ "rustix 0.36.15",
 ]
 
 [[package]]
@@ -11341,7 +11398,7 @@ dependencies = [
  "memoffset 0.8.0",
  "paste",
  "rand 0.8.5",
- "rustix 0.36.14",
+ "rustix 0.36.15",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-jit-debug",
@@ -11425,7 +11482,7 @@ dependencies = [
  "sha2 0.10.7",
  "stun",
  "thiserror",
- "time 0.3.22",
+ "time 0.3.23",
  "tokio",
  "turn",
  "url",
@@ -11685,22 +11742,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -11718,7 +11760,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -11738,9 +11780,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",
@@ -11867,9 +11909,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
+checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
 dependencies = [
  "memchr",
 ]
@@ -11931,7 +11973,7 @@ dependencies = [
  "ring",
  "rusticata-macros",
  "thiserror",
- "time 0.3.22",
+ "time 0.3.23",
 ]
 
 [[package]]
@@ -11949,23 +11991,23 @@ dependencies = [
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
- "time 0.3.22",
+ "time 0.3.23",
 ]
 
 [[package]]
 name = "xshell"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962c039b3a7b16cf4e9a4248397c6585c07547412e7d6a6e035389a802dcfe90"
+checksum = "ce2107fe03e558353b4c71ad7626d58ed82efaf56c54134228608893c77023ad"
 dependencies = [
  "xshell-macros",
 ]
 
 [[package]]
 name = "xshell-macros"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbabb1cbd15a1d6d12d9ed6b35cc6777d4af87ab3ba155ea37215f20beab80c"
+checksum = "7e2c411759b501fb9501aac2b1b2d287a6e93e5bdcf13c25306b23e1b716dd0e"
 
 [[package]]
 name = "yamux"
@@ -11993,7 +12035,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.22",
+ "time 0.3.23",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,12 +832,12 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 [[package]]
 name = "blockifier"
 version = "0.1.0"
-source = "git+https://github.com/apoorvsadana/blockifier?branch=dev/query_tx_version#929abf006fb46db55caf877bf88550a89e9984e7"
+source = "git+https://github.com/keep-starknet-strange/blockifier?branch=no_std-support#15c81976e72f76ab7b5b19e68b597f9ae583dcd8"
 dependencies = [
- "cairo-felt 0.6.0 (git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version)",
- "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
- "cairo-lang-casm-contract-class 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-felt",
+ "cairo-lang-casm",
+ "cairo-lang-casm-contract-class",
+ "cairo-lang-utils",
  "cairo-lang-vm-utils",
  "cairo-vm",
  "derive_more",
@@ -856,7 +856,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "starknet-crypto",
+ "starknet-crypto 0.5.1",
  "starknet_api",
  "strum",
  "strum_macros",
@@ -950,40 +950,13 @@ dependencies = [
 [[package]]
 name = "cairo-felt"
 version = "0.6.0"
-source = "git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version#d3e99729afc5c586ee88b68033908146d6361177"
+source = "git+https://github.com/keep-starknet-strange/cairo-rs?branch=no_std-support-with-cairo-1#3f406f4a335fd3a0bf22237e493be5a9947efa7d"
 dependencies = [
  "lazy_static",
  "num-bigint",
  "num-integer",
  "num-traits 0.2.15",
  "parity-scale-codec",
- "serde",
-]
-
-[[package]]
-name = "cairo-felt"
-version = "0.6.0"
-source = "git+https://github.com/keep-starknet-strange/cairo-rs.git?branch=no_std-support-with-cairo-1#3f406f4a335fd3a0bf22237e493be5a9947efa7d"
-dependencies = [
- "lazy_static",
- "num-bigint",
- "num-integer",
- "num-traits 0.2.15",
- "serde",
-]
-
-[[package]]
-name = "cairo-lang-casm"
-version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
-dependencies = [
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
- "hashbrown 0.14.0",
- "indoc",
- "num-bigint",
- "num-traits 0.2.15",
- "parity-scale-codec",
- "parity-scale-codec-derive",
  "serde",
 ]
 
@@ -992,7 +965,7 @@ name = "cairo-lang-casm"
 version = "2.0.0-rc2"
 source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support)",
+ "cairo-lang-utils",
  "hashbrown 0.14.0",
  "indoc",
  "num-bigint",
@@ -1005,21 +978,10 @@ dependencies = [
 [[package]]
 name = "cairo-lang-casm-contract-class"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
-dependencies = [
- "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
- "num-bigint",
- "serde",
-]
-
-[[package]]
-name = "cairo-lang-casm-contract-class"
-version = "2.0.0-rc2"
 source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
- "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support)",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support)",
+ "cairo-lang-casm",
+ "cairo-lang-utils",
  "num-bigint",
  "serde",
 ]
@@ -1027,7 +989,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-compiler"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -1041,7 +1003,7 @@ dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-sierra-generator",
  "cairo-lang-syntax",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "log",
  "salsa",
  "smol_str",
@@ -1051,22 +1013,22 @@ dependencies = [
 [[package]]
 name = "cairo-lang-debug"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
  "cairo-lang-parser",
  "cairo-lang-syntax",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "indexmap 2.0.0",
  "itertools",
  "salsa",
@@ -1076,10 +1038,10 @@ dependencies = [
 [[package]]
 name = "cairo-lang-diagnostics"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "cairo-lang-filesystem",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "itertools",
  "salsa",
 ]
@@ -1087,9 +1049,9 @@ dependencies = [
 [[package]]
 name = "cairo-lang-eq-solver"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "good_lp",
  "indexmap 2.0.0",
  "itertools",
@@ -1098,10 +1060,10 @@ dependencies = [
 [[package]]
 name = "cairo-lang-filesystem"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "cairo-lang-debug",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "path-clean",
  "salsa",
  "serde",
@@ -1111,7 +1073,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-lowering"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1121,7 +1083,7 @@ dependencies = [
  "cairo-lang-proc-macros",
  "cairo-lang-semantic",
  "cairo-lang-syntax",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "id-arena",
  "indexmap 2.0.0",
  "itertools",
@@ -1135,13 +1097,13 @@ dependencies = [
 [[package]]
 name = "cairo-lang-parser"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
  "cairo-lang-syntax",
  "cairo-lang-syntax-codegen",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "colored",
  "itertools",
  "log",
@@ -1155,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-plugins"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -1163,7 +1125,7 @@ dependencies = [
  "cairo-lang-parser",
  "cairo-lang-semantic",
  "cairo-lang-syntax",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "indoc",
  "itertools",
  "num-bigint",
@@ -1174,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-proc-macros"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -1184,10 +1146,10 @@ dependencies = [
 [[package]]
 name = "cairo-lang-project"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "cairo-lang-filesystem",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "serde",
  "smol_str",
  "thiserror",
@@ -1197,7 +1159,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-semantic"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1206,7 +1168,7 @@ dependencies = [
  "cairo-lang-parser",
  "cairo-lang-proc-macros",
  "cairo-lang-syntax",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "id-arena",
  "itertools",
  "log",
@@ -1219,9 +1181,9 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "const-fnv1a-hash",
  "convert_case",
  "derivative",
@@ -1241,12 +1203,12 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-ap-change"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "itertools",
  "thiserror",
 ]
@@ -1254,12 +1216,12 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-gas"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "itertools",
  "thiserror",
 ]
@@ -1267,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-generator"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1280,7 +1242,7 @@ dependencies = [
  "cairo-lang-semantic",
  "cairo-lang-sierra",
  "cairo-lang-syntax",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "id-arena",
  "indexmap 2.0.0",
  "itertools",
@@ -1292,16 +1254,16 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-to-casm"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "assert_matches",
- "cairo-felt 0.6.0 (git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version)",
- "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-felt",
+ "cairo-lang-casm",
  "cairo-lang-sierra",
  "cairo-lang-sierra-ap-change",
  "cairo-lang-sierra-gas",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "indoc",
  "itertools",
  "log",
@@ -1313,21 +1275,21 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-type-size"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "cairo-lang-sierra",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-starknet"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "anyhow",
- "cairo-felt 0.6.0 (git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version)",
- "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
- "cairo-lang-casm-contract-class 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-felt",
+ "cairo-lang-casm",
+ "cairo-lang-casm-contract-class",
  "cairo-lang-compiler",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -1342,7 +1304,7 @@ dependencies = [
  "cairo-lang-sierra-generator",
  "cairo-lang-sierra-to-casm",
  "cairo-lang-syntax",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "convert_case",
  "genco",
  "indoc",
@@ -1362,11 +1324,11 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "num-bigint",
  "num-traits 0.2.15",
  "salsa",
@@ -1378,7 +1340,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax-codegen"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "genco",
  "xshell",
@@ -1387,25 +1349,9 @@ dependencies = [
 [[package]]
 name = "cairo-lang-utils"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
-dependencies = [
- "cairo-felt 0.6.0 (git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version)",
- "hashbrown 0.14.0",
- "indexmap 2.0.0",
- "itertools",
- "num-bigint",
- "num-integer",
- "num-traits 0.2.15",
- "parity-scale-codec",
- "serde",
-]
-
-[[package]]
-name = "cairo-lang-utils"
-version = "2.0.0-rc2"
 source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
- "cairo-felt 0.6.0 (git+https://github.com/keep-starknet-strange/cairo-rs.git?branch=no_std-support-with-cairo-1)",
+ "cairo-felt",
  "hashbrown 0.14.0",
  "indexmap 2.0.0",
  "itertools",
@@ -1419,13 +1365,13 @@ dependencies = [
 [[package]]
 name = "cairo-lang-vm-utils"
 version = "2.0.0-rc2"
-source = "git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version#88987c2f8bfc4817ec615a88ab5302a44cbd5b3e"
+source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support#64ef5864c5b92ee40b46ecb0b6fd854bd790938d"
 dependencies = [
  "ark-ff",
  "ark-std 0.3.0",
- "cairo-felt 0.6.0 (git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version)",
- "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-felt",
+ "cairo-lang-casm",
+ "cairo-lang-utils",
  "cairo-vm",
  "hashbrown 0.14.0",
  "num-bigint",
@@ -1436,7 +1382,7 @@ dependencies = [
 [[package]]
 name = "cairo-take_until_unbalanced"
 version = "0.29.0"
-source = "git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version#d3e99729afc5c586ee88b68033908146d6361177"
+source = "git+https://github.com/keep-starknet-strange/cairo-rs?branch=no_std-support-with-cairo-1#3f406f4a335fd3a0bf22237e493be5a9947efa7d"
 dependencies = [
  "nom",
 ]
@@ -1444,16 +1390,16 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "0.6.0"
-source = "git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version#d3e99729afc5c586ee88b68033908146d6361177"
+source = "git+https://github.com/keep-starknet-strange/cairo-rs?branch=no_std-support-with-cairo-1#3f406f4a335fd3a0bf22237e493be5a9947efa7d"
 dependencies = [
  "anyhow",
  "ark-ff",
  "ark-std 0.3.0",
  "bincode 2.0.0-rc.2",
  "bitvec",
- "cairo-felt 0.6.0 (git+https://github.com/apoorvsadana/cairo-rs?branch=dev/query_tx_version)",
- "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
- "cairo-lang-casm-contract-class 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-felt",
+ "cairo-lang-casm",
+ "cairo-lang-casm-contract-class",
  "cairo-take_until_unbalanced",
  "generic-array 0.14.7",
  "hashbrown 0.13.2",
@@ -1473,7 +1419,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.7",
  "sha3",
- "starknet-crypto",
+ "starknet-crypto 0.5.1",
  "thiserror",
  "thiserror-no-std",
 ]
@@ -5164,10 +5110,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "blockifier",
- "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
- "cairo-lang-casm-contract-class 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-casm",
+ "cairo-lang-casm-contract-class",
  "cairo-lang-starknet",
- "cairo-lang-utils 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-utils",
  "cairo-vm",
  "flate2",
  "frame-support",
@@ -5402,8 +5348,8 @@ dependencies = [
  "async-trait",
  "bitvec",
  "blockifier",
- "cairo-lang-casm 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
- "cairo-lang-casm-contract-class 2.0.0-rc2 (git+https://github.com/apoorvsadana/cairo-madara?branch=dev/query_tx_version)",
+ "cairo-lang-casm",
+ "cairo-lang-casm-contract-class",
  "cairo-vm",
  "derive_more",
  "flate2",
@@ -5421,7 +5367,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "starknet-core",
- "starknet-crypto",
+ "starknet-crypto 0.6.0",
  "starknet-ff",
  "starknet_api",
  "thiserror-no-std",
@@ -6119,7 +6065,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "starknet-core",
- "starknet-crypto",
+ "starknet-crypto 0.6.0",
  "starknet_api",
  "test-case",
 ]
@@ -9750,8 +9696,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starknet-core"
-version = "0.4.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?branch=dev/query_tx_version#73151f51215acb26b2cdc79336f80bbee4fad3f4"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cb0413a47f7820a6e2f1df956f6842c781bbe32356e254e60087032c873d9"
 dependencies = [
  "base64 0.21.2",
  "flate2",
@@ -9761,14 +9708,15 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with",
  "sha3",
- "starknet-crypto",
+ "starknet-crypto 0.6.0",
  "starknet-ff",
 ]
 
 [[package]]
 name = "starknet-crypto"
-version = "0.6.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?branch=dev/query_tx_version#73151f51215acb26b2cdc79336f80bbee4fad3f4"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693e6362f150f9276e429a910481fb7f3bcb8d6aa643743f587cfece0b374874"
 dependencies = [
  "crypto-bigint 0.5.2",
  "hex",
@@ -9779,7 +9727,27 @@ dependencies = [
  "rfc6979 0.4.0",
  "sha2 0.10.7",
  "starknet-crypto-codegen",
- "starknet-curve",
+ "starknet-curve 0.3.0",
+ "starknet-ff",
+ "zeroize",
+]
+
+[[package]]
+name = "starknet-crypto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbb308033b5c60c5677645f7ba3b012b4e3e81f773480d27fb5f342d50621e6"
+dependencies = [
+ "crypto-bigint 0.5.2",
+ "hex",
+ "hmac 0.12.1",
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.15",
+ "rfc6979 0.4.0",
+ "sha2 0.10.7",
+ "starknet-crypto-codegen",
+ "starknet-curve 0.4.0",
  "starknet-ff",
  "zeroize",
 ]
@@ -9787,17 +9755,28 @@ dependencies = [
 [[package]]
 name = "starknet-crypto-codegen"
 version = "0.3.2"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?branch=dev/query_tx_version#73151f51215acb26b2cdc79336f80bbee4fad3f4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af6527b845423542c8a16e060ea1bc43f67229848e7cd4c4d80be994a84220ce"
 dependencies = [
- "starknet-curve",
+ "starknet-curve 0.4.0",
  "starknet-ff",
  "syn 2.0.25",
 ]
 
 [[package]]
 name = "starknet-curve"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252610baff59e4c4332ce3569f7469c5d3f9b415a2240d698fb238b2b4fc0942"
+dependencies = [
+ "starknet-ff",
+]
+
+[[package]]
+name = "starknet-curve"
 version = "0.4.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?branch=dev/query_tx_version#73151f51215acb26b2cdc79336f80bbee4fad3f4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68a0d87ae56572abf83ddbfd44259a7c90dbeeee1629a1ffe223e7f9a8f3052"
 dependencies = [
  "starknet-ff",
 ]
@@ -9805,7 +9784,8 @@ dependencies = [
 [[package]]
 name = "starknet-ff"
 version = "0.3.4"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?branch=dev/query_tx_version#73151f51215acb26b2cdc79336f80bbee4fad3f4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2cb1d9c0a50380cddab99cb202c6bfb3332728a2769bd0ca2ee80b0b390dd4"
 dependencies = [
  "ark-ff",
  "bigdecimal",
@@ -9818,9 +9798,9 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.1.0"
-source = "git+https://github.com/apoorvsadana/starknet-api-madara?branch=dev/query_tx_version#b9984b0a0c9f5419edb009c7f90f46c9c492ab11"
+source = "git+https://github.com/keep-starknet-strange/starknet-api?branch=no_std-support#6a48e7c8636685b80515c6ab666c1ae9d01278a2"
 dependencies = [
- "cairo-lang-casm-contract-class 2.0.0-rc2 (git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support)",
+ "cairo-lang-casm-contract-class",
  "derive_more",
  "hashbrown 0.13.2",
  "hex",
@@ -9828,10 +9808,9 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "primitive-types",
- "scale-info",
  "serde",
  "serde_json",
- "starknet-crypto",
+ "starknet-crypto 0.5.1",
  "thiserror-no-std",
 ]
 
@@ -10833,7 +10812,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,27 +126,28 @@ madara-runtime = { path = "crates/runtime" }
 
 # Starknet dependencies
 # Cairo Virtual Machine
-cairo-vm = { git = "https://github.com/keep-starknet-strange/cairo-rs", branch = "no_std-support-with-cairo-1", default-features = false, features = [
+cairo-vm = { git = "https://github.com/apoorvsadana/cairo-rs", branch = "dev/query_tx_version", default-features = false, features = [
   "cairo-1-hints",
   "parity-scale-codec",
 ] }
-starknet-crypto = { version = "0.6.0", default-features = false }
-starknet-core = { version = "0.4.0", default-features = false }
-starknet-ff = { version = "0.3.4", default-features = false }
+starknet-crypto = { git = "https://github.com/xJonathanLEI/starknet-rs", branch = "dev/query_tx_version", default-features = false }
+starknet-core = { git = "https://github.com/xJonathanLEI/starknet-rs", branch = "dev/query_tx_version", default-features = false }
+starknet-ff = { git = "https://github.com/xJonathanLEI/starknet-rs", branch = "dev/query_tx_version", default-features = false }
 
-blockifier = { git = "https://github.com/keep-starknet-strange/blockifier", branch = "no_std-support", default-features = false, features = [
+blockifier = { git = "https://github.com/apoorvsadana/blockifier", branch = "dev/query_tx_version", default-features = false, features = [
   "parity-scale-codec",
 ] }
-starknet_api = { git = "https://github.com/keep-starknet-strange/starknet-api", branch = "no_std-support", features = [
+starknet_api = { git = "https://github.com/apoorvsadana/starknet-api-madara", branch = "dev/query_tx_version", features = [
   "testing",
   "parity-scale-codec",
+  "scale-info",
 ], default-features = false }
 
 # Cairo lang
-cairo-lang-starknet = { git = "https://github.com/keep-starknet-strange/cairo.git", branch = "no_std-support", default-features = false }
-cairo-lang-casm-contract-class = { git = "https://github.com/keep-starknet-strange/cairo.git", branch = "no_std-support", default-features = false }
-cairo-lang-casm = { git = "https://github.com/keep-starknet-strange/cairo.git", branch = "no_std-support", default-features = false }
-cairo-lang-utils = { git = "https://github.com/keep-starknet-strange/cairo.git", branch = "no_std-support", default-features = false }
+cairo-lang-starknet = { git = "https://github.com/apoorvsadana/cairo-madara", branch = "dev/query_tx_version", default-features = false }
+cairo-lang-casm-contract-class = { git = "https://github.com/apoorvsadana/cairo-madara", branch = "dev/query_tx_version", default-features = false }
+cairo-lang-casm = { git = "https://github.com/apoorvsadana/cairo-madara", branch = "dev/query_tx_version", default-features = false }
+cairo-lang-utils = { git = "https://github.com/apoorvsadana/cairo-madara", branch = "dev/query_tx_version", default-features = false }
 
 # Other third party dependencies
 anyhow = "1.0.71"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,28 +126,27 @@ madara-runtime = { path = "crates/runtime" }
 
 # Starknet dependencies
 # Cairo Virtual Machine
-cairo-vm = { git = "https://github.com/apoorvsadana/cairo-rs", branch = "dev/query_tx_version", default-features = false, features = [
+cairo-vm = { git = "https://github.com/keep-starknet-strange/cairo-rs", branch = "no_std-support-with-cairo-1", default-features = false, features = [
   "cairo-1-hints",
   "parity-scale-codec",
 ] }
-starknet-crypto = { git = "https://github.com/xJonathanLEI/starknet-rs", branch = "dev/query_tx_version", default-features = false }
-starknet-core = { git = "https://github.com/xJonathanLEI/starknet-rs", branch = "dev/query_tx_version", default-features = false }
-starknet-ff = { git = "https://github.com/xJonathanLEI/starknet-rs", branch = "dev/query_tx_version", default-features = false }
+starknet-crypto = { version = "0.6.0", default-features = false }
+starknet-core = { version = "0.5.0", default-features = false }
+starknet-ff = { version = "0.3.4", default-features = false }
 
-blockifier = { git = "https://github.com/apoorvsadana/blockifier", branch = "dev/query_tx_version", default-features = false, features = [
+blockifier = { git = "https://github.com/keep-starknet-strange/blockifier", branch = "no_std-support", default-features = false, features = [
   "parity-scale-codec",
 ] }
-starknet_api = { git = "https://github.com/apoorvsadana/starknet-api-madara", branch = "dev/query_tx_version", features = [
+starknet_api = { git = "https://github.com/keep-starknet-strange/starknet-api", branch = "no_std-support", features = [
   "testing",
-  "parity-scale-codec",
-  "scale-info",
+  "parity-scale-codec"
 ], default-features = false }
 
 # Cairo lang
-cairo-lang-starknet = { git = "https://github.com/apoorvsadana/cairo-madara", branch = "dev/query_tx_version", default-features = false }
-cairo-lang-casm-contract-class = { git = "https://github.com/apoorvsadana/cairo-madara", branch = "dev/query_tx_version", default-features = false }
-cairo-lang-casm = { git = "https://github.com/apoorvsadana/cairo-madara", branch = "dev/query_tx_version", default-features = false }
-cairo-lang-utils = { git = "https://github.com/apoorvsadana/cairo-madara", branch = "dev/query_tx_version", default-features = false }
+cairo-lang-starknet = { git = "https://github.com/keep-starknet-strange/cairo.git", branch = "no_std-support", default-features = false }
+cairo-lang-casm-contract-class = { git = "https://github.com/keep-starknet-strange/cairo.git", branch = "no_std-support", default-features = false }
+cairo-lang-casm = { git = "https://github.com/keep-starknet-strange/cairo.git", branch = "no_std-support", default-features = false }
+cairo-lang-utils = { git = "https://github.com/keep-starknet-strange/cairo.git", branch = "no_std-support", default-features = false }
 
 # Other third party dependencies
 anyhow = "1.0.71"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ blockifier = { git = "https://github.com/keep-starknet-strange/blockifier", bran
 ] }
 starknet_api = { git = "https://github.com/keep-starknet-strange/starknet-api", branch = "no_std-support", features = [
   "testing",
-  "parity-scale-codec"
+  "parity-scale-codec",
 ], default-features = false }
 
 # Cairo lang

--- a/crates/client/rpc-core/src/tests.rs
+++ b/crates/client/rpc-core/src/tests.rs
@@ -60,6 +60,7 @@ fn test_try_into_declare_transaction_v1_valid() {
         nonce: FieldElement::default(),
         contract_class: Arc::new(compressed_contract_class),
         sender_address: FieldElement::default(),
+        is_query: false,
     };
 
     let input: BroadcastedDeclareTransaction = BroadcastedDeclareTransaction::V1(txn);
@@ -77,6 +78,7 @@ fn test_try_into_declare_transaction_v1_max_signature() {
         nonce: FieldElement::default(),
         contract_class: Arc::new(compressed_contract_class),
         sender_address: FieldElement::default(),
+        is_query: false,
     };
 
     let input: BroadcastedDeclareTransaction = BroadcastedDeclareTransaction::V1(txn);
@@ -102,6 +104,7 @@ fn test_try_into_declare_transaction_v1_bad_gzip() {
         nonce: FieldElement::default(),
         contract_class: Arc::new(compressed_contract_class),
         sender_address: FieldElement::default(),
+        is_query: false,
     };
 
     let input: BroadcastedDeclareTransaction = BroadcastedDeclareTransaction::V1(txn);
@@ -123,6 +126,7 @@ fn test_try_into_declare_transaction_v2_with_correct_compiled_class_hash() {
         contract_class: Arc::new(flattened_contract_class),
         sender_address: FieldElement::default(),
         compiled_class_hash: FieldElement::from_hex_be(CAIRO_1_NO_VALIDATE_ACCOUNT_COMPILED_CLASS_HASH).unwrap(),
+        is_query: false,
     };
 
     let input: BroadcastedDeclareTransaction = BroadcastedDeclareTransaction::V2(txn);
@@ -142,6 +146,7 @@ fn test_try_into_declare_transaction_v2_with_incorrect_compiled_class_hash() {
         contract_class: Arc::new(flattened_contract_class),
         sender_address: FieldElement::default(),
         compiled_class_hash: FieldElement::from_hex_be("0x1").unwrap(), // incorrect compiled class hash
+        is_query: false,
     };
 
     let input: BroadcastedDeclareTransaction = BroadcastedDeclareTransaction::V2(txn);

--- a/crates/client/rpc-core/src/utils.rs
+++ b/crates/client/rpc-core/src/utils.rs
@@ -236,6 +236,7 @@ pub fn to_declare_transaction(
                 }))),
                 class_hash: legacy_contract_class.class_hash()?.into(),
                 compiled_class_hash: None,
+                is_query: declare_tx_v1.is_query,
             })
         }
         BroadcastedDeclareTransaction::V2(declare_tx_v2) => {
@@ -266,6 +267,7 @@ pub fn to_declare_transaction(
                 contract_class: BlockifierContractClass::V1(contract_class),
                 compiled_class_hash: Some(Felt252Wrapper::from(declare_tx_v2.compiled_class_hash)),
                 class_hash: declare_tx_v2.contract_class.class_hash().into(),
+                is_query: declare_tx_v2.is_query,
             })
         }
     }

--- a/crates/pallets/starknet/src/tests/call_contract.rs
+++ b/crates/pallets/starknet/src/tests/call_contract.rs
@@ -41,6 +41,7 @@ fn given_call_contract_call_works() {
             nonce: Felt252Wrapper::ZERO,
             calldata: constructor_calldata,
             max_fee: Felt252Wrapper::from(u128::MAX),
+			is_query: false
         };
 
         assert_ok!(Starknet::invoke(origin, deploy_transaction));

--- a/crates/pallets/starknet/src/tests/declare_tx.rs
+++ b/crates/pallets/starknet/src/tests/declare_tx.rs
@@ -30,6 +30,7 @@ fn given_contract_declare_tx_works_once_not_twice() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         assert_ok!(Starknet::declare(none_origin.clone(), transaction.clone()));
@@ -63,6 +64,7 @@ fn given_contract_declare_tx_fails_sender_not_deployed() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         assert_err!(Starknet::declare(none_origin, transaction), Error::<MockRuntime>::AccountNotDeployed);
@@ -93,6 +95,7 @@ fn given_contract_declare_tx_fails_wrong_tx_version() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         assert_err!(Starknet::declare(none_origin, transaction), Error::<MockRuntime>::TransactionExecutionFailed);
@@ -120,6 +123,7 @@ fn given_contract_declare_on_openzeppelin_account_then_it_works() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         let chain_id = Starknet::chain_id();
@@ -161,6 +165,7 @@ fn given_contract_declare_on_openzeppelin_account_with_incorrect_signature_then_
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(Felt252Wrapper::ZERO, Felt252Wrapper::ONE),
+            is_query: false,
         };
 
         let validate_result = Starknet::validate_unsigned(
@@ -194,6 +199,7 @@ fn given_contract_declare_on_braavos_account_then_it_works() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         let chain_id = Starknet::chain_id();
@@ -235,6 +241,7 @@ fn given_contract_declare_on_braavos_account_with_incorrect_signature_then_it_fa
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(Felt252Wrapper::ZERO, Felt252Wrapper::ONE),
+            is_query: false,
         };
 
         let validate_result = Starknet::validate_unsigned(
@@ -268,6 +275,7 @@ fn given_contract_declare_on_argent_account_then_it_works() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         let chain_id = Starknet::chain_id();
@@ -309,6 +317,7 @@ fn given_contract_declare_on_argent_account_with_incorrect_signature_then_it_fai
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(Felt252Wrapper::ZERO, Felt252Wrapper::ONE),
+            is_query: false,
         };
 
         let validate_result = Starknet::validate_unsigned(
@@ -344,6 +353,7 @@ fn given_contract_declare_on_cairo_1_no_validate_account_then_it_works() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         let chain_id = Starknet::chain_id();
@@ -383,6 +393,7 @@ fn test_verify_tx_longevity() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
         let validate_result =
             Starknet::validate_unsigned(TransactionSource::InBlock, &crate::Call::declare { transaction });
@@ -411,6 +422,7 @@ fn test_verify_no_require_tag() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         let validate_result = Starknet::validate_unsigned(
@@ -449,6 +461,7 @@ fn test_verify_require_tag() {
             nonce: Felt252Wrapper::ONE,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         let validate_result = Starknet::validate_unsigned(

--- a/crates/pallets/starknet/src/tests/deploy_account_tx.rs
+++ b/crates/pallets/starknet/src/tests/deploy_account_tx.rs
@@ -38,6 +38,7 @@ fn given_contract_run_deploy_account_tx_works() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         assert_ok!(Starknet::deploy_account(none_origin, transaction));
@@ -86,6 +87,7 @@ fn given_contract_run_deploy_account_tx_twice_fails() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         assert_ok!(Starknet::deploy_account(RuntimeOrigin::none(), transaction.clone()));
@@ -111,6 +113,7 @@ fn given_contract_run_deploy_account_tx_undeclared_then_it_fails() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         assert_err!(
@@ -148,6 +151,7 @@ fn given_contract_run_deploy_account_tx_fails_wrong_tx_version() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         assert_err!(
@@ -183,6 +187,7 @@ fn given_contract_run_deploy_account_openzeppelin_tx_works() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
         let mp_transaction = transaction.clone().from_deploy(get_chain_id()).unwrap();
 
@@ -224,6 +229,7 @@ fn given_contract_run_deploy_account_openzeppelin_with_incorrect_signature_then_
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(Felt252Wrapper::ONE, Felt252Wrapper::ONE),
+            is_query: false,
         };
 
         let address = transaction.clone().from_deploy(get_chain_id()).unwrap().sender_address;
@@ -262,6 +268,7 @@ fn given_contract_run_deploy_account_argent_tx_works() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         let mp_transaction = transaction.clone().from_deploy(get_chain_id()).unwrap();
@@ -304,6 +311,7 @@ fn given_contract_run_deploy_account_argent_with_incorrect_signature_then_it_fai
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(Felt252Wrapper::ONE, Felt252Wrapper::ONE),
+            is_query: false,
         };
 
         let address = transaction.clone().from_deploy(get_chain_id()).unwrap().sender_address;
@@ -352,6 +360,7 @@ fn given_contract_run_deploy_account_braavos_tx_works() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: signatures.try_into().unwrap(),
+            is_query: false,
         };
 
         let address = transaction.clone().from_deploy(get_chain_id()).unwrap().sender_address;
@@ -395,6 +404,7 @@ fn given_contract_run_deploy_account_braavos_with_incorrect_signature_then_it_fa
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: [Felt252Wrapper::ZERO; 10].to_vec().try_into().unwrap(),
+            is_query: false,
         };
 
         assert_err!(
@@ -429,6 +439,7 @@ fn test_verify_tx_longevity() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
         let validate_result =
             Starknet::validate_unsigned(TransactionSource::InBlock, &crate::Call::deploy_account { transaction });

--- a/crates/pallets/starknet/src/tests/erc20.rs
+++ b/crates/pallets/starknet/src/tests/erc20.rs
@@ -42,6 +42,7 @@ fn given_erc20_transfer_when_invoke_then_it_works() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         let expected_erc20_address =
@@ -119,6 +120,7 @@ fn given_erc20_transfer_when_invoke_then_it_works() {
             nonce: Felt252Wrapper::ONE,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         // Also asserts that the deployment has been saved.

--- a/crates/pallets/starknet/src/tests/invoke_tx.rs
+++ b/crates/pallets/starknet/src/tests/invoke_tx.rs
@@ -38,6 +38,7 @@ fn given_hardcoded_contract_run_invoke_tx_fails_sender_not_deployed() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         assert_err!(Starknet::invoke(none_origin, transaction), Error::<MockRuntime>::AccountNotDeployed);
@@ -211,6 +212,7 @@ fn given_hardcoded_contract_run_invoke_tx_then_multiple_events_is_emitted() {
             nonce: Felt252Wrapper::ZERO,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         let none_origin = RuntimeOrigin::none();
@@ -236,6 +238,7 @@ fn given_hardcoded_contract_run_invoke_tx_then_multiple_events_is_emitted() {
             nonce: Felt252Wrapper::ONE,
             max_fee: Felt252Wrapper::from(u128::MAX),
             signature: bounded_vec!(),
+            is_query: false,
         };
 
         let none_origin = RuntimeOrigin::none();

--- a/crates/pallets/starknet/src/tests/l1_message.rs
+++ b/crates/pallets/starknet/src/tests/l1_message.rs
@@ -30,6 +30,7 @@ fn given_contract_l1_message_fails_sender_not_deployed() {
             signature: Default::default(),
             max_fee: Default::default(),
             class_hash: Default::default(),
+            is_query: false,
         };
 
         assert_err!(Starknet::declare(none_origin, transaction), Error::<MockRuntime>::AccountNotDeployed);

--- a/crates/pallets/starknet/src/tests/mod.rs
+++ b/crates/pallets/starknet/src/tests/mod.rs
@@ -43,6 +43,7 @@ pub fn get_invoke_dummy() -> Transaction {
         nonce,
         signature,
         max_fee: Felt252Wrapper::from(u128::MAX),
+        is_query: false,
     }
     .from_invoke(Starknet::chain_id())
 }
@@ -73,6 +74,7 @@ fn get_invoke_argent_dummy() -> Transaction {
         nonce,
         signature,
         max_fee: Felt252Wrapper::from(u128::MAX),
+        is_query: false,
     }
     .from_invoke(Starknet::chain_id())
 }
@@ -103,6 +105,7 @@ fn get_invoke_braavos_dummy() -> Transaction {
         nonce,
         signature,
         max_fee: Felt252Wrapper::from(u128::MAX),
+        is_query: false,
     }
     .from_invoke(Starknet::chain_id())
 }
@@ -129,6 +132,7 @@ fn get_invoke_emit_event_dummy() -> Transaction {
         nonce,
         signature,
         max_fee: Felt252Wrapper::from(u128::MAX),
+        is_query: false,
     }
     .from_invoke(Starknet::chain_id())
 }
@@ -155,6 +159,7 @@ fn get_invoke_nonce_dummy() -> Transaction {
         nonce,
         signature,
         max_fee: Felt252Wrapper::from(u128::MAX),
+        is_query: false,
     }
     .from_invoke(Starknet::chain_id())
 }
@@ -179,6 +184,7 @@ fn get_storage_read_write_dummy() -> Transaction {
         nonce,
         signature,
         max_fee: Felt252Wrapper::from(u128::MAX),
+        is_query: false,
     }
     .from_invoke(Starknet::chain_id());
 
@@ -213,6 +219,7 @@ fn get_invoke_openzeppelin_dummy() -> Transaction {
         nonce,
         signature,
         max_fee: Felt252Wrapper::from(u128::MAX),
+        is_query: false,
     }
     .from_invoke(Starknet::chain_id())
 }

--- a/crates/primitives/starknet/src/tests/block.rs
+++ b/crates/primitives/starknet/src/tests/block.rs
@@ -43,6 +43,7 @@ fn generate_dummy_transactions() -> BoundedVec<Transaction, MaxTransactions> {
             contract_class: None,
             contract_address_salt: None,
             max_fee: Felt252Wrapper::from_dec_str("1000").unwrap(),
+            is_query: false,
         },
         Transaction {
             tx_type: TxType::Invoke,
@@ -55,6 +56,7 @@ fn generate_dummy_transactions() -> BoundedVec<Transaction, MaxTransactions> {
             contract_class: None,
             contract_address_salt: None,
             max_fee: Felt252Wrapper::from_dec_str("1000").unwrap(),
+            is_query: false,
         },
     ]
     .try_into()

--- a/crates/primitives/starknet/src/tests/crypto.rs
+++ b/crates/primitives/starknet/src/tests/crypto.rs
@@ -38,6 +38,7 @@ fn test_deploy_account_tx_hash() {
         signature: bounded_vec!(),
         account_class_hash: Felt252Wrapper::THREE,
         max_fee: Felt252Wrapper::ONE,
+        is_query: false,
     };
     let address = Felt252Wrapper::from(19911991_u64);
 
@@ -62,6 +63,7 @@ fn test_declare_tx_hash() {
         // Arbitrary choice to pick v1 vs v0.
         contract_class: ContractClass::from(ContractClassV1::default()),
         compiled_class_hash: None,
+        is_query: false,
     };
     assert_eq!(calculate_declare_tx_hash(transaction, chain_id), expected_tx_hash);
 }
@@ -81,6 +83,7 @@ fn test_invoke_tx_hash() {
         nonce: Felt252Wrapper::ZERO,
         signature: bounded_vec!(),
         max_fee: Felt252Wrapper::ONE,
+        is_query: false,
     };
     assert_eq!(calculate_invoke_tx_hash(transaction, chain_id), expected_tx_hash);
 }
@@ -103,6 +106,7 @@ fn test_ref_merkle_tree() {
             contract_class: None,
             contract_address_salt: None,
             max_fee: Felt252Wrapper::from(u128::MAX),
+            is_query: false,
         },
         Transaction {
             tx_type: TxType::Invoke,
@@ -115,6 +119,7 @@ fn test_ref_merkle_tree() {
             contract_class: None,
             contract_address_salt: None,
             max_fee: Felt252Wrapper::from(u128::MAX),
+            is_query: false,
         },
     ];
     let tx_com = calculate_transaction_commitment::<PedersenHasher>(&txs);

--- a/crates/primitives/starknet/src/tests/transaction.rs
+++ b/crates/primitives/starknet/src/tests/transaction.rs
@@ -403,6 +403,7 @@ fn test_try_invoke_txn_from_broadcasted_invoke_txn_v0() {
         contract_address: FieldElement::default(),
         entry_point_selector: FieldElement::default(),
         calldata: vec![FieldElement::default()],
+        is_query: false,
     };
 
     let broadcasted_invoke_txn = BroadcastedInvokeTransaction::V0(broadcasted_invoke_txn_v0);
@@ -423,6 +424,7 @@ fn test_try_invoke_txn_from_broadcasted_invoke_txn_v1() {
         sender_address: FieldElement::default(),
         signature: vec![FieldElement::default()],
         calldata: vec![FieldElement::default()],
+        is_query: false,
     };
 
     let broadcasted_invoke_txn = BroadcastedInvokeTransaction::V1(broadcasted_invoke_txn_v1);
@@ -451,6 +453,7 @@ fn test_try_invoke_txn_from_broadcasted_invoke_txn_v1_max_sig_size() {
         sender_address: FieldElement::default(),
         signature: signature_size_maxed,
         calldata: vec![FieldElement::default()],
+        is_query: false,
     };
 
     let broadcasted_invoke_txn = BroadcastedInvokeTransaction::V1(broadcasted_invoke_txn_v1);
@@ -470,6 +473,7 @@ fn test_try_invoke_txn_from_broadcasted_invoke_txn_v1_max_calldata_size() {
         sender_address: FieldElement::default(),
         signature: vec![FieldElement::default()],
         calldata: calldata_size_maxed,
+        is_query: false,
     };
 
     let broadcasted_invoke_txn = BroadcastedInvokeTransaction::V1(broadcasted_invoke_txn_v1);
@@ -496,6 +500,7 @@ fn get_try_into_and_expected_value(
         nonce: FieldElement::default(),
         contract_address_salt: FieldElement::default(),
         class_hash: FieldElement::default(),
+        is_query: false,
     };
 
     let output: DeployAccountTransaction = input.try_into()?;
@@ -511,6 +516,7 @@ fn get_try_into_and_expected_value(
         salt: FieldElement::default().into(),
         account_class_hash: FieldElement::default().into(),
         max_fee: FieldElement::default().into(),
+        is_query: false,
     };
 
     Ok((output, expected_output))

--- a/crates/primitives/starknet/src/transaction/mod.rs
+++ b/crates/primitives/starknet/src/transaction/mod.rs
@@ -43,6 +43,7 @@ use self::types::{
     TransactionExecutionInfoWrapper, TransactionExecutionResultWrapper, TransactionReceiptWrapper,
     TransactionValidationErrorWrapper, TransactionValidationResultWrapper, TxType,
 };
+use self::utils::{calculate_transaction_version, calculate_transaction_version_from_u8};
 use crate::execution::types::{CallEntryPointWrapper, ContractAddressWrapper, Felt252Wrapper};
 use crate::fees::{self, charge_fee};
 use crate::state::StateChanges;
@@ -306,6 +307,7 @@ impl Transaction {
         contract_class: Option<ContractClass>,
         contract_address_salt: Option<U256>,
         max_fee: Felt252Wrapper,
+        is_query: bool,
     ) -> Self {
         Self {
             tx_type,
@@ -318,6 +320,7 @@ impl Transaction {
             contract_class,
             contract_address_salt,
             max_fee,
+            is_query,
         }
     }
 
@@ -732,7 +735,7 @@ impl Transaction {
         AccountTransactionContext {
             transaction_hash: tx.transaction_hash,
             max_fee: Fee::default(),
-            version: tx.version,
+            version: calculate_transaction_version(self.is_query, tx.version),
             signature: TransactionSignature::default(),
             nonce: tx.nonce,
             sender_address: tx.contract_address,
@@ -753,7 +756,7 @@ impl Transaction {
         AccountTransactionContext {
             transaction_hash: tx.transaction_hash(),
             max_fee: tx.max_fee(),
-            version: TransactionVersion(StarkFelt::from(1_u8)),
+            version: calculate_transaction_version_from_u8(self.is_query, 1_u8),
             signature: tx.signature(),
             nonce: tx.nonce(),
             sender_address: tx.sender_address(),
@@ -774,7 +777,7 @@ impl Transaction {
         AccountTransactionContext {
             transaction_hash: tx.transaction_hash,
             max_fee: tx.max_fee,
-            version: tx.version,
+            version: calculate_transaction_version(self.is_query, tx.version),
             signature: tx.signature.clone(),
             nonce: tx.nonce,
             sender_address: tx.contract_address,
@@ -795,7 +798,7 @@ impl Transaction {
         AccountTransactionContext {
             transaction_hash: tx.transaction_hash(),
             max_fee: tx.max_fee(),
-            version: tx.version(),
+            version: calculate_transaction_version(self.is_query, tx.version()),
             signature: tx.signature(),
             nonce: tx.nonce(),
             sender_address: tx.sender_address(),
@@ -817,6 +820,7 @@ impl Default for Transaction {
             contract_class: None,
             contract_address_salt: None,
             max_fee: Felt252Wrapper::from(u128::MAX),
+            is_query: false,
         }
     }
 }

--- a/crates/primitives/starknet/src/transaction/types.rs
+++ b/crates/primitives/starknet/src/transaction/types.rs
@@ -177,6 +177,8 @@ pub struct DeclareTransaction {
     pub signature: BoundedVec<Felt252Wrapper, MaxArraySize>,
     /// Max fee.
     pub max_fee: Felt252Wrapper,
+    /// If set to `true`, uses a query-only transaction version that's invalid for execution
+    pub is_query: bool,
 }
 
 impl DeclareTransaction {
@@ -202,6 +204,7 @@ impl DeclareTransaction {
             contract_class: Some(self.contract_class),
             contract_address_salt: None,
             max_fee: self.max_fee,
+            is_query: self.is_query,
         }
     }
 }
@@ -234,6 +237,8 @@ pub struct DeployAccountTransaction {
     pub account_class_hash: Felt252Wrapper,
     /// Max fee.
     pub max_fee: Felt252Wrapper,
+    /// If set to `true`, uses a query-only transaction version that's invalid for execution
+    pub is_query: bool,
 }
 
 impl DeployAccountTransaction {
@@ -277,6 +282,7 @@ impl DeployAccountTransaction {
             contract_class: None,
             contract_address_salt: Some(self.salt.into()),
             max_fee: self.max_fee,
+            is_query: self.is_query,
         })
     }
 }
@@ -319,6 +325,7 @@ impl TryFrom<Transaction> for DeclareTransaction {
             compiled_class_hash: casm_class_hash,
             class_hash: value.call_entrypoint.class_hash.ok_or(TransactionConversionError::MissingClassHash)?,
             max_fee: value.max_fee,
+            is_query: value.is_query,
         })
     }
 }
@@ -349,6 +356,8 @@ pub struct InvokeTransaction {
     pub signature: BoundedVec<Felt252Wrapper, MaxArraySize>,
     /// Max fee.
     pub max_fee: Felt252Wrapper,
+    /// If set to `true`, uses a query-only transaction version that's invalid for execution
+    pub is_query: bool,
 }
 
 impl From<Transaction> for InvokeTransaction {
@@ -360,6 +369,7 @@ impl From<Transaction> for InvokeTransaction {
             nonce: value.nonce,
             calldata: value.call_entrypoint.calldata,
             max_fee: value.max_fee,
+            is_query: value.is_query,
         }
     }
 }
@@ -387,6 +397,7 @@ impl InvokeTransaction {
             contract_class: None,
             contract_address_salt: None,
             max_fee: self.max_fee,
+            is_query: self.is_query,
         }
     }
 }
@@ -424,6 +435,8 @@ pub struct Transaction {
     pub contract_address_salt: Option<U256>,
     /// Max fee.
     pub max_fee: Felt252Wrapper,
+    /// If set to `true`, uses a query-only transaction version that's invalid for execution
+    pub is_query: bool,
 }
 
 impl TryFrom<Transaction> for DeployAccountTransaction {
@@ -439,6 +452,7 @@ impl TryFrom<Transaction> for DeployAccountTransaction {
             salt: salt_as_felt_wrapper,
             account_class_hash: value.call_entrypoint.class_hash.ok_or(TransactionConversionError::MissingClassHash)?,
             max_fee: value.max_fee,
+            is_query: value.is_query,
         })
     }
 }
@@ -636,6 +650,7 @@ mod reexport_private_types {
                     )
                     .map_err(|_| BroadcastedTransactionConversionErrorWrapper::CalldataConversionError)?,
                     max_fee: Felt252Wrapper::from(invoke_tx_v1.max_fee),
+                    is_query: invoke_tx_v1.is_query,
                 }),
             }
         }
@@ -675,6 +690,7 @@ mod reexport_private_types {
                 account_class_hash: account_class_hash.into(),
                 nonce,
                 max_fee,
+                is_query: tx.is_query,
             })
         }
     }

--- a/crates/primitives/starknet/src/transaction/utils.rs
+++ b/crates/primitives/starknet/src/transaction/utils.rs
@@ -23,7 +23,7 @@ pub fn calculate_transaction_version(is_query: bool, version: TransactionVersion
 
 /// calls [calculate_transaction_version] after converting version to [TransactionVersion]
 pub fn calculate_transaction_version_from_u8(is_query: bool, version: u8) -> TransactionVersion {
-    return calculate_transaction_version(is_query, TransactionVersion(StarkFelt::from(version)));
+    calculate_transaction_version(is_query, TransactionVersion(StarkFelt::from(version)))
 }
 
 #[cfg(feature = "std")]

--- a/crates/primitives/starknet/src/transaction/utils.rs
+++ b/crates/primitives/starknet/src/transaction/utils.rs
@@ -1,6 +1,30 @@
 use alloc::vec::Vec;
 
+use starknet_api::hash::StarkFelt;
+use starknet_api::transaction::TransactionVersion;
+use starknet_ff::FieldElement;
+
 use crate::execution::types::{EntryPointTypeWrapper, EntryPointWrapper};
+
+const QUERY_VERSION_OFFSET: FieldElement =
+    FieldElement::from_mont([18446744073700081665, 17407, 18446744073709551584, 576460752142434320]);
+
+/// Estimate fee adds an additional offset to the transaction version
+/// when handling Transaction within Madara, we ignore the offset and use the actual version.
+/// However, before sending the transaction to the account, we need to add the offset back for
+/// signature verification to work
+pub fn calculate_transaction_version(is_query: bool, version: TransactionVersion) -> TransactionVersion {
+    if !is_query {
+        return version;
+    }
+    let version = FieldElement::from(version.0) + QUERY_VERSION_OFFSET;
+    TransactionVersion(StarkFelt::from(version))
+}
+
+/// calls [calculate_transaction_version] after converting version to [TransactionVersion]
+pub fn calculate_transaction_version_from_u8(is_query: bool, version: u8) -> TransactionVersion {
+    return calculate_transaction_version(is_query, TransactionVersion(StarkFelt::from(version)));
+}
 
 #[cfg(feature = "std")]
 mod reexport_std_types {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix
- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Estimate fee with version `0x100000000000000000000000000000001` doesn't work. Starknet-rs has added support for it and this PR integrates it.

Resolves: #646 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Estimate fee works correctly now
- Once `dev/query_tx_version` is merged in `starknet-rs`, I will update the packages in this PR and we can merge

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

No
