### PR TITLE
Fixed madara-infra link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ growth within the Starknet ecosystem.
 - [Madara Explorer](https://github.com/lambdaclass/madara_explorer)
 by the great [LambdaClass](https://lambdaclass.com/) team 🫶:
  A block explorer for Madara.
-- [Madara Infra](https://github.com/keep-starknet-strange/madara-app):
+- [Madara Infra](https://github.com/keep-starknet-strange/madara-infra):
  A collection of scripts and tools to deploy and manage Madara
  on different environments (e.g. AWS, docker, ansible, etc.).
  It also contains


### PR DESCRIPTION
# Pull Request type
- Documentation content changes

## What is the current behavior?
- Incorrect link in docs (app instead of infra)

## What is the new behavior?
- Correct link to madara-infra repo

## Does this introduce a breaking change?
No

## Other information
N/A