### PR TITLE
Update the default port for running Madara locally in getting-started…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,5 @@
 - feat: add a `genesis_loader` for the node and mocking
 - feat: add `madara_tsukuyomi` as a submodule
 - branding: use new logo in the README
+- fix: update the default port for running Madara locally in getting-started.md
+  file from 9933 to 9944.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -153,7 +153,7 @@ See more details about
 
 To test the Madara RPC endpoints, follow the steps below:
 
-Run Madara locally (by default, it runs on port 9933):
+Run Madara locally (by default, it runs on port 9944):
 
 ```bash
 cargo run --release -- --dev


### PR DESCRIPTION
Documentation content changes：

Update the default port to 9944 instead of 9933 in `getting-started.md` file.





