### PR TITLE
Update RPC URL to use localhost instead of 0.0.0.0 in hurl.config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@
 - feat: add a `genesis_loader` for the node and mocking
 - feat: add `madara_tsukuyomi` as a submodule
 - branding: use new logo in the README
+- fix: update RPC URL to use localhost instead of 0.0.0.0 in hurl.config file

--- a/examples/rpc/hurl.config
+++ b/examples/rpc/hurl.config
@@ -1,1 +1,1 @@
-RPC_URL=http://0.0.0.0:9944
+RPC_URL=http://localhost:9944


### PR DESCRIPTION

# Pull Request type

- Bugfix

## What is the current behavior?

When testing RPC with a local node, the error is like:

```
hurl --variables-file examples/rpc/hurl.config  --test examples/rpc/starknet/starknet_chainId.hurl
examples/rpc/starknet/starknet_chainId.hurl: Running [1/1]
error: Assert status code
  --> examples/rpc/starknet/starknet_chainId.hurl:10:6
   |
10 | HTTP 200
   |      ^^^ actual value is <403>
   |

examples/rpc/starknet/starknet_chainId.hurl: Failure (1 request(s) in 8 ms)
```

## What is the new behavior?

```
hurl --variables-file examples/rpc/hurl.config  --test examples/rpc/starknet/starknet_chainId.hurl
examples/rpc/starknet/starknet_chainId.hurl: Running [1/1]
examples/rpc/starknet/starknet_chainId.hurl: Success (1 request(s) in 5 ms)
--------------------------------------------------------------------------------
Executed files:  1
Succeeded files: 1 (100.0%)
Failed files:    0 (0.0%)
Duration:        5 ms
```

