### PR TITLE
test: #904: add get_class_hash_at.rs

### DIFF
--- a/starknet-rpc-test/Cargo.toml
+++ b/starknet-rpc-test/Cargo.toml
@@ -42,3 +42,7 @@ path = "chain_id.rs"
 [[test]]
 name = "starknet_get_storage_at"
 path = "get_storage_at.rs"
+
+[[test]]
+name = "starknet_get_class_hash_at"
+path = "get_class_hash_at.rs"

--- a/starknet-rpc-test/get_class_hash_at.rs
+++ b/starknet-rpc-test/get_class_hash_at.rs
@@ -1,0 +1,66 @@
+extern crate starknet_rpc_test;
+
+use assert_matches::assert_matches;
+use starknet_core::types::{BlockId, StarknetError};
+use starknet_ff::FieldElement;
+use starknet_providers::ProviderError::StarknetError as StarknetProviderError;
+use starknet_providers::{MaybeUnknownErrorCode, Provider, StarknetErrorWithMessage};
+use starknet_rpc_test::constants::{TEST_CONTRACT_ADDRESS, TEST_CONTRACT_CLASS_HASH};
+use starknet_rpc_test::{ExecutionStrategy, MadaraClient};
+
+#[tokio::test]
+async fn fail_non_existing_block() -> Result<(), anyhow::Error> {
+    let madara = MadaraClient::new(ExecutionStrategy::Native).await;
+    let rpc = madara.get_starknet_client();
+    let test_contract_address = FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).expect("Invalid Contract Address");
+
+    assert_matches!(
+        rpc
+        .get_class_hash_at(
+            BlockId::Number(100),
+            test_contract_address,
+        )
+        .await,
+        Err(StarknetProviderError(StarknetErrorWithMessage { code: MaybeUnknownErrorCode::Known(code), .. })) if code == StarknetError::BlockNotFound
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn fail_non_existing_contract() -> Result<(), anyhow::Error> {
+    let madara = MadaraClient::new(ExecutionStrategy::Native).await;
+    let rpc = madara.get_starknet_client();
+    let unknown_contract_address = FieldElement::from_hex_be("0x4269DEADBEEF").expect("Invalid Contract Address");
+
+    assert_matches!(
+        rpc
+        .get_class_hash_at(
+            BlockId::Number(0),
+            unknown_contract_address,
+        )
+        .await,
+        Err(StarknetProviderError(StarknetErrorWithMessage { code: MaybeUnknownErrorCode::Known(code), .. })) if code == StarknetError::ContractNotFound
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn work_ok_retrieving_class_hash() -> Result<(), anyhow::Error> {
+    let madara = MadaraClient::new(ExecutionStrategy::Native).await;
+    let rpc = madara.get_starknet_client();
+    let test_contract_address = FieldElement::from_hex_be(TEST_CONTRACT_ADDRESS).expect("Invalid Contract Address");
+
+    assert_eq!(
+        rpc
+        .get_class_hash_at(
+            BlockId::Number(0),
+            test_contract_address,
+        )
+        .await?,
+        FieldElement::from_hex_be(TEST_CONTRACT_CLASS_HASH).unwrap()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Add test case in rust for `getClassHashAt` route.

Parent issue: #904 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Testing

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?

Contains the following tests:
- [x] Return an error for a nonexisting block
- [x] Return an error for an address that has not contract deployed
- [x] Otherwise, return the hash of the ContractClass of the contract that was deployed at this address

## Does this introduce a breaking change?

No
<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
