### PR TITLE
fix: #1032: RPC: getClassAt doesn't follow specification for Cairo legacy program code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix: RPC getClassAt cairo legacy program code encoding
 - ci: added wasm to test
 - docs: added translation of madara beast article.md to portuguese
 - ci: disable benchmark for pushes and pr's

--- a/crates/client/rpc-core/src/utils.rs
+++ b/crates/client/rpc-core/src/utils.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io::Write;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
@@ -61,7 +62,11 @@ pub fn to_rpc_contract_class(contract_class: BlockifierContractClass) -> Result<
 /// Returns a compressed vector of bytes
 pub(crate) fn compress(data: &[u8]) -> Result<Vec<u8>> {
     let mut gzip_encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
-    serde_json::to_writer(&mut gzip_encoder, data)?;
+    // 2023-08-22: JSON serialization is already done in Blockifier
+    // https://github.com/keep-starknet-strange/blockifier/blob/no_std-support-7578442/crates/blockifier/src/execution/contract_class.rs#L129
+    // https://github.com/keep-starknet-strange/blockifier/blob/no_std-support-7578442/crates/blockifier/src/execution/contract_class.rs#L389
+    // serde_json::to_writer(&mut gzip_encoder, data)?;
+    gzip_encoder.write_all(data)?;
     Ok(gzip_encoder.finish()?)
 }
 

--- a/tests/tests/test-starknet-rpc/test-contracts.ts
+++ b/tests/tests/test-starknet-rpc/test-contracts.ts
@@ -31,10 +31,7 @@ function stringToArrayBuffer(s: string): Uint8Array {
 }
 function decompressProgram(base64: CompressedProgram) {
   if (Array.isArray(base64)) return base64;
-  const decompressed = encode.arrayBufferToString(
-    ungzip(atobUniversal(base64)),
-  );
-  return json.parse(decompressed);
+  return encode.arrayBufferToString(ungzip(atobUniversal(base64)));
 }
 
 describeDevMadara("Starknet RPC - Contracts Test", (context) => {
@@ -145,9 +142,7 @@ describeDevMadara("Starknet RPC - Contracts Test", (context) => {
         ERC20_CONTRACT.entry_points_by_type,
       );
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const program = json.parse(
-        encode.arrayBufferToString(decompressProgram(contract_class.program)),
-      );
+      const program = json.parse(decompressProgram(contract_class.program));
       // starknet js parses the values in the identifiers as negative numbers (maybe it's in madara).
       // FIXME: https://github.com/keep-starknet-strange/madara/issues/664
       // expect(program).to.deep.equal(ERC20_CONTRACT.program);


### PR DESCRIPTION
Removed double JSON serialization for Cairo legacy program code.

<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- Bugfix

## What is the current behavior?

Calling RPC `getClassAt` with a Cairo legacy contract address doesn't return a valid compressed program code.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #1032

## What is the new behavior?

Calling RPC `getClassAt` with a Cairo legacy contract address returns a valid compressed program code.

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
No

