### PR TITLE
Initial gas fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
       // As such, this path would have to change accordingly.
       "program": "${workspaceFolder}/target/debug/madara",
       // If you wish to supply arguments/parameters to the program, supply them below:
-      "args": ["--dev", "--sealing=instant"],
+      "args": ["--dev", "--sealing=instant", "--tmp", "--execution=Native"],
       // Working folder for execution. Change as necessary if program requires a different value:
       "cwd": "${workspaceFolder}",
       "terminal": "integrated",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - chore: cairo-contracts compilation scripts & docs are updated, cairo_0
   contracts recompiled
 - chore: rebase of core deps and 0.12.1
+- fix: initial_gas set to max_fee and fixed fee not being charged when max_fee=0
 
 ## v0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: estimate_fee should make sure all transaction have a version being
   2^128 + 1 or 2^128+2 depending on the tx type
+- fix: initial_gas set to max_fee and fixed fee not being charged when max_fee=0
 
 ## v0.2.0
 
@@ -29,7 +30,6 @@
 - chore: cairo-contracts compilation scripts & docs are updated, cairo_0
   contracts recompiled
 - chore: rebase of core deps and 0.12.1
-- fix: initial_gas set to max_fee and fixed fee not being charged when max_fee=0
 
 ## v0.1.0
 

--- a/crates/pallets/starknet/src/tests/call_contract.rs
+++ b/crates/pallets/starknet/src/tests/call_contract.rs
@@ -42,7 +42,7 @@ fn given_call_contract_call_works() {
             signature: bounded_vec!(),
             nonce: Felt252Wrapper::ZERO,
             calldata: constructor_calldata,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
 			is_query: false
         };
 

--- a/crates/pallets/starknet/src/tests/declare_tx.rs
+++ b/crates/pallets/starknet/src/tests/declare_tx.rs
@@ -30,7 +30,7 @@ fn given_contract_declare_tx_works_once_not_twice() {
             compiled_class_hash: None,
             contract_class: erc20_class,
             nonce: Felt252Wrapper::ZERO,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             signature: bounded_vec!(),
             is_query: false,
         };
@@ -64,7 +64,7 @@ fn given_contract_declare_tx_fails_sender_not_deployed() {
             class_hash: erc20_class_hash,
             compiled_class_hash: None,
             nonce: Felt252Wrapper::ZERO,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             signature: bounded_vec!(),
             is_query: false,
         };
@@ -95,7 +95,7 @@ fn given_contract_declare_tx_fails_wrong_tx_version() {
             class_hash: erc20_class_hash,
             compiled_class_hash: None,
             nonce: Felt252Wrapper::ZERO,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             signature: bounded_vec!(),
             is_query: false,
         };
@@ -263,7 +263,7 @@ fn given_contract_declare_on_cairo_1_no_validate_account_then_it_works() {
             class_hash: hello_starknet_class_hash,
             compiled_class_hash: Some(hello_starknet_compiled_class_hash),
             nonce: Felt252Wrapper::ZERO,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             signature: bounded_vec!(),
             is_query: false,
         };

--- a/crates/pallets/starknet/src/tests/deploy_account_tx.rs
+++ b/crates/pallets/starknet/src/tests/deploy_account_tx.rs
@@ -1,4 +1,5 @@
 use frame_support::{assert_err, assert_ok, bounded_vec, BoundedVec};
+use mp_starknet::constants::SN_GOERLI_CHAIN_ID;
 use mp_starknet::execution::types::Felt252Wrapper;
 use mp_starknet::transaction::types::{DeployAccountTransaction, EventWrapper};
 use sp_runtime::traits::ValidateUnsigned;
@@ -39,7 +40,7 @@ fn given_contract_run_deploy_account_tx_works() {
             )
             .unwrap(),
             nonce: Felt252Wrapper::ZERO,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             signature: bounded_vec!(),
             is_query: false,
         };
@@ -98,7 +99,7 @@ fn given_contract_run_deploy_account_tx_undeclared_then_it_fails() {
             calldata: bounded_vec!(),
             salt: Felt252Wrapper::ZERO,
             nonce: Felt252Wrapper::ZERO,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             signature: bounded_vec!(),
             is_query: false,
         };
@@ -225,7 +226,7 @@ fn given_contract_run_deploy_account_braavos_tx_works() {
         calldata.push(ACCOUNT_PUBLIC_KEY);
 
         let tx_hash =
-            Felt252Wrapper::from_hex_be("0x00de7a5bc4a54852d47b99070ac74baf71d5993a9029dbc45fa1d48f28acb0a4").unwrap();
+            Felt252Wrapper::from_hex_be("0x06a8bb3d81c2ad23db93f01f72f987feac5210a95bc530eabb6abfaa5a769944").unwrap();
 
         let mut signatures: Vec<Felt252Wrapper> = sign_message_hash(tx_hash).into();
         let empty_signatures = [Felt252Wrapper::ZERO; 8];
@@ -244,10 +245,12 @@ fn given_contract_run_deploy_account_braavos_tx_works() {
             )
             .unwrap(),
             nonce: Felt252Wrapper::ZERO,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             signature: signatures.try_into().unwrap(),
             is_query: false,
         };
+        let transaction1 = transaction.clone().from_deploy(SN_GOERLI_CHAIN_ID);
+        println!("this is transaction hash {}", transaction1.unwrap().hash.0);
 
         let address = transaction.clone().from_deploy(Starknet::chain_id()).unwrap().sender_address;
         set_infinite_tokens::<MockRuntime>(address);
@@ -285,7 +288,7 @@ fn given_contract_run_deploy_account_braavos_with_incorrect_signature_then_it_fa
             )
             .unwrap(),
             nonce: Felt252Wrapper::ZERO,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             signature: [Felt252Wrapper::ZERO; 10].to_vec().try_into().unwrap(),
             is_query: false,
         };

--- a/crates/pallets/starknet/src/tests/erc20.rs
+++ b/crates/pallets/starknet/src/tests/erc20.rs
@@ -42,7 +42,7 @@ fn given_erc20_transfer_when_invoke_then_it_works() {
                 sender_account  // recipient
             ],
             nonce: Felt252Wrapper::ZERO,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             signature: bounded_vec!(),
             is_query: false,
         };

--- a/crates/pallets/starknet/src/tests/events.rs
+++ b/crates/pallets/starknet/src/tests/events.rs
@@ -31,7 +31,7 @@ fn internal_and_external_events_are_emitted_in_the_right_order() {
                 Felt252Wrapper::ZERO, // Calldata len
             ],
             nonce: Felt252Wrapper::ZERO,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             signature: bounded_vec!(),
             is_query: false,
         };

--- a/crates/pallets/starknet/src/tests/invoke_tx.rs
+++ b/crates/pallets/starknet/src/tests/invoke_tx.rs
@@ -37,7 +37,7 @@ fn given_hardcoded_contract_run_invoke_tx_fails_sender_not_deployed() {
             sender_address: contract_address,
             calldata: bounded_vec!(),
             nonce: Felt252Wrapper::ZERO,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             signature: bounded_vec!(),
             is_query: false,
         };
@@ -89,7 +89,7 @@ fn given_hardcoded_contract_run_invoke_tx_then_it_works() {
         let receipt = &pending.get(0).unwrap().1;
         let expected_receipt = TransactionReceiptWrapper {
             transaction_hash: Felt252Wrapper::from_hex_be(
-                "0x01b8ffedfb222c609b81f301df55c640225abaa6a0715437c89f8edc21bbe5e8",
+                "0x02dfd0ded452658d67535279591c1ed9898431e1eafad7896239f0bfa68493d6",
             )
             .unwrap(),
             actual_fee: Felt252Wrapper::from(53510_u128),
@@ -175,7 +175,7 @@ fn given_hardcoded_contract_run_invoke_tx_then_event_is_emitted() {
 
         let expected_receipt = TransactionReceiptWrapper {
             transaction_hash: Felt252Wrapper::from_hex_be(
-                "0x0554f9443c06ce406badc7159f2c0da29eac095f8571fe1a6ce44a2076829a52",
+                "0x0730465ceb5da086fd11078a56f15a49ff676c1b541571a6fead0baec39812cf",
             )
             .unwrap(),
             actual_fee: Felt252Wrapper::from(54020_u128),
@@ -211,7 +211,7 @@ fn given_hardcoded_contract_run_invoke_tx_then_multiple_events_is_emitted() {
                 Felt252Wrapper::ZERO, // Calldata len
             ],
             nonce: Felt252Wrapper::ZERO,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             signature: bounded_vec!(),
             is_query: false,
         };
@@ -237,7 +237,7 @@ fn given_hardcoded_contract_run_invoke_tx_then_multiple_events_is_emitted() {
                 Felt252Wrapper::ZERO, // Calldata len
             ],
             nonce: Felt252Wrapper::ONE,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             signature: bounded_vec!(),
             is_query: false,
         };

--- a/crates/pallets/starknet/src/tests/mod.rs
+++ b/crates/pallets/starknet/src/tests/mod.rs
@@ -50,7 +50,7 @@ pub fn get_invoke_dummy() -> Transaction {
         calldata,
         nonce,
         signature,
-        max_fee: Felt252Wrapper::from(u128::MAX),
+        max_fee: Felt252Wrapper::from(u64::MAX),
         is_query: false,
     }
     .from_invoke(Starknet::chain_id())
@@ -81,7 +81,7 @@ fn get_invoke_argent_dummy() -> Transaction {
         calldata,
         nonce,
         signature,
-        max_fee: Felt252Wrapper::from(u128::MAX),
+        max_fee: Felt252Wrapper::from(u64::MAX),
         is_query: false,
     }
     .from_invoke(Starknet::chain_id())
@@ -112,7 +112,7 @@ fn get_invoke_braavos_dummy() -> Transaction {
         calldata,
         nonce,
         signature,
-        max_fee: Felt252Wrapper::from(u128::MAX),
+        max_fee: Felt252Wrapper::from(u64::MAX),
         is_query: false,
     }
     .from_invoke(Starknet::chain_id())
@@ -139,7 +139,7 @@ fn get_invoke_emit_event_dummy() -> Transaction {
         calldata,
         nonce,
         signature,
-        max_fee: Felt252Wrapper::from(u128::MAX),
+        max_fee: Felt252Wrapper::from(u64::MAX),
         is_query: false,
     }
     .from_invoke(Starknet::chain_id())
@@ -166,7 +166,7 @@ fn get_invoke_nonce_dummy() -> Transaction {
         calldata,
         nonce,
         signature,
-        max_fee: Felt252Wrapper::from(u128::MAX),
+        max_fee: Felt252Wrapper::from(u64::MAX),
         is_query: false,
     }
     .from_invoke(Starknet::chain_id())
@@ -191,7 +191,7 @@ fn get_storage_read_write_dummy() -> Transaction {
         calldata,
         nonce,
         signature,
-        max_fee: Felt252Wrapper::from(u128::MAX),
+        max_fee: Felt252Wrapper::from(u64::MAX),
         is_query: false,
     }
     .from_invoke(Starknet::chain_id());
@@ -204,8 +204,8 @@ fn get_storage_read_write_dummy() -> Transaction {
 // ref: https://github.com/OpenZeppelin/cairo-contracts/blob/main/src/openzeppelin/account/IAccount.cairo
 fn get_invoke_openzeppelin_dummy() -> Transaction {
     let signature = bounded_vec!(
-        Felt252Wrapper::from_hex_be("0x01ef15c18599971b7beced415a40f0c7deacfd9b0d1819e03d723d8bc943cfca").unwrap(),
-        Felt252Wrapper::from_hex_be("0x004f0481f89eae56dec538294bde0bf84bba526517dd9ff7dcb2a22628ee4d9e").unwrap(),
+        Felt252Wrapper::from_hex_be("0x028ef1ae6c37314bf9df65663db1cf68f95d67c4b4cf7f6590654933a84912b0").unwrap(),
+        Felt252Wrapper::from_hex_be("0x0625aae99c58b18e5161c719fef0f99579c6468ca6c1c866f9b2b968a5447e4").unwrap(),
     );
     let sender_address =
         Felt252Wrapper::from_hex_be("0x06e2616a2dceff4355997369246c25a78e95093df7a49e5ca6a06ce1544ffd50").unwrap();
@@ -226,7 +226,7 @@ fn get_invoke_openzeppelin_dummy() -> Transaction {
         calldata,
         nonce,
         signature,
-        max_fee: Felt252Wrapper::from(u128::MAX),
+        max_fee: Felt252Wrapper::from(u64::MAX),
         is_query: false,
     }
     .from_invoke(Starknet::chain_id())
@@ -249,7 +249,7 @@ pub fn get_declare_dummy(account_type: AccountType) -> DeclareTransaction {
         class_hash: erc20_class_hash,
         compiled_class_hash: None,
         nonce: Felt252Wrapper::ZERO,
-        max_fee: Felt252Wrapper::from(u128::MAX),
+        max_fee: Felt252Wrapper::from(u64::MAX),
         signature: bounded_vec!(),
         is_query: false,
     }
@@ -272,7 +272,7 @@ pub fn get_deploy_account_dummy(salt: Felt252Wrapper, account_type: AccountType)
         )
         .unwrap(),
         nonce: Felt252Wrapper::ZERO,
-        max_fee: Felt252Wrapper::from(u128::MAX),
+        max_fee: Felt252Wrapper::from(u64::MAX),
         signature: bounded_vec!(),
         is_query: false,
     }

--- a/crates/pallets/starknet/src/tests/utils.rs
+++ b/crates/pallets/starknet/src/tests/utils.rs
@@ -48,7 +48,7 @@ pub fn build_transfer_invoke_transaction(request: BuildTransferInvokeTransaction
             request.amount_high,   // initial supply high
         ],
         nonce: request.nonce,
-        max_fee: Felt252Wrapper::from(u128::MAX),
+        max_fee: Felt252Wrapper::from(u64::MAX),
         signature: bounded_vec!(),
         is_query: false,
     }

--- a/crates/primitives/starknet/src/execution/call_entrypoint_wrapper.rs
+++ b/crates/primitives/starknet/src/execution/call_entrypoint_wrapper.rs
@@ -18,6 +18,7 @@ use super::entrypoint_wrapper::{
     EntryPointExecutionErrorWrapper, EntryPointExecutionResultWrapper, EntryPointTypeWrapper,
 };
 use super::types::{ClassHashWrapper, ContractAddressWrapper, Felt252Wrapper};
+use crate::alloc::string::ToString;
 
 /// Max number of calldata / tx.
 #[cfg(not(test))]
@@ -161,11 +162,10 @@ impl TryInto<CallEntryPoint> for CallEntryPointWrapper {
             // starknet-lib is constantly breaking it's api
             // I hope it's nothing important ¯\_(ツ)_/¯
             code_address: None,
-            // initial_gas should come from the RPC call
-            // and should be a u64. If it's not, the error must
-            // be caught on the client side, hence it's safe to
-            // unwrap over here
-            initial_gas: self.initial_gas.try_into().unwrap(),
+            initial_gas: self
+                .initial_gas
+                .try_into()
+                .map_err(|_| StarknetApiError::OutOfRange { string: self.initial_gas.0.to_string() })?,
         };
 
         Ok(entrypoint)

--- a/crates/primitives/starknet/src/fees/mod.rs
+++ b/crates/primitives/starknet/src/fees/mod.rs
@@ -113,12 +113,15 @@ pub fn charge_fee<S: State + StateChanges + FeeConfig>(
     is_query: bool,
 ) -> Result<(Fee, Option<CallInfo>), TransactionExecutionErrorWrapper> {
     let no_fee = Fee::default();
-    if !is_query || state.is_transaction_fee_disabled() {
+    if state.is_transaction_fee_disabled() {
         // Fee charging is not enforced in some tests.
         return Ok((no_fee, None));
     }
     let actual_fee = calculate_tx_fee(resources, block_context)
         .map_err(|_| TransactionExecutionErrorWrapper::FeeComputationError)?;
+
+    // even if the user doesn't have enough balance
+    // estimate fee shouldn't fail
     if is_query {
         return Ok((actual_fee, None));
     }

--- a/crates/primitives/starknet/src/fees/mod.rs
+++ b/crates/primitives/starknet/src/fees/mod.rs
@@ -113,7 +113,7 @@ pub fn charge_fee<S: State + StateChanges + FeeConfig>(
     is_query: bool,
 ) -> Result<(Fee, Option<CallInfo>), TransactionExecutionErrorWrapper> {
     let no_fee = Fee::default();
-    if (!is_query && account_tx_context.max_fee == no_fee) || state.is_transaction_fee_disabled() {
+    if !is_query || state.is_transaction_fee_disabled() {
         // Fee charging is not enforced in some tests.
         return Ok((no_fee, None));
     }

--- a/crates/primitives/starknet/src/fees/mod.rs
+++ b/crates/primitives/starknet/src/fees/mod.rs
@@ -114,7 +114,6 @@ pub fn charge_fee<S: State + StateChanges + FeeConfig>(
 ) -> Result<(Fee, Option<CallInfo>), TransactionExecutionErrorWrapper> {
     let no_fee = Fee::default();
     if state.is_transaction_fee_disabled() {
-        // Fee charging is not enforced in some tests.
         return Ok((no_fee, None));
     }
     let actual_fee = calculate_tx_fee(resources, block_context)

--- a/crates/primitives/starknet/src/tests/crypto.rs
+++ b/crates/primitives/starknet/src/tests/crypto.rs
@@ -105,7 +105,7 @@ fn test_ref_merkle_tree() {
             call_entrypoint: CallEntryPointWrapper::default(),
             contract_class: None,
             contract_address_salt: None,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             is_query: false,
         },
         Transaction {
@@ -118,7 +118,7 @@ fn test_ref_merkle_tree() {
             call_entrypoint: CallEntryPointWrapper::default(),
             contract_class: None,
             contract_address_salt: None,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             is_query: false,
         },
     ];

--- a/crates/primitives/starknet/src/transaction/mod.rs
+++ b/crates/primitives/starknet/src/transaction/mod.rs
@@ -429,7 +429,7 @@ impl Transaction {
         };
 
         // FIXME 710
-        let mut initial_gas = super::constants::INITIAL_GAS;
+        let mut initial_gas = self.max_fee.try_into().unwrap(); // unwrap safe as >u64 case will be handled at client side
 
         self.validate_tx(state, execution_resources, block_context, &account_context, tx_type, &mut initial_gas)
     }
@@ -556,7 +556,7 @@ impl Transaction {
         self.verify_tx_version(&tx_type)?;
 
         // FIXME 710
-        let mut initial_gas = super::constants::INITIAL_GAS;
+        let mut initial_gas = self.max_fee.try_into().unwrap(); // unwrap safe as >u64 case will be handled at client side
 
         // Going one lower level gives us more flexibility like not validating the tx as we could do
         // it before the tx lands in the mempool.
@@ -850,7 +850,7 @@ impl Default for Transaction {
             call_entrypoint: CallEntryPointWrapper::default(),
             contract_class: None,
             contract_address_salt: None,
-            max_fee: Felt252Wrapper::from(u128::MAX),
+            max_fee: Felt252Wrapper::from(u64::MAX),
             is_query: false,
         }
     }

--- a/crates/primitives/starknet/src/transaction/mod.rs
+++ b/crates/primitives/starknet/src/transaction/mod.rs
@@ -428,8 +428,8 @@ impl Transaction {
             }
         };
 
-        // FIXME 710
-        let mut initial_gas = self.max_fee.try_into().unwrap(); // unwrap safe as >u64 case will be handled at client side
+        let mut initial_gas =
+            self.max_fee.try_into().map_err(|_| StarknetApiError::OutOfRange { string: self.max_fee.0.to_string() })?;
 
         self.validate_tx(state, execution_resources, block_context, &account_context, tx_type, &mut initial_gas)
     }
@@ -558,7 +558,10 @@ impl Transaction {
         // if it's an estimate fee then use max initial_gas
         let mut initial_gas = match self.is_query {
             true => u64::MAX,
-            false => self.max_fee.try_into().unwrap(), // unwrap safe as >u64 case will be handled at client side
+            false => self
+                .max_fee
+                .try_into()
+                .map_err(|_| StarknetApiError::OutOfRange { string: self.max_fee.0.to_string() })?,
         };
 
         // Going one lower level gives us more flexibility like not validating the tx as we could do

--- a/crates/primitives/starknet/src/transaction/types.rs
+++ b/crates/primitives/starknet/src/transaction/types.rs
@@ -9,7 +9,7 @@ use blockifier::execution::errors::EntryPointExecutionError;
 use blockifier::state::errors::StateError;
 use blockifier::transaction::errors::TransactionExecutionError;
 use blockifier::transaction::transaction_types::TransactionType;
-use frame_support::BoundedVec;
+use frame_support::{log, BoundedVec};
 use sp_core::{ConstU32, U256};
 use starknet_api::api_core::{calculate_contract_address, ClassHash, ContractAddress};
 use starknet_api::hash::StarkFelt;

--- a/crates/primitives/starknet/src/transaction/types.rs
+++ b/crates/primitives/starknet/src/transaction/types.rs
@@ -9,7 +9,7 @@ use blockifier::execution::errors::EntryPointExecutionError;
 use blockifier::state::errors::StateError;
 use blockifier::transaction::errors::TransactionExecutionError;
 use blockifier::transaction::transaction_types::TransactionType;
-use frame_support::{log, BoundedVec};
+use frame_support::BoundedVec;
 use sp_core::{ConstU32, U256};
 use starknet_api::api_core::{calculate_contract_address, ClassHash, ContractAddress};
 use starknet_api::hash::StarkFelt;

--- a/tests/tests/test-starknet-rpc/test-cairo-1.ts
+++ b/tests/tests/test-starknet-rpc/test-cairo-1.ts
@@ -122,6 +122,7 @@ describeDevMadara(
           {
             nonce: CAIRO_1_NO_VALIDATE_ACCOUNT.value,
             version: 1,
+            maxFee:'12345678'
           },
         );
         CAIRO_1_NO_VALIDATE_ACCOUNT.value += 1;
@@ -152,6 +153,7 @@ describeDevMadara(
           {
             nonce: CAIRO_1_NO_VALIDATE_ACCOUNT.value,
             version: 1,
+            maxFee:'12345678'
           },
         );
         await jumpBlocks(context, 1);

--- a/tests/tests/test-starknet-rpc/test-cairo-1.ts
+++ b/tests/tests/test-starknet-rpc/test-cairo-1.ts
@@ -122,7 +122,7 @@ describeDevMadara(
           {
             nonce: CAIRO_1_NO_VALIDATE_ACCOUNT.value,
             version: 1,
-            maxFee:'12345678'
+            maxFee: "12345678",
           },
         );
         CAIRO_1_NO_VALIDATE_ACCOUNT.value += 1;
@@ -153,7 +153,7 @@ describeDevMadara(
           {
             nonce: CAIRO_1_NO_VALIDATE_ACCOUNT.value,
             version: 1,
-            maxFee:'12345678'
+            maxFee: "12345678",
           },
         );
         await jumpBlocks(context, 1);

--- a/tests/tests/test-starknet-rpc/test-transactions.ts
+++ b/tests/tests/test-starknet-rpc/test-transactions.ts
@@ -511,7 +511,7 @@ describeDevMadara(
       it("should be possible for an account to estimateAccountDeployFee", async function () {
         const account = new Account(
           providerRPC,
-          "0x064d39e7bbf886361bd8ae14b482a0828a51ffd3e2d0256db867ac21d03fc41d",
+          ARGENT_CONTRACT_ADDRESS,
           SIGNER_PRIVATE,
         );
 
@@ -519,7 +519,7 @@ describeDevMadara(
           classHash: CAIRO_1_ACCOUNT_CONTRACT_CLASS_HASH,
           constructorCalldata: ["0x123"],
           addressSalt: SALT,
-          contractAddress:'0x064d39e7bbf886361bd8ae14b482a0828a51ffd3e2d0256db867ac21d03fc41d'
+          contractAddress: ARGENT_CONTRACT_ADDRESS
         });
 
         expect(suggestedMaxFee > 0n).to.be.equal(true);

--- a/tests/tests/test-starknet-rpc/test-transactions.ts
+++ b/tests/tests/test-starknet-rpc/test-transactions.ts
@@ -519,7 +519,7 @@ describeDevMadara(
           classHash: CAIRO_1_ACCOUNT_CONTRACT_CLASS_HASH,
           constructorCalldata: ["0x123"],
           addressSalt: SALT,
-          contractAddress: ARGENT_CONTRACT_ADDRESS
+          contractAddress: ARGENT_CONTRACT_ADDRESS,
         });
 
         expect(suggestedMaxFee > 0n).to.be.equal(true);

--- a/tests/tests/test-starknet-rpc/test-transactions.ts
+++ b/tests/tests/test-starknet-rpc/test-transactions.ts
@@ -274,7 +274,7 @@ describeDevMadara(
 
         const invocationDetails = {
           nonce: "0x0",
-          maxFee: "0x1111111111111111111111",
+          maxFee: "0x11111111111111",
           version: "0x1",
         };
 
@@ -511,7 +511,7 @@ describeDevMadara(
       it("should be possible for an account to estimateAccountDeployFee", async function () {
         const account = new Account(
           providerRPC,
-          ARGENT_CONTRACT_ADDRESS,
+          "0x064d39e7bbf886361bd8ae14b482a0828a51ffd3e2d0256db867ac21d03fc41d",
           SIGNER_PRIVATE,
         );
 
@@ -519,6 +519,7 @@ describeDevMadara(
           classHash: CAIRO_1_ACCOUNT_CONTRACT_CLASS_HASH,
           constructorCalldata: ["0x123"],
           addressSalt: SALT,
+          contractAddress:'0x064d39e7bbf886361bd8ae14b482a0828a51ffd3e2d0256db867ac21d03fc41d'
         });
 
         expect(suggestedMaxFee > 0n).to.be.equal(true);

--- a/tests/util/starknet.ts
+++ b/tests/util/starknet.ts
@@ -157,7 +157,7 @@ export function deploy(
       "0x0000000000000000000000000000000000000000000000000000000000000001", // deploy from zero
     ],
     max_fee:
-      "0x000000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+      "0x0000000000000000000000000000000000000000000000000FFFFFFFFFFFFFFF",
   };
 
   const extrisinc_deploy = api.tx.starknet.invoke(tx_deploy);
@@ -260,6 +260,8 @@ export function transfer(
       transferAmount,
       "0x0000000000000000000000000000000000000000000000000000000000000000",
     ],
+    max_fee:
+      "0x0000000000000000000000000000000000000000000000000FFFFFFFFFFFFFFF",
   };
 
   const extrisinc_transfer = api.tx.starknet.invoke(tx_transfer);
@@ -318,6 +320,8 @@ export function mintERC721(
       tokenID,
       "0x0000000000000000000000000000000000000000000000000000000000000000",
     ],
+    max_fee:
+      "0x0000000000000000000000000000000000000000000000000FFFFFFFFFFFFFFF",
   };
 
   return api.tx.starknet.invoke(tx_mint);
@@ -355,6 +359,8 @@ export function deployTokenContractUDC(
       "0x000000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", // Initial supply high
       "0x0000000000000000000000000000000000000000000000000000000000001111", // recipient
     ],
+    max_fee:
+      "0x0000000000000000000000000000000000000000000000000FFFFFFFFFFFFFFF",
   };
 
   const extrisinc_udc_deploy = api.tx.starknet.invoke(tx_udc_deploy);


### PR DESCRIPTION
- fixes incorrect initial_gas for transactions which would cause transactions to go through in the blockifier even if enough gas was not present
- fixed a bug where fees wouldn't be charged if max_fee was 0