### PR TITLE
fix: correct value of compiled_class_hash in RPCTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: estimate_fee should make sure all transaction have a version being
   2^128 + 1 or 2^128+2 depending on the tx type
+- fix: correct value of compiled_class_hash in RPCTransaction
 
 ## v0.2.0
 

--- a/crates/primitives/starknet/src/transaction/types.rs
+++ b/crates/primitives/starknet/src/transaction/types.rs
@@ -770,7 +770,11 @@ mod reexport_private_types {
                             nonce,
                             class_hash,
                             sender_address,
-                            compiled_class_hash: class_hash,
+                            compiled_class_hash: value
+                                .call_entrypoint
+                                .compiled_class_hash
+                                .ok_or(RPCTransactionConversionError::MissingInformation)?
+                                .0,
                         }))),
                         _ => Err(RPCTransactionConversionError::UnknownVersion),
                     }


### PR DESCRIPTION
class_hash was being returned instead of `compiled_class_hash` in RPCTransaction which is used in get_block_with_txs