### PR TITLE
feat: update starknet-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fix: initial_gas set to max_fee and fixed fee not being charged when max_fee=0
 - fix: correct value of compiled_class_hash in RPCTransaction
 - ci: scope cache by branch and add cache cleanup
+- feat: bump starknet-core to 0.6.0 and remove InvokeV0
 
 ## v0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## Next release
 
+- feat: bump starknet-core to 0.6.0 and remove InvokeV0
 - fix: estimate_fee should make sure all transaction have a version being
   2^128 + 1 or 2^128+2 depending on the tx type
 - fix: initial_gas set to max_fee and fixed fee not being charged when max_fee=0
 - fix: correct value of compiled_class_hash in RPCTransaction
 - ci: scope cache by branch and add cache cleanup
-- feat: bump starknet-core to 0.6.0 and remove InvokeV0
 
 ## v0.2.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9876,9 +9876,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starknet-core"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f89c79b641618de8aa9668d74c6b6634659ceca311c6318a35c025f9d4d969"
+checksum = "b796a32a7400f7d85e95d3900b5cee7a392b2adbf7ad16093ed45ec6f8d85de6"
 dependencies = [
  "base64 0.21.2",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ cairo-vm = { git = "https://github.com/keep-starknet-strange/cairo-rs", branch =
   "parity-scale-codec",
 ] }
 starknet-crypto = { version = "0.6.0", default-features = false }
-starknet-core = { version = "0.5.0", default-features = false }
+starknet-core = { version = "0.6.0", default-features = false }
 starknet-ff = { version = "0.3.4", default-features = false }
 
 blockifier = { git = "https://github.com/keep-starknet-strange/blockifier", branch = "no_std-support-7578442", default-features = false, features = [

--- a/crates/client/rpc/src/errors.rs
+++ b/crates/client/rpc/src/errors.rs
@@ -37,6 +37,8 @@ pub enum StarknetRpcApiError {
     InvalidContractClass = 50,
     #[error("Class already declared")]
     ClassAlreadyDeclared = 51,
+    #[error("Account validation failed")]
+    ValidationFailure = 55,
     #[error("The transaction version is not supported")]
     UnsupportedTxVersion = 61,
     #[error("Internal server error")]

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -28,6 +28,7 @@ use mp_starknet::transaction::types::{
 use pallet_starknet::runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_network_sync::SyncingService;
+use sc_transaction_pool_api::error::{Error as PoolError, IntoPoolError};
 use sc_transaction_pool_api::{InPoolTransaction, TransactionPool, TransactionSource};
 use sp_api::{ApiError, ProvideRuntimeApi};
 use sp_arithmetic::traits::UniqueSaturatedInto;
@@ -35,6 +36,7 @@ use sp_blockchain::HeaderBackend;
 use sp_core::H256;
 use sp_runtime::generic::BlockId as SPBlockId;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
+use sp_runtime::transaction_validity::InvalidTransaction;
 use sp_runtime::DispatchError;
 use starknet_core::types::{
     BlockHashAndNumber, BlockId, BlockStatus, BlockTag, BlockWithTxHashes, BlockWithTxs, BroadcastedDeclareTransaction,
@@ -42,7 +44,7 @@ use starknet_core::types::{
     DeclareTransactionResult, DeployAccountTransactionResult, EmittedEvent, EventFilterWithPage, EventsPage,
     FeeEstimate, FieldElement, FunctionCall, InvokeTransactionResult, MaybePendingBlockWithTxHashes,
     MaybePendingBlockWithTxs, MaybePendingTransactionReceipt, StateDiff, StateUpdate, SyncStatus, SyncStatusType,
-    Transaction, TransactionStatus,
+    Transaction, TransactionFinalityStatus,
 };
 
 use crate::constants::{MAX_EVENTS_CHUNK_SIZE, MAX_EVENTS_KEYS};
@@ -527,8 +529,7 @@ where
         block_id: BlockId,
     ) -> RpcResult<Vec<FeeEstimate>> {
         let is_invalid_query_transaction = request.iter().any(|tx| match tx {
-            BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V0(tx_v0)) => !tx_v0.is_query,
-            BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(tx_v1)) => !tx_v1.is_query,
+            BroadcastedTransaction::Invoke(invoke_tx) => !invoke_tx.is_query,
             BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V1(tx_v1)) => !tx_v1.is_query,
             BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(tx_v2)) => !tx_v2.is_query,
             BroadcastedTransaction::DeployAccount(deploy_tx) => !deploy_tx.is_query,
@@ -865,9 +866,10 @@ where
             .into_iter()
             .find(|receipt| receipt.transaction_hash == transaction_hash.into())
             .map(|receipt| {
-                receipt
-                    .clone()
-                    .into_maybe_pending_transaction_receipt(TransactionStatus::AcceptedOnL2, (block_hash, block_number))
+                receipt.clone().into_maybe_pending_transaction_receipt(
+                    TransactionFinalityStatus::AcceptedOnL2,
+                    (block_hash, block_number),
+                )
             });
 
         match find_receipt {
@@ -889,7 +891,10 @@ where
 {
     pool.submit_one(&SPBlockId::hash(best_block_hash), TX_SOURCE, extrinsic).await.map_err(|e| {
         error!("Failed to submit extrinsic: {:?}", e);
-        StarknetRpcApiError::InternalServerError
+        match e.into_pool_error() {
+            Ok(PoolError::InvalidTransaction(InvalidTransaction::BadProof)) => StarknetRpcApiError::ValidationFailure,
+            _ => StarknetRpcApiError::InternalServerError,
+        }
     })
 }
 

--- a/crates/primitives/starknet/src/tests/transaction.rs
+++ b/crates/primitives/starknet/src/tests/transaction.rs
@@ -12,10 +12,7 @@ use starknet_api::transaction::{
     Event, EventContent, EventData, EventKey, Fee, InvokeTransactionOutput, TransactionExecutionStatus,
     TransactionHash, TransactionOutput, TransactionReceipt,
 };
-use starknet_core::types::{
-    BroadcastedDeployAccountTransaction, BroadcastedInvokeTransaction, BroadcastedInvokeTransactionV0,
-    BroadcastedInvokeTransactionV1, StarknetError,
-};
+use starknet_core::types::{BroadcastedDeployAccountTransaction, BroadcastedInvokeTransaction};
 use starknet_ff::FieldElement;
 
 use crate::execution::call_entrypoint_wrapper::{CallEntryPointWrapper, MaxCalldataSize};
@@ -399,30 +396,8 @@ fn test_try_into_deploy_account_transaction() {
 }
 
 #[test]
-fn test_try_invoke_txn_from_broadcasted_invoke_txn_v0() {
-    let broadcasted_invoke_txn_v0 = BroadcastedInvokeTransactionV0 {
-        max_fee: FieldElement::default(),
-        signature: vec![FieldElement::default()],
-        nonce: FieldElement::default(),
-        contract_address: FieldElement::default(),
-        entry_point_selector: FieldElement::default(),
-        calldata: vec![FieldElement::default()],
-        is_query: false,
-    };
-
-    let broadcasted_invoke_txn = BroadcastedInvokeTransaction::V0(broadcasted_invoke_txn_v0);
-    let invoke_txn = InvokeTransaction::try_from(broadcasted_invoke_txn);
-
-    assert!(invoke_txn.is_err());
-    assert!(matches!(
-        invoke_txn.unwrap_err(),
-        BroadcastedTransactionConversionErrorWrapper::StarknetError(StarknetError::FailedToReceiveTransaction)
-    ))
-}
-
-#[test]
 fn test_try_invoke_txn_from_broadcasted_invoke_txn_v1() {
-    let broadcasted_invoke_txn_v1 = BroadcastedInvokeTransactionV1 {
+    let broadcasted_invoke_txn = BroadcastedInvokeTransaction {
         max_fee: FieldElement::default(),
         nonce: FieldElement::default(),
         sender_address: FieldElement::default(),
@@ -431,7 +406,6 @@ fn test_try_invoke_txn_from_broadcasted_invoke_txn_v1() {
         is_query: false,
     };
 
-    let broadcasted_invoke_txn = BroadcastedInvokeTransaction::V1(broadcasted_invoke_txn_v1);
     let invoke_txn = InvokeTransaction::try_from(broadcasted_invoke_txn).unwrap();
 
     let expected_sig: BoundedVec<Felt252Wrapper, MaxArraySize> =
@@ -451,7 +425,7 @@ fn test_try_invoke_txn_from_broadcasted_invoke_txn_v1() {
 fn test_try_invoke_txn_from_broadcasted_invoke_txn_v1_max_sig_size() {
     let signature_size_maxed = vec![FieldElement::default(); MaxArraySize::get() as usize + 1];
 
-    let broadcasted_invoke_txn_v1 = BroadcastedInvokeTransactionV1 {
+    let broadcasted_invoke_txn = BroadcastedInvokeTransaction {
         max_fee: FieldElement::default(),
         nonce: FieldElement::default(),
         sender_address: FieldElement::default(),
@@ -460,7 +434,6 @@ fn test_try_invoke_txn_from_broadcasted_invoke_txn_v1_max_sig_size() {
         is_query: false,
     };
 
-    let broadcasted_invoke_txn = BroadcastedInvokeTransaction::V1(broadcasted_invoke_txn_v1);
     let invoke_txn = InvokeTransaction::try_from(broadcasted_invoke_txn);
 
     assert!(invoke_txn.is_err());
@@ -471,7 +444,7 @@ fn test_try_invoke_txn_from_broadcasted_invoke_txn_v1_max_sig_size() {
 fn test_try_invoke_txn_from_broadcasted_invoke_txn_v1_max_calldata_size() {
     let calldata_size_maxed = vec![FieldElement::default(); MaxCalldataSize::get() as usize + 1];
 
-    let broadcasted_invoke_txn_v1 = BroadcastedInvokeTransactionV1 {
+    let broadcasted_invoke_txn = BroadcastedInvokeTransaction {
         max_fee: FieldElement::default(),
         nonce: FieldElement::default(),
         sender_address: FieldElement::default(),
@@ -480,7 +453,6 @@ fn test_try_invoke_txn_from_broadcasted_invoke_txn_v1_max_calldata_size() {
         is_query: false,
     };
 
-    let broadcasted_invoke_txn = BroadcastedInvokeTransaction::V1(broadcasted_invoke_txn_v1);
     let invoke_txn = InvokeTransaction::try_from(broadcasted_invoke_txn);
 
     assert!(invoke_txn.is_err());

--- a/tests/tests/test-starknet-rpc/test-block.ts
+++ b/tests/tests/test-starknet-rpc/test-block.ts
@@ -67,11 +67,11 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
           providerRPC,
           ARGENT_CONTRACT_NONCE,
           ARGENT_CONTRACT_ADDRESS,
-          MINT_AMOUNT
+          MINT_AMOUNT,
         ),
         {
           finalize: true,
-        }
+        },
       );
 
       const transactionCount = await providerRPC.getTransactionCount("latest");
@@ -92,7 +92,7 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
     it("should increase after a transaction", async function () {
       let nonce = await providerRPC.getNonceForAddress(
         ARGENT_CONTRACT_ADDRESS,
-        "latest"
+        "latest",
       );
 
       await context.createBlock(
@@ -100,13 +100,13 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
           providerRPC,
           ARGENT_CONTRACT_NONCE,
           ARGENT_CONTRACT_ADDRESS,
-          MINT_AMOUNT
-        )
+          MINT_AMOUNT,
+        ),
       );
 
       nonce = await providerRPC.getNonceForAddress(
         ARGENT_CONTRACT_ADDRESS,
-        "latest"
+        "latest",
       );
 
       expect(nonce).to.not.be.undefined;
@@ -126,10 +126,10 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
       // starknet current and highest block number should be equal to
       // the current block with this test setup
       expect(parseInt(status["current_block_num"])).to.be.equal(
-        current_block["block_number"]
+        current_block["block_number"],
       );
       expect(parseInt(status["highest_block_num"])).to.be.equal(
-        current_block["block_number"]
+        current_block["block_number"],
       );
 
       // the starknet block hash for number 0 starts with "0x31eb" with this test setup
@@ -137,10 +137,10 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
       // starknet current and highest block number should be equal to
       // the current block with this test setup
       expect(status["current_block_hash"]).to.be.equal(
-        current_block["block_hash"]
+        current_block["block_hash"],
       );
       expect(status["highest_block_hash"]).to.be.equal(
-        current_block["block_hash"]
+        current_block["block_hash"],
       );
     });
   });
@@ -153,9 +153,8 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
       });
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      const latestBlock: Block = await providerRPC.getBlockWithTxHashes(
-        "latest"
-      );
+      const latestBlock: Block =
+        await providerRPC.getBlockWithTxHashes("latest");
       expect(latestBlock).to.not.be.undefined;
       expect(latestBlock.status).to.be.equal("ACCEPTED_ON_L2");
       expect(latestBlock.transactions.length).to.be.equal(0);
@@ -167,15 +166,14 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
           providerRPC,
           ARGENT_CONTRACT_NONCE,
           ARGENT_CONTRACT_ADDRESS,
-          MINT_AMOUNT
-        )
+          MINT_AMOUNT,
+        ),
       );
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      const blockWithTxHashes: Block = await providerRPC.getBlockWithTxHashes(
-        "latest"
-      );
+      const blockWithTxHashes: Block =
+        await providerRPC.getBlockWithTxHashes("latest");
       expect(blockWithTxHashes).to.not.be.undefined;
       expect(blockWithTxHashes.status).to.be.equal("ACCEPTED_ON_L2");
       expect(blockWithTxHashes.transactions.length).to.be.equal(1);
@@ -209,15 +207,15 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
           providerRPC,
           ARGENT_CONTRACT_NONCE,
           ARGENT_CONTRACT_ADDRESS,
-          MINT_AMOUNT
-        )
+          MINT_AMOUNT,
+        ),
       );
 
       const blockHash = await providerRPC.getBlockHashAndNumber();
       await jumpBlocks(context, 10);
 
       const blockWithTxHashes = await providerRPC.getBlockWithTxs(
-        blockHash.block_hash
+        blockHash.block_hash,
       );
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -237,7 +235,7 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
           ARGENT_CONTRACT_ADDRESS,
           MINT_AMOUNT,
           0,
-        ].map(toHex)
+        ].map(toHex),
       );
     });
 
@@ -253,7 +251,7 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
     it("should support 'pending' block id", async function () {
       const nonce = await providerRPC.getNonceForAddress(
         ARGENT_CONTRACT_ADDRESS,
-        "pending"
+        "pending",
       );
       expect(nonce).to.not.be.undefined;
     });
@@ -261,7 +259,7 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
     it("should support 'latest' block id", async function () {
       const nonce = await providerRPC.getNonceForAddress(
         ARGENT_CONTRACT_ADDRESS,
-        "latest"
+        "latest",
       );
       expect(nonce).to.not.be.undefined;
     });

--- a/tests/tests/test-starknet-rpc/test-block.ts
+++ b/tests/tests/test-starknet-rpc/test-block.ts
@@ -67,11 +67,11 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
           providerRPC,
           ARGENT_CONTRACT_NONCE,
           ARGENT_CONTRACT_ADDRESS,
-          MINT_AMOUNT,
+          MINT_AMOUNT
         ),
         {
           finalize: true,
-        },
+        }
       );
 
       const transactionCount = await providerRPC.getTransactionCount("latest");
@@ -92,7 +92,7 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
     it("should increase after a transaction", async function () {
       let nonce = await providerRPC.getNonceForAddress(
         ARGENT_CONTRACT_ADDRESS,
-        "latest",
+        "latest"
       );
 
       await context.createBlock(
@@ -100,13 +100,13 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
           providerRPC,
           ARGENT_CONTRACT_NONCE,
           ARGENT_CONTRACT_ADDRESS,
-          MINT_AMOUNT,
-        ),
+          MINT_AMOUNT
+        )
       );
 
       nonce = await providerRPC.getNonceForAddress(
         ARGENT_CONTRACT_ADDRESS,
-        "latest",
+        "latest"
       );
 
       expect(nonce).to.not.be.undefined;
@@ -122,14 +122,14 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
       const current_block = await providerRPC.getBlockHashAndNumber();
 
       // starknet starting block number should be 0 with this test setup
-      expect(status["starting_block_num"]).to.be.equal("0x0");
+      expect(status["starting_block_num"]).to.be.equal(0);
       // starknet current and highest block number should be equal to
       // the current block with this test setup
       expect(parseInt(status["current_block_num"])).to.be.equal(
-        current_block["block_number"],
+        current_block["block_number"]
       );
       expect(parseInt(status["highest_block_num"])).to.be.equal(
-        current_block["block_number"],
+        current_block["block_number"]
       );
 
       // the starknet block hash for number 0 starts with "0x31eb" with this test setup
@@ -137,10 +137,10 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
       // starknet current and highest block number should be equal to
       // the current block with this test setup
       expect(status["current_block_hash"]).to.be.equal(
-        current_block["block_hash"],
+        current_block["block_hash"]
       );
       expect(status["highest_block_hash"]).to.be.equal(
-        current_block["block_hash"],
+        current_block["block_hash"]
       );
     });
   });
@@ -153,8 +153,9 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
       });
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      const latestBlock: Block =
-        await providerRPC.getBlockWithTxHashes("latest");
+      const latestBlock: Block = await providerRPC.getBlockWithTxHashes(
+        "latest"
+      );
       expect(latestBlock).to.not.be.undefined;
       expect(latestBlock.status).to.be.equal("ACCEPTED_ON_L2");
       expect(latestBlock.transactions.length).to.be.equal(0);
@@ -166,14 +167,15 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
           providerRPC,
           ARGENT_CONTRACT_NONCE,
           ARGENT_CONTRACT_ADDRESS,
-          MINT_AMOUNT,
-        ),
+          MINT_AMOUNT
+        )
       );
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      const blockWithTxHashes: Block =
-        await providerRPC.getBlockWithTxHashes("latest");
+      const blockWithTxHashes: Block = await providerRPC.getBlockWithTxHashes(
+        "latest"
+      );
       expect(blockWithTxHashes).to.not.be.undefined;
       expect(blockWithTxHashes.status).to.be.equal("ACCEPTED_ON_L2");
       expect(blockWithTxHashes.transactions.length).to.be.equal(1);
@@ -207,15 +209,15 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
           providerRPC,
           ARGENT_CONTRACT_NONCE,
           ARGENT_CONTRACT_ADDRESS,
-          MINT_AMOUNT,
-        ),
+          MINT_AMOUNT
+        )
       );
 
       const blockHash = await providerRPC.getBlockHashAndNumber();
       await jumpBlocks(context, 10);
 
       const blockWithTxHashes = await providerRPC.getBlockWithTxs(
-        blockHash.block_hash,
+        blockHash.block_hash
       );
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -235,7 +237,7 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
           ARGENT_CONTRACT_ADDRESS,
           MINT_AMOUNT,
           0,
-        ].map(toHex),
+        ].map(toHex)
       );
     });
 
@@ -251,7 +253,7 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
     it("should support 'pending' block id", async function () {
       const nonce = await providerRPC.getNonceForAddress(
         ARGENT_CONTRACT_ADDRESS,
-        "pending",
+        "pending"
       );
       expect(nonce).to.not.be.undefined;
     });
@@ -259,7 +261,7 @@ describeDevMadara("Starknet RPC - Block Test", (context) => {
     it("should support 'latest' block id", async function () {
       const nonce = await providerRPC.getNonceForAddress(
         ARGENT_CONTRACT_ADDRESS,
-        "latest",
+        "latest"
       );
       expect(nonce).to.not.be.undefined;
     });


### PR DESCRIPTION
- bump starknet-core to 0.6.0
- remove InvokeTransactionV0 (it's deprecated now)
- return `ValidationFailure` if there's an error in signature validation