### PR TITLE
build: add rust-analyzer to toolchain components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - ci: scope cache by branch and add cache cleanup
 - feat: print development accounts at node startup
 - test: add test to check tx signed by OZ account can be signed with Argent pk
+- buid: add rust-analyzer to toolchain components
 
 ## v0.2.0
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "nightly-2023-08-24"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
My rust analyzer stopped working after #1068 and I didn't understand why.
With this, I can just run `cargo install` in the project and it will install the correct version