### PR TITLE
dev: increase threshold for codecov to 1%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     patch:
       default:
-        target: 0%
+        target: 1%
     project:
       default:
-        threshold: 0%
+        threshold: 1%

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - feat: print development accounts at node startup
 - test: add test to check tx signed by OZ account can be signed with Argent pk
 - buid: add rust-analyzer to toolchain components
+- ci: increase threshold for codecov to 1%
 
 ## v0.2.0
 


### PR DESCRIPTION
The issue #1072 gives a valid reason for this increase. I was looking through the repo and saw this smol issue hanging around.

# Pull Request type
Please add the labels corresponding to the type of changes your PR introduces:
- Other (please describe): CI tweak

## What is the current behavior?
Threshold is 0%

Resolves: #1072 

## What is the new behavior?
Increased to 1%

## Does this introduce a breaking change?
No

## Other information
