### PR TITLE
chore: add tx hashing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - reduce the amount of data stored in the runtime and use the Substrate block to
   as source of data in the client
 - perf: use perfect hash function in calculate_l1_gas_by_vm_usage
+- chore: add tests for tx hashing
 
 ## v0.2.0
 


### PR DESCRIPTION
Adds tests for all transaction type hashing. Closes #1114

# Pull Request type
- Testing

## Does this introduce a breaking change?

No
