### PR TITLE
fix: transactions crate std import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - perf: use perfect hash function in calculate_l1_gas_by_vm_usage
 - chore: add tests for tx hashing
 - split `primitives` crates into multiple smaller crates
+- fix: std feature import in transactions crate
 
 ## v0.2.0
 

--- a/crates/primitives/transactions/Cargo.toml
+++ b/crates/primitives/transactions/Cargo.toml
@@ -49,6 +49,10 @@ std = [
   "starknet-ff/std",
   "starknet-core/std",
   "blockifier/std",
+  "mp-state/std",
+  "mp-hashers/std",
+  "mp-felt/std",
+  "mp-fee/std",
   # Optional
   "parity-scale-codec?/std",
   "scale-info?/std",


### PR DESCRIPTION
The transactions crate was missing the std feature for 4 crates, causing the tests in the crate to compile in no_std, which doesn't work. As a result, the crate tests cant be run from within the crate.

# Pull Request type

- Bugfix

## What is the current behavior?

transactions tests can't be run in `crates/primitives/transactions`

## What is the new behavior?
The tests can be run within the crate

## Does this introduce a breaking change?

No

