### PR TITLE
Fix logging during setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - fix: fix sharingan chain spec
 - fix: update madara infra to main branch
 - fix: update `Cargo.lock`
-- fix: ensure logger is initialized for `setup` cli command to produce logging output
+- fix: ensure logger is initialized for `setup` cli command
 
 ## v0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fix: fix sharingan chain spec
 - fix: update madara infra to main branch
 - fix: update `Cargo.lock`
+- fix: ensure logger is initialized for `setup` cli command to produce logging output
 
 ## v0.3.0
 

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use mc_data_availability::DaLayer;
-use sc_cli::RunCmd;
+use sc_cli::{CliConfiguration, DatabaseParams, RunCmd, SharedParams};
 
 use crate::constants;
 
@@ -71,6 +71,24 @@ pub struct SetupCmd {
     /// Where the `md5` and `url` fields are optional
     #[clap(long, default_value = constants::DEFAULT_CONFIGS_URL)]
     pub fetch_madara_configs: Option<String>,
+
+    #[allow(missing_docs)]
+    #[clap(flatten)]
+    pub shared_params: SharedParams,
+
+    #[allow(missing_docs)]
+    #[clap(flatten)]
+    pub database_params: DatabaseParams,
+}
+
+impl CliConfiguration for SetupCmd {
+    fn shared_params(&self) -> &SharedParams {
+        &self.shared_params
+    }
+
+    fn database_params(&self) -> Option<&DatabaseParams> {
+        Some(&self.database_params)
+    }
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/crates/node/src/command.rs
+++ b/crates/node/src/command.rs
@@ -322,8 +322,9 @@ pub fn run() -> sc_cli::Result<()> {
                 service::new_full(config, sealing, da_config).map_err(sc_cli::Error::Service)
             })
         }
-        Some(Subcommand::Setup(cmd)) => {
-            fetch_madara_configs(&cli.madara_path, &cmd)?;
+        Some(Subcommand::Setup(ref cmd)) => {
+            let _runner = cli.create_runner(cmd)?;
+            fetch_madara_configs(&cli.madara_path, cmd)?;
             Ok(())
         }
         _ => Err("You need to specify some subcommand. E.g. `madara run`".into()),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

## What is the current behavior?

Current behavior is that the setup cli command produces no logs to output, despite invoking functions which contain logs.

Resolves: https://github.com/keep-starknet-strange/madara/issues/1126

## What is the new behavior?

- Setup function produces logs as expected
- The logger is initialized 

## Does this introduce a breaking change?
No

## Other information

Screenshot of new output:
![image](https://github.com/keep-starknet-strange/madara/assets/81839854/207f303e-8229-43f9-8c5f-2e1a8e84a882)
Are we okay with this output? I am not sure what this is all doing, but if all the information is useful, I think it makes sense.

Noting one other thing: if we're not happy with initializing the whole runner for whatever reason, a third option is to just run it as a script.