### PR TITLE
Tests for `validate_unsigned` for L1 Messages transactions

### DIFF
--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -763,17 +763,17 @@ pub mod pallet {
             let mut valid_transaction_builder = ValidTransaction::with_tag_prefix("starknet")
                 .priority(u64::MAX - nonce_for_priority)
                 .and_provides((sender_address, transaction_nonce))
-				.longevity(T::TransactionLongevity::get())
+                .longevity(T::TransactionLongevity::get())
                 .propagate(true);
 
             if let Some(sender_nonce) = sender_nonce {
-					// Enforce waiting for the tx with the previous nonce,
-                    // to be either executed or ordered before in the block
-                    if transaction_nonce > sender_nonce {
-                        valid_transaction_builder = valid_transaction_builder
-                            .and_requires((sender_address, Felt252Wrapper(transaction_nonce.0 - FieldElement::ONE)));
-                    }
+                // Enforce waiting for the tx with the previous nonce,
+                // to be either executed or ordered before in the block
+                if transaction_nonce > sender_nonce {
+                    valid_transaction_builder = valid_transaction_builder
+                        .and_requires((sender_address, Felt252Wrapper(transaction_nonce.0 - FieldElement::ONE)));
                 }
+            }
 
             valid_transaction_builder.build()
         }

--- a/crates/pallets/starknet/src/tests/l1_message.rs
+++ b/crates/pallets/starknet/src/tests/l1_message.rs
@@ -1,46 +1,19 @@
-use frame_support::assert_err;
 use mp_felt::Felt252Wrapper;
-use mp_transactions::{DeclareTransactionV1, HandleL1MessageTransaction};
+use mp_transactions::HandleL1MessageTransaction;
 use sp_runtime::traits::ValidateUnsigned;
-use sp_runtime::transaction_validity::TransactionSource;
+use sp_runtime::transaction_validity::{TransactionSource, TransactionTag};
+use starknet_api::api_core::ContractAddress;
 use starknet_api::transaction::Fee;
 
 use super::mock::default_mock::*;
 use super::mock::*;
-use super::utils::get_contract_class;
-use crate::Error;
+
+use frame_support::codec::Encode;
+
+const VALID_TX_BUILDER_TAG: &str = "starknet";
 
 #[test]
-fn given_contract_l1_message_fails_sender_not_deployed() {
-    new_test_ext::<MockRuntime>().execute_with(|| {
-        basic_test_setup(2);
-
-        let none_origin = RuntimeOrigin::none();
-
-        // Wrong address (not deployed)
-        let contract_address =
-            Felt252Wrapper::from_hex_be("0x03e437FB56Bb213f5708Fcd6966502070e276c093ec271aA33433b89E21fd31f").unwrap();
-
-        let erc20_class = get_contract_class("ERC20.json", 0);
-
-        let transaction = DeclareTransactionV1 {
-            sender_address: contract_address,
-            nonce: Default::default(),
-            signature: Default::default(),
-            max_fee: Default::default(),
-            class_hash: Default::default(),
-        };
-
-        assert_err!(
-            Starknet::declare(none_origin, transaction.into(), erc20_class),
-            Error::<MockRuntime>::AccountNotDeployed
-        );
-    })
-}
-
-#[test]
-#[ignore = "l1 handler validation not implemented yet"]
-fn verify_tx_longevity() {
+fn verify_tx_validity() {
     new_test_ext::<MockRuntime>().execute_with(|| {
         basic_test_setup(2);
 
@@ -51,11 +24,24 @@ fn verify_tx_longevity() {
             calldata: Default::default(),
         };
 
+        let expected_priority = u64::MAX - transaction.nonce;
+        let expected_provide: (Felt252Wrapper, Felt252Wrapper) = (ContractAddress::default().into(), transaction.nonce.into());
+		let expected_provide: TransactionTag = (VALID_TX_BUILDER_TAG, expected_provide).encode();
+        let expected_longetivity = TransactionLongevity::get();
+        let expected_propagate = true;
+
         let validate_result = Starknet::validate_unsigned(
             TransactionSource::InBlock,
             &crate::Call::consume_l1_message { transaction, paid_fee_on_l1: Fee(100) },
         );
 
-        assert!(validate_result.unwrap().longevity == TransactionLongevity::get());
+        assert!(validate_result.is_ok());
+        let validate_result = validate_result.unwrap();
+
+		assert_eq!(validate_result.priority, expected_priority);
+		assert_eq!(validate_result.requires, Vec::<TransactionTag>::new());
+        assert_eq!(validate_result.provides, Vec::<TransactionTag>::from([expected_provide]));
+		assert_eq!(validate_result.longevity, expected_longetivity);
+		assert_eq!(validate_result.propagate, expected_propagate);
     });
 }

--- a/crates/pallets/starknet/src/tests/l1_message.rs
+++ b/crates/pallets/starknet/src/tests/l1_message.rs
@@ -1,14 +1,15 @@
+use frame_support::codec::Encode;
 use mp_felt::Felt252Wrapper;
 use mp_transactions::HandleL1MessageTransaction;
 use sp_runtime::traits::ValidateUnsigned;
-use sp_runtime::transaction_validity::{TransactionSource, TransactionTag};
-use starknet_api::api_core::ContractAddress;
+use sp_runtime::transaction_validity::{TransactionSource, TransactionTag, TransactionValidityError};
+use starknet_api::api_core::{ContractAddress, Nonce};
+use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::Fee;
 
 use super::mock::default_mock::*;
 use super::mock::*;
-
-use frame_support::codec::Encode;
+use crate::{Call, InvalidTransaction, L1Messages};
 
 const VALID_TX_BUILDER_TAG: &str = "starknet";
 
@@ -25,23 +26,52 @@ fn verify_tx_validity() {
         };
 
         let expected_priority = u64::MAX - transaction.nonce;
-        let expected_provide: (Felt252Wrapper, Felt252Wrapper) = (ContractAddress::default().into(), transaction.nonce.into());
-		let expected_provide: TransactionTag = (VALID_TX_BUILDER_TAG, expected_provide).encode();
+        let expected_provide: (Felt252Wrapper, Felt252Wrapper) =
+            (ContractAddress::default().into(), transaction.nonce.into());
+        let expected_provide: TransactionTag = (VALID_TX_BUILDER_TAG, expected_provide).encode();
         let expected_longetivity = TransactionLongevity::get();
         let expected_propagate = true;
 
         let validate_result = Starknet::validate_unsigned(
             TransactionSource::InBlock,
-            &crate::Call::consume_l1_message { transaction, paid_fee_on_l1: Fee(100) },
+            &Call::consume_l1_message { transaction, paid_fee_on_l1: Fee(100) },
         );
 
         assert!(validate_result.is_ok());
         let validate_result = validate_result.unwrap();
 
-		assert_eq!(validate_result.priority, expected_priority);
-		assert_eq!(validate_result.requires, Vec::<TransactionTag>::new());
+        assert_eq!(validate_result.priority, expected_priority);
+        assert_eq!(validate_result.requires, Vec::<TransactionTag>::new());
         assert_eq!(validate_result.provides, Vec::<TransactionTag>::from([expected_provide]));
-		assert_eq!(validate_result.longevity, expected_longetivity);
-		assert_eq!(validate_result.propagate, expected_propagate);
+        assert_eq!(validate_result.longevity, expected_longetivity);
+        assert_eq!(validate_result.propagate, expected_propagate);
+    });
+}
+
+#[test]
+fn should_reject_used_nonce() {
+    new_test_ext::<MockRuntime>().execute_with(|| {
+        basic_test_setup(2);
+
+        let nonce: u64 = 1;
+
+        let transaction = HandleL1MessageTransaction {
+            nonce,
+            contract_address: Default::default(),
+            entry_point_selector: Default::default(),
+            calldata: Default::default(),
+        };
+
+        let tx_source = TransactionSource::InBlock;
+        let call = Call::consume_l1_message { transaction, paid_fee_on_l1: Fee(100) };
+
+        assert!(Starknet::validate_unsigned(tx_source, &call).is_ok());
+
+        L1Messages::<MockRuntime>::insert(Nonce(StarkFelt::from(nonce)), ());
+
+        assert_eq!(
+            Starknet::validate_unsigned(tx_source, &call),
+            Err(TransactionValidityError::Invalid(InvalidTransaction::Stale))
+        );
     });
 }

--- a/crates/pallets/starknet/src/tests/mod.rs
+++ b/crates/pallets/starknet/src/tests/mod.rs
@@ -26,6 +26,7 @@ mod no_nonce_validation;
 mod query_tx;
 mod send_message;
 mod sequencer_address;
+mod transaction_validation;
 
 mod block;
 mod constants;

--- a/crates/pallets/starknet/src/tests/transaction_validation.rs
+++ b/crates/pallets/starknet/src/tests/transaction_validation.rs
@@ -1,0 +1,86 @@
+use mp_transactions::{HandleL1MessageTransaction, UserAndL1HandlerTransaction};
+use sp_runtime::transaction_validity::InvalidTransaction;
+use starknet_api::api_core::{ContractAddress, Nonce};
+use starknet_api::hash::StarkFelt;
+use starknet_api::transaction::Fee;
+
+use super::mock::default_mock::*;
+use super::mock::*;
+use crate::L1Messages;
+
+#[test]
+fn should_ensure_l1_message_not_executed_work_properly() {
+    new_test_ext::<MockRuntime>().execute_with(|| {
+        basic_test_setup(2);
+
+        let nonce = Nonce(StarkFelt::from(1u64));
+
+        assert!(Starknet::ensure_l1_message_not_executed(&nonce).is_ok());
+
+        L1Messages::<MockRuntime>::insert(nonce, ());
+
+        assert_eq!(Starknet::ensure_l1_message_not_executed(&nonce), Err(InvalidTransaction::Stale));
+    });
+}
+
+#[test]
+fn should_accept_unused_nonce() {
+    new_test_ext::<MockRuntime>().execute_with(|| {
+        basic_test_setup(2);
+
+        let nonce: u64 = 1;
+        let transaction = HandleL1MessageTransaction {
+            nonce,
+            contract_address: Default::default(),
+            entry_point_selector: Default::default(),
+            calldata: Default::default(),
+        };
+
+        let tx = UserAndL1HandlerTransaction::L1Handler(transaction, Fee(100));
+
+        assert_eq!(
+            Starknet::validate_usigned_tx_nonce(&tx),
+            Ok((ContractAddress::default().into(), None, nonce.into()))
+        );
+    });
+}
+
+#[test]
+fn should_reject_used_nonce() {
+    new_test_ext::<MockRuntime>().execute_with(|| {
+        basic_test_setup(2);
+
+        let nonce: u64 = 1;
+        let transaction = HandleL1MessageTransaction {
+            nonce,
+            contract_address: Default::default(),
+            entry_point_selector: Default::default(),
+            calldata: Default::default(),
+        };
+
+        let tx = UserAndL1HandlerTransaction::L1Handler(transaction, Fee(100));
+
+        L1Messages::<MockRuntime>::insert(Nonce(StarkFelt::from(nonce)), ());
+
+        assert_eq!(Starknet::validate_usigned_tx_nonce(&tx), Err(InvalidTransaction::Stale));
+    });
+}
+
+#[test]
+fn should_accept_valid_unsigned_l1_message_tx() {
+    new_test_ext::<MockRuntime>().execute_with(|| {
+        basic_test_setup(2);
+
+        let nonce: u64 = 1;
+        let transaction = HandleL1MessageTransaction {
+            nonce,
+            contract_address: Default::default(),
+            entry_point_selector: Default::default(),
+            calldata: Default::default(),
+        };
+
+        let tx = UserAndL1HandlerTransaction::L1Handler(transaction, Fee(100));
+
+        assert!(Starknet::validate_unsigned_tx(&tx).is_ok());
+    });
+}


### PR DESCRIPTION
Part of #1163 