### PR TITLE
fix(starknet-rpc-test): don't share reqwest client across test runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(starknet-rpc-test): init one request client per runtime
 - test: validate Nonce for unsigned user txs
 - fix: fixed declare V0 placeholder with the hash of an empty list of felts
 - feat(cli): `run` is the by default command when running the `madara` bin
@@ -21,7 +22,7 @@
 - refacto(pallet/starknet): `GenesisLoader` refactored as `GenesisData` + a
   `base_path` field
 - feat(cli): for `run` param `--dev` now imply `--tmp`, as it is in substrate
-- test(starknet-rpx-test): run all tests against a single madara node
+- test(starknet-rpc-test): run all tests against a single madara node
 
 ## v0.4.0
 

--- a/starknet-rpc-test/src/lib.rs
+++ b/starknet-rpc-test/src/lib.rs
@@ -84,7 +84,6 @@ impl Transaction<'_> {
 #[derive(Debug)]
 /// A wrapper over the Madara process handle, reqwest client and request counter
 pub struct MadaraClient {
-    client: Client,
     rpc_request_count: Cell<usize>,
     url: Url,
 }
@@ -92,7 +91,7 @@ pub struct MadaraClient {
 impl Default for MadaraClient {
     fn default() -> Self {
         let url = Url::parse(NODE_RPC_URL).expect("Invalid JSONRPC Url");
-        MadaraClient { client: Client::new(), url, rpc_request_count: Default::default() }
+        MadaraClient { url, rpc_request_count: Default::default() }
     }
 }
 
@@ -132,8 +131,7 @@ impl MadaraClient {
 
         let body = serde_json::to_string(&body).expect("the json body must be serializable");
 
-        let response = self
-            .client
+        let response = Client::new()
             .post("http://localhost:9944")
             .header(CONTENT_TYPE, "application/json; charset=utf-8")
             .body(body)


### PR DESCRIPTION
https://github.com/keep-starknet-strange/madara/actions/runs/6495558436/job/17642025203?pr=1182
https://users.rust-lang.org/t/runtime-dropped-the-dispatch-task/91915/8