### PR TITLE
fix event commitment documentation typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix: event commitment documentation typo
 - ci: added testing key generation in the ci
 - fix(starknet-rpc-test): init one request client per runtime
 - test: validate Nonce for unsigned user txs

--- a/crates/primitives/commitments/src/lib.rs
+++ b/crates/primitives/commitments/src/lib.rs
@@ -161,7 +161,7 @@ pub(crate) fn calculate_transaction_commitment<H: HasherT>(
     tree.commit()
 }
 
-/// Calculate transaction commitment hash value.
+/// Calculate event commitment hash value.
 ///
 /// The event commitment is the root of the Patricia Merkle tree with height 64
 /// constructed by adding the event hash
@@ -170,11 +170,11 @@ pub(crate) fn calculate_transaction_commitment<H: HasherT>(
 ///
 /// # Arguments
 ///
-/// * `transactions` - The transactions to get the events from.
+/// * `events` - The events to calculate the commitment from.
 ///
 /// # Returns
 ///
-/// The merkle root of the merkle tree built from the transactions and the number of events.
+/// The merkle root of the merkle tree built from the events.
 pub(crate) fn calculate_event_commitment<H: HasherT>(events: &[Event]) -> Felt252Wrapper {
     let mut tree = CommitmentTree::<H>::default();
     events.iter().enumerate().for_each(|(id, event)| {


### PR DESCRIPTION
Corrected typo here: https://github.com/keep-starknet-strange/madara/blob/ee2602aed93eb54b9582f67ff926b16f403a69df/crates/primitives/commitments/src/lib.rs#L164