### PR TITLE
Add the `--cache` option, allows caching more information into the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   method being used)
 - refactor(sealing): how the sealing mode is passed into runtime
 - feat(sealing): finalization for instant sealing
+- feat(cache-option): add an option to enable aggressive caching in the command-line parameters
 
 ## v0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@
   method being used)
 - refactor(sealing): how the sealing mode is passed into runtime
 - feat(sealing): finalization for instant sealing
-- feat(cache-option): add an option to enable aggressive caching in the command-line parameters
+- feat(cache-option): add an option to enable aggressive caching in the
+  command-line parameters
 
 ## v0.4.0
 

--- a/crates/client/db/src/lib.rs
+++ b/crates/client/db/src/lib.rs
@@ -19,7 +19,7 @@ mod meta_db;
 
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use da_db::DaDb;
 use mapping_db::MappingDb;
@@ -38,14 +38,17 @@ struct DatabaseSettings {
 }
 
 pub(crate) mod columns {
-    pub const NUM_COLUMNS: u32 = 5;
+    /// Total number of columns.
+    // ===== /!\ ===================================================================================
+    // MUST BE INCREMENTED WHEN A NEW COLUMN IN ADDED
+    // ===== /!\ ===================================================================================
+    pub const NUM_COLUMNS: u32 = 6;
 
     pub const META: u32 = 0;
     pub const BLOCK_MAPPING: u32 = 1;
     pub const TRANSACTION_MAPPING: u32 = 2;
     pub const SYNCED_MAPPING: u32 = 3;
     pub const DA: u32 = 4;
-
     /// This column is used to map starknet block hashes to a list of transaction hashes that are
     /// contained in the block.
     ///
@@ -78,30 +81,33 @@ impl<B: BlockT> Backend<B> {
     /// Open the database
     ///
     /// The database will be created at db_config_dir.join(<db_type_name>)
-    pub fn open(database: &DatabaseSource, db_config_dir: &Path) -> Result<Self, String> {
-        Self::new(&DatabaseSettings {
-            source: match database {
-                DatabaseSource::RocksDb { .. } => {
-                    DatabaseSource::RocksDb { path: starknet_database_dir(db_config_dir, "rockdb"), cache_size: 0 }
-                }
-                DatabaseSource::ParityDb { .. } => {
-                    DatabaseSource::ParityDb { path: starknet_database_dir(db_config_dir, "paritydb") }
-                }
-                DatabaseSource::Auto { .. } => DatabaseSource::Auto {
-                    rocksdb_path: starknet_database_dir(db_config_dir, "rockdb"),
-                    paritydb_path: starknet_database_dir(db_config_dir, "paritydb"),
-                    cache_size: 0,
+    pub fn open(database: &DatabaseSource, db_config_dir: &Path, cache_more_things: bool) -> Result<Self, String> {
+        Self::new(
+            &DatabaseSettings {
+                source: match database {
+                    DatabaseSource::RocksDb { .. } => {
+                        DatabaseSource::RocksDb { path: starknet_database_dir(db_config_dir, "rockdb"), cache_size: 0 }
+                    }
+                    DatabaseSource::ParityDb { .. } => {
+                        DatabaseSource::ParityDb { path: starknet_database_dir(db_config_dir, "paritydb") }
+                    }
+                    DatabaseSource::Auto { .. } => DatabaseSource::Auto {
+                        rocksdb_path: starknet_database_dir(db_config_dir, "rockdb"),
+                        paritydb_path: starknet_database_dir(db_config_dir, "paritydb"),
+                        cache_size: 0,
+                    },
+                    _ => return Err("Supported db sources: `rocksdb` | `paritydb` | `auto`".to_string()),
                 },
-                _ => return Err("Supported db sources: `rocksdb` | `paritydb` | `auto`".to_string()),
             },
-        })
+            cache_more_things,
+        )
     }
 
-    fn new(config: &DatabaseSettings) -> Result<Self, String> {
+    fn new(config: &DatabaseSettings, cache_more_things: bool) -> Result<Self, String> {
         let db = db_opening_utils::open_database(config)?;
 
         Ok(Self {
-            mapping: Arc::new(MappingDb { db: db.clone(), write_lock: Arc::new(Mutex::new(())), _marker: PhantomData }),
+            mapping: Arc::new(MappingDb::new(db.clone(), cache_more_things)),
             meta: Arc::new(MetaDb { db: db.clone(), _marker: PhantomData }),
             da: Arc::new(DaDb { db: db.clone(), _marker: PhantomData }),
         })

--- a/crates/client/db/src/lib.rs
+++ b/crates/client/db/src/lib.rs
@@ -45,6 +45,12 @@ pub(crate) mod columns {
     pub const TRANSACTION_MAPPING: u32 = 2;
     pub const SYNCED_MAPPING: u32 = 3;
     pub const DA: u32 = 4;
+
+    /// This column is used to map starknet block hashes to a list of transaction hashes that are
+    /// contained in the block.
+    ///
+    /// This column should only be accessed if the `--cache` flag is enabled.
+    pub const STARKNET_TRANSACTION_HASHES_CACHE: u32 = 5;
 }
 
 pub mod static_keys {

--- a/crates/client/db/src/mapping_db.rs
+++ b/crates/client/db/src/mapping_db.rs
@@ -143,6 +143,11 @@ impl<B: BlockT> MappingDb<B> {
     /// - The cache is disabled.
     /// - The provided `starknet_hash` is not present in the cache.
     pub fn cached_transaction_hashes_from_block_hash(&self, starknet_hash: H256) -> Result<Option<Vec<H256>>, String> {
+        if !self.cache_more_things {
+            // The cache is not enabled, no need to even touch the database.
+            return Ok(None);
+        }
+
         match self.db.get(crate::columns::STARKNET_TRANSACTION_HASHES_CACHE, &starknet_hash.encode()) {
             Some(raw) => Ok(Some(Vec::<H256>::decode(&mut &raw[..]).map_err(|e| format!("{:?}", e))?)),
             None => Ok(None),

--- a/crates/client/mapping-sync/src/lib.rs
+++ b/crates/client/mapping-sync/src/lib.rs
@@ -41,18 +41,12 @@ pub struct MappingSyncWorker<B: BlockT, C, BE, H> {
     have_next: bool,
     retry_times: usize,
     sync_from: <B::Header as HeaderT>::Number,
-
-    /// Whether more information should be cached when storing the block in the database.
-    cache: bool,
 }
 
 impl<B: BlockT, C, BE, H> Unpin for MappingSyncWorker<B, C, BE, H> {}
 
 #[allow(clippy::too_many_arguments)]
 impl<B: BlockT, C, BE, H> MappingSyncWorker<B, C, BE, H> {
-    /// # Arguments
-    ///
-    /// - `cache`: whether more information should be cached when storing the block in the database.
     pub fn new(
         import_notifications: ImportNotifications<B>,
         timeout: Duration,
@@ -61,8 +55,6 @@ impl<B: BlockT, C, BE, H> MappingSyncWorker<B, C, BE, H> {
         frontier_backend: Arc<mc_db::Backend<B>>,
         retry_times: usize,
         sync_from: <B::Header as HeaderT>::Number,
-        hasher: PhantomData<H>,
-        cache: bool,
     ) -> Self {
         Self {
             import_notifications,
@@ -72,13 +64,11 @@ impl<B: BlockT, C, BE, H> MappingSyncWorker<B, C, BE, H> {
             client,
             substrate_backend,
             madara_backend: frontier_backend,
-            hasher,
+            hasher: PhantomData,
 
             have_next: true,
             retry_times,
             sync_from,
-
-            cache,
         }
     }
 }
@@ -124,7 +114,6 @@ where
             self.inner_delay = None;
 
             match sync_blocks::sync_blocks::<_, _, _, H>(
-                self.cache,
                 self.client.as_ref(),
                 self.substrate_backend.as_ref(),
                 self.madara_backend.as_ref(),

--- a/crates/client/mapping-sync/src/lib.rs
+++ b/crates/client/mapping-sync/src/lib.rs
@@ -41,12 +41,18 @@ pub struct MappingSyncWorker<B: BlockT, C, BE, H> {
     have_next: bool,
     retry_times: usize,
     sync_from: <B::Header as HeaderT>::Number,
+
+    /// Whether more information should be cached when storing the block in the database.
+    cache: bool,
 }
 
 impl<B: BlockT, C, BE, H> Unpin for MappingSyncWorker<B, C, BE, H> {}
 
 #[allow(clippy::too_many_arguments)]
 impl<B: BlockT, C, BE, H> MappingSyncWorker<B, C, BE, H> {
+    /// # Arguments
+    ///
+    /// - `cache`: whether more information should be cached when storing the block in the database.
     pub fn new(
         import_notifications: ImportNotifications<B>,
         timeout: Duration,
@@ -56,6 +62,7 @@ impl<B: BlockT, C, BE, H> MappingSyncWorker<B, C, BE, H> {
         retry_times: usize,
         sync_from: <B::Header as HeaderT>::Number,
         hasher: PhantomData<H>,
+        cache: bool,
     ) -> Self {
         Self {
             import_notifications,
@@ -70,6 +77,8 @@ impl<B: BlockT, C, BE, H> MappingSyncWorker<B, C, BE, H> {
             have_next: true,
             retry_times,
             sync_from,
+
+            cache,
         }
     }
 }
@@ -115,6 +124,7 @@ where
             self.inner_delay = None;
 
             match sync_blocks::sync_blocks::<_, _, _, H>(
+                self.cache,
                 self.client.as_ref(),
                 self.substrate_backend.as_ref(),
                 self.madara_backend.as_ref(),

--- a/crates/client/mapping-sync/src/sync_blocks.rs
+++ b/crates/client/mapping-sync/src/sync_blocks.rs
@@ -9,15 +9,7 @@ use sp_blockchain::{Backend as _, HeaderBackend};
 use sp_core::H256;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, Zero};
 
-/// # Arguments
-///
-/// - `cache`: whether more information should be cached when storing the block in the database.
-fn sync_block<B: BlockT, C, BE, H>(
-    cache: bool,
-    client: &C,
-    backend: &mc_db::Backend<B>,
-    header: &B::Header,
-) -> Result<(), String>
+fn sync_block<B: BlockT, C, BE, H>(client: &C, backend: &mc_db::Backend<B>, header: &B::Header) -> Result<(), String>
 where
     C: HeaderBackend<B> + StorageProvider<B, BE>,
     C: ProvideRuntimeApi<B>,
@@ -59,7 +51,6 @@ where
                                 .iter()
                                 .map(|tx| H256::from(tx.compute_hash::<H>(chain_id, false)))
                                 .collect(),
-                            cache,
                         };
 
                         backend.mapping().write_hashes(mapping_commitment)
@@ -75,11 +66,7 @@ where
     }
 }
 
-/// # Arguments
-///
-/// - `cache`: whether more information should be cached when storing the block in the database.
 fn sync_genesis_block<B: BlockT, C, H>(
-    cache: bool,
     _client: &C,
     backend: &mc_db::Backend<B>,
     header: &B::Header,
@@ -101,7 +88,6 @@ where
         block_hash: substrate_block_hash,
         starknet_block_hash: block_hash.into(),
         starknet_transaction_hashes: Vec::new(),
-        cache,
     };
 
     backend.mapping().write_hashes(mapping_commitment)?;
@@ -109,11 +95,7 @@ where
     Ok(())
 }
 
-/// # Arguments
-///
-/// - `cache`: whether more information should be cached when storing the block in the database.
 fn sync_one_block<B: BlockT, C, BE, H>(
-    cache: bool,
     client: &C,
     substrate_backend: &BE,
     madara_backend: &mc_db::Backend<B>,
@@ -154,12 +136,12 @@ where
     };
 
     if operating_header.number() == &Zero::zero() {
-        sync_genesis_block::<_, _, H>(cache, client, madara_backend, &operating_header)?;
+        sync_genesis_block::<_, _, H>(client, madara_backend, &operating_header)?;
 
         madara_backend.meta().write_current_syncing_tips(current_syncing_tips)?;
         Ok(true)
     } else {
-        sync_block::<_, _, _, H>(cache, client, madara_backend, &operating_header)?;
+        sync_block::<_, _, _, H>(client, madara_backend, &operating_header)?;
 
         current_syncing_tips.push(*operating_header.parent_hash());
         madara_backend.meta().write_current_syncing_tips(current_syncing_tips)?;
@@ -167,11 +149,7 @@ where
     }
 }
 
-/// # Arguments
-///
-/// - `cache`: whether more information should be cached when storing the block in the database.
 pub fn sync_blocks<B: BlockT, C, BE, H>(
-    cache: bool,
     client: &C,
     substrate_backend: &BE,
     madara_backend: &mc_db::Backend<B>,
@@ -188,8 +166,7 @@ where
     let mut synced_any = false;
 
     for _ in 0..limit {
-        synced_any =
-            synced_any || sync_one_block::<_, _, _, H>(cache, client, substrate_backend, madara_backend, sync_from)?;
+        synced_any = synced_any || sync_one_block::<_, _, _, H>(client, substrate_backend, madara_backend, sync_from)?;
     }
 
     Ok(synced_any)

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -656,7 +656,7 @@ where
 
         let transaction_hash = self
             .get_cached_transaction_hashes(block.header().hash::<H>().into())
-            .map(|vec| h256_to_felt(*vec.get(index as usize).ok_or(StarknetRpcApiError::InvalidTxnIndex)?))
+            .map(|tx_hashes| h256_to_felt(*tx_hashes.get(index as usize).ok_or(StarknetRpcApiError::InvalidTxnIndex)?))
             .unwrap_or_else(|| Ok(transaction.compute_hash::<H>(chain_id.0.into(), false).0))?;
 
         Ok(to_starknet_core_tx::<H>(transaction.clone(), transaction_hash))
@@ -679,7 +679,7 @@ where
         for (index, tx) in block.transactions().iter().enumerate() {
             let hash = transaction_hashes
                 .as_ref()
-                .map(|vec| h256_to_felt(*vec.get(index).ok_or(StarknetRpcApiError::InternalServerError)?))
+                .map(|tx_hashes| h256_to_felt(*tx_hashes.get(index).ok_or(StarknetRpcApiError::InternalServerError)?))
                 .unwrap_or_else(|| Ok(tx.compute_hash::<H>(chain_id.0.into(), false).0))?;
             transactions.push(to_starknet_core_tx::<H>(tx.clone(), hash));
         }

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -402,8 +402,7 @@ where
         let block = get_block_by_block_hash(self.client.as_ref(), substrate_block_hash).unwrap_or_default();
         let chain_id = self.chain_id()?;
 
-        let transactions =
-            block.transactions_hashes::<H>(Felt252Wrapper(chain_id.0)).into_iter().map(FieldElement::from).collect();
+        let transactions = block.transactions_hashes::<H>(Felt252Wrapper(chain_id.0)).map(FieldElement::from).collect();
         let blockhash = block.header().hash::<H>();
         let parent_blockhash = block.header().parent_block_hash;
         let block_with_tx_hashes = BlockWithTxHashes {

--- a/crates/node/src/command.rs
+++ b/crates/node/src/command.rs
@@ -72,28 +72,28 @@ pub fn run() -> sc_cli::Result<()> {
         Some(Subcommand::CheckBlock(ref cmd)) => {
             let runner = cli.create_runner(cmd)?;
             runner.async_run(|mut config| {
-                let (client, _, import_queue, task_manager, _) = service::new_chain_ops(&mut config)?;
+                let (client, _, import_queue, task_manager, _) = service::new_chain_ops(&mut config, cli.run.cache)?;
                 Ok((cmd.run(client, import_queue), task_manager))
             })
         }
         Some(Subcommand::ExportBlocks(ref cmd)) => {
             let runner = cli.create_runner(cmd)?;
             runner.async_run(|mut config| {
-                let (client, _, _, task_manager, _) = service::new_chain_ops(&mut config)?;
+                let (client, _, _, task_manager, _) = service::new_chain_ops(&mut config, cli.run.cache)?;
                 Ok((cmd.run(client, config.database), task_manager))
             })
         }
         Some(Subcommand::ExportState(ref cmd)) => {
             let runner = cli.create_runner(cmd)?;
             runner.async_run(|mut config| {
-                let (client, _, _, task_manager, _) = service::new_chain_ops(&mut config)?;
+                let (client, _, _, task_manager, _) = service::new_chain_ops(&mut config, cli.run.cache)?;
                 Ok((cmd.run(client, config.chain_spec), task_manager))
             })
         }
         Some(Subcommand::ImportBlocks(ref cmd)) => {
             let runner = cli.create_runner(cmd)?;
             runner.async_run(|mut config| {
-                let (client, _, import_queue, task_manager, _) = service::new_chain_ops(&mut config)?;
+                let (client, _, import_queue, task_manager, _) = service::new_chain_ops(&mut config, cli.run.cache)?;
                 Ok((cmd.run(client, import_queue), task_manager))
             })
         }
@@ -104,7 +104,7 @@ pub fn run() -> sc_cli::Result<()> {
         Some(Subcommand::Revert(ref cmd)) => {
             let runner = cli.create_runner(cmd)?;
             runner.async_run(|mut config| {
-                let (client, backend, _, task_manager, _) = service::new_chain_ops(&mut config)?;
+                let (client, backend, _, task_manager, _) = service::new_chain_ops(&mut config, cli.run.cache)?;
                 let aux_revert = Box::new(|client, _, blocks| {
                     sc_consensus_grandpa::revert(client, blocks)?;
                     Ok(())
@@ -129,7 +129,7 @@ pub fn run() -> sc_cli::Result<()> {
                         cmd.run::<Block, service::ExecutorDispatch>(config)
                     }
                     BenchmarkCmd::Block(cmd) => {
-                        let (client, _, _, _, _) = service::new_chain_ops(&mut config)?;
+                        let (client, _, _, _, _) = service::new_chain_ops(&mut config, cli.run.cache)?;
                         cmd.run(client)
                     }
                     #[cfg(not(feature = "runtime-benchmarks"))]
@@ -145,13 +145,13 @@ pub fn run() -> sc_cli::Result<()> {
                         cmd.run(config, client, db, storage)
                     }
                     BenchmarkCmd::Overhead(cmd) => {
-                        let (client, _, _, _, _) = service::new_chain_ops(&mut config)?;
+                        let (client, _, _, _, _) = service::new_chain_ops(&mut config, cli.run.cache)?;
                         let ext_builder = RemarkBuilder::new(client.clone());
 
                         cmd.run(config, client, inherent_benchmark_data()?, Vec::new(), &ext_builder)
                     }
                     BenchmarkCmd::Extrinsic(cmd) => {
-                        let (client, _, _, _, _) = service::new_chain_ops(&mut config)?;
+                        let (client, _, _, _, _) = service::new_chain_ops(&mut config, cli.run.cache)?;
                         // Register the *Remark* builder.
                         let ext_factory = ExtrinsicFactory(vec![Box::new(RemarkBuilder::new(client.clone()))]);
 

--- a/crates/node/src/commands/run.rs
+++ b/crates/node/src/commands/run.rs
@@ -29,6 +29,14 @@ pub struct ExtendedRunCmd {
     /// Choose a supported DA Layer
     #[clap(long)]
     pub da_layer: Option<DaLayer>,
+
+    /// When enabled, more information about the blocks and their transaction is cached and stored
+    /// in the database.
+    ///
+    /// This may improve response times for RPCs that require that information, but it also
+    /// increases the memory footprint of the node.
+    #[clap(long, action)]
+    pub cache: bool,
 }
 
 impl ExtendedRunCmd {
@@ -64,9 +72,10 @@ pub fn run_node(mut cli: Cli) -> Result<()> {
         }
     };
     let sealing = cli.run.sealing;
+    let cache = cli.run.cache;
 
     runner.run_node_until_exit(|config| async move {
-        service::new_full(config, sealing, da_config).map_err(sc_cli::Error::Service)
+        service::new_full(config, sealing, da_config, cache).map_err(sc_cli::Error::Service)
     })
 }
 

--- a/crates/node/src/commands/run.rs
+++ b/crates/node/src/commands/run.rs
@@ -50,7 +50,7 @@ pub struct ExtendedRunCmd {
     ///
     /// This may improve response times for RPCs that require that information, but it also
     /// increases the memory footprint of the node.
-    #[clap(long, action)]
+    #[clap(long)]
     pub cache: bool,
 }
 

--- a/crates/node/src/service.rs
+++ b/crates/node/src/service.rs
@@ -1,7 +1,6 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
 use std::cell::RefCell;
-use std::marker::PhantomData;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -76,6 +75,7 @@ type BoxBlockImport<Client> = sc_consensus::BoxBlockImport<Block, TransactionFor
 pub fn new_partial<BIQ>(
     config: &Configuration,
     build_import_queue: BIQ,
+    cache_more_things: bool,
 ) -> Result<
     sc_service::PartialComponents<
         FullClient,
@@ -164,7 +164,7 @@ where
         telemetry.as_ref().map(|x| x.handle()),
     )?;
 
-    let madara_backend = Arc::new(MadaraBackend::open(&config.database, &db_config_dir(config))?);
+    let madara_backend = Arc::new(MadaraBackend::open(&config.database, &db_config_dir(config), cache_more_things)?);
 
     let (import_queue, block_import) = build_import_queue(
         client.clone(),
@@ -260,7 +260,7 @@ pub fn new_full(
     config: Configuration,
     sealing: Option<Sealing>,
     da_layer: Option<(DaLayer, PathBuf)>,
-    cache: bool,
+    cache_more_things: bool,
 ) -> Result<TaskManager, ServiceError> {
     let build_import_queue =
         if sealing.is_some() { build_manual_seal_import_queue } else { build_aura_grandpa_import_queue };
@@ -274,7 +274,7 @@ pub fn new_full(
         select_chain,
         transaction_pool,
         other: (block_import, grandpa_link, mut telemetry, madara_backend),
-    } = new_partial(&config, build_import_queue)?;
+    } = new_partial(&config, build_import_queue, cache_more_things)?;
 
     let mut net_config = sc_network::config::FullNetworkConfiguration::new(&config.network);
 
@@ -370,7 +370,7 @@ pub fn new_full(
     task_manager.spawn_essential_handle().spawn(
         "mc-mapping-sync-worker",
         Some("madara"),
-        MappingSyncWorker::new(
+        MappingSyncWorker::<_, _, _, StarknetHasher>::new(
             client.import_notification_stream(),
             Duration::new(6, 0),
             client.clone(),
@@ -378,8 +378,6 @@ pub fn new_full(
             madara_backend.clone(),
             3,
             0,
-            PhantomData::<StarknetHasher>,
-            cache,
         )
         .for_each(|()| future::ready(())),
     );
@@ -634,9 +632,9 @@ type ChainOpsResult = Result<
     ServiceError,
 >;
 
-pub fn new_chain_ops(config: &mut Configuration) -> ChainOpsResult {
+pub fn new_chain_ops(config: &mut Configuration, cache_more_things: bool) -> ChainOpsResult {
     config.keystore = sc_service::config::KeystoreConfig::InMemory;
     let sc_service::PartialComponents { client, backend, import_queue, task_manager, other, .. } =
-        new_partial::<_>(config, build_aura_grandpa_import_queue)?;
+        new_partial::<_>(config, build_aura_grandpa_import_queue, cache_more_things)?;
     Ok((client, backend, import_queue, task_manager, other.3))
 }

--- a/crates/node/src/service.rs
+++ b/crates/node/src/service.rs
@@ -252,10 +252,15 @@ where
 }
 
 /// Builds a new service for a full client.
+///
+/// # Arguments
+///
+/// - `cache`: whether more information should be cached when storing the block in the database.
 pub fn new_full(
     config: Configuration,
     sealing: Option<Sealing>,
     da_layer: Option<(DaLayer, PathBuf)>,
+    cache: bool,
 ) -> Result<TaskManager, ServiceError> {
     let build_import_queue =
         if sealing.is_some() { build_manual_seal_import_queue } else { build_aura_grandpa_import_queue };
@@ -374,6 +379,7 @@ pub fn new_full(
             3,
             0,
             PhantomData::<StarknetHasher>,
+            cache,
         )
         .for_each(|()| future::ready(())),
     );

--- a/crates/primitives/block/src/lib.rs
+++ b/crates/primitives/block/src/lib.rs
@@ -48,9 +48,14 @@ impl Block {
         &self.transactions
     }
 
-    /// Return a reference to all transaction hashes
-    pub fn transactions_hashes<H: HasherT>(&self, chain_id: Felt252Wrapper) -> Vec<Felt252Wrapper> {
-        self.transactions.iter().map(|tx| tx.compute_hash::<H>(chain_id, false)).collect()
+    /// Returns an iterator that iterates over all transaction hashes.
+    ///
+    /// Those transactions are computed using the given `chain_id`.
+    pub fn transactions_hashes<H: HasherT>(
+        &self,
+        chain_id: Felt252Wrapper,
+    ) -> impl '_ + Iterator<Item = Felt252Wrapper> {
+        self.transactions.iter().map(move |tx| tx.compute_hash::<H>(chain_id, false))
     }
 }
 

--- a/crates/primitives/transactions/src/to_starknet_core_transaction.rs
+++ b/crates/primitives/transactions/src/to_starknet_core_transaction.rs
@@ -4,8 +4,6 @@ use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
 use starknet_crypto::FieldElement;
 
-use super::compute_hash::ComputeTransactionHash;
-
 fn cast_vec_of_felt_252_wrappers(data: Vec<Felt252Wrapper>) -> Vec<FieldElement> {
     // Non-copy but less dangerous than transmute
     // https://doc.rust-lang.org/std/mem/fn.transmute.html#alternatives
@@ -15,12 +13,10 @@ fn cast_vec_of_felt_252_wrappers(data: Vec<Felt252Wrapper>) -> Vec<FieldElement>
 
 pub fn to_starknet_core_tx<H: HasherT>(
     tx: super::Transaction,
-    chain_id: Felt252Wrapper,
+    transaction_hash: FieldElement,
 ) -> starknet_core::types::Transaction {
     match tx {
         super::Transaction::Declare(tx) => {
-            let tx_hash = tx.compute_hash::<H>(chain_id, false);
-
             let tx = match tx {
                 super::DeclareTransaction::V0(super::DeclareTransactionV0 {
                     max_fee,
@@ -29,7 +25,7 @@ pub fn to_starknet_core_tx<H: HasherT>(
                     class_hash,
                     sender_address,
                 }) => starknet_core::types::DeclareTransaction::V0(starknet_core::types::DeclareTransactionV0 {
-                    transaction_hash: tx_hash.0,
+                    transaction_hash,
                     max_fee: max_fee.into(),
                     signature: cast_vec_of_felt_252_wrappers(signature),
                     class_hash: class_hash.into(),
@@ -42,7 +38,7 @@ pub fn to_starknet_core_tx<H: HasherT>(
                     class_hash,
                     sender_address,
                 }) => starknet_core::types::DeclareTransaction::V1(starknet_core::types::DeclareTransactionV1 {
-                    transaction_hash: tx_hash.0,
+                    transaction_hash,
                     max_fee: max_fee.into(),
                     signature: cast_vec_of_felt_252_wrappers(signature),
                     nonce: nonce.into(),
@@ -57,7 +53,7 @@ pub fn to_starknet_core_tx<H: HasherT>(
                     sender_address,
                     compiled_class_hash,
                 }) => starknet_core::types::DeclareTransaction::V2(starknet_core::types::DeclareTransactionV2 {
-                    transaction_hash: tx_hash.0,
+                    transaction_hash,
                     max_fee: max_fee.into(),
                     signature: cast_vec_of_felt_252_wrappers(signature),
                     nonce: nonce.into(),
@@ -70,10 +66,8 @@ pub fn to_starknet_core_tx<H: HasherT>(
             starknet_core::types::Transaction::Declare(tx)
         }
         super::Transaction::DeployAccount(tx) => {
-            let tx_hash = tx.compute_hash::<H>(chain_id, false);
-
             let tx = starknet_core::types::DeployAccountTransaction {
-                transaction_hash: tx_hash.0,
+                transaction_hash,
                 max_fee: tx.max_fee.into(),
                 signature: cast_vec_of_felt_252_wrappers(tx.signature),
                 nonce: tx.nonce.into(),
@@ -85,8 +79,6 @@ pub fn to_starknet_core_tx<H: HasherT>(
             starknet_core::types::Transaction::DeployAccount(tx)
         }
         super::Transaction::Invoke(tx) => {
-            let tx_hash = tx.compute_hash::<H>(chain_id, false);
-
             let tx = match tx {
                 super::InvokeTransaction::V0(super::InvokeTransactionV0 {
                     max_fee,
@@ -95,7 +87,7 @@ pub fn to_starknet_core_tx<H: HasherT>(
                     entry_point_selector,
                     calldata,
                 }) => starknet_core::types::InvokeTransaction::V0(starknet_core::types::InvokeTransactionV0 {
-                    transaction_hash: tx_hash.0,
+                    transaction_hash,
                     max_fee: max_fee.into(),
                     signature: cast_vec_of_felt_252_wrappers(signature),
                     contract_address: contract_address.into(),
@@ -109,7 +101,7 @@ pub fn to_starknet_core_tx<H: HasherT>(
                     sender_address,
                     calldata,
                 }) => starknet_core::types::InvokeTransaction::V1(starknet_core::types::InvokeTransactionV1 {
-                    transaction_hash: tx_hash.0,
+                    transaction_hash,
                     max_fee: max_fee.into(),
                     signature: cast_vec_of_felt_252_wrappers(signature),
                     nonce: nonce.into(),
@@ -121,10 +113,8 @@ pub fn to_starknet_core_tx<H: HasherT>(
             starknet_core::types::Transaction::Invoke(tx)
         }
         super::Transaction::L1Handler(tx) => {
-            let tx_hash = tx.compute_hash::<H>(chain_id, false);
-
             let tx = starknet_core::types::L1HandlerTransaction {
-                transaction_hash: tx_hash.0,
+                transaction_hash,
                 version: 0,
                 nonce: tx.nonce,
                 contract_address: tx.contract_address.into(),


### PR DESCRIPTION
This allows trading a bit of the memory footprint of Madara for better response time (specifically in the RPC client implementation).

# Pull Request type

This is a new feature.

## What is the current behavior?

Nothing is cached and transaction hashes are re-computed every time they are needed.

Resolves: #1180 

## What is the new behavior?

Transaction hashes are not stored along with block data in the database under the column `STARKNET_TRANSACTION_HASHES_CACHE`.

## Does this introduce a breaking change?

No.

## Other information

Currently, the flag is introduce as a simple boolean flag.

```Rust
    #[clap(long, action)]
    cache: bool,
```

In the future, it might be good to make this a vector of flags, which could optionally enable caching for only *some* parts of the database. Right now it's only for transaction hashes.