### PR TITLE
Alter transaction checks for starknet-rs/foundry compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - feat(sealing): finalization for instant sealing
 - feat(cache-option): add an option to enable aggressive caching in command-line
   parameters
+- fix: Ensure transaction checks are compatible with starknet-rs
 
 ## v0.4.0
 

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -608,7 +608,9 @@ where
             BroadcastedTransaction::DeployAccount(deploy_tx) => !deploy_tx.is_query,
         });
         if is_invalid_query_transaction {
-            log::error!("Got `is_query`: false. In a future version, this will fail fee estimation with UnsupportedTxVersion");
+            log::error!(
+                "Got `is_query`: false. In a future version, this will fail fee estimation with UnsupportedTxVersion"
+            );
         }
 
         let substrate_block_hash = self.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -608,7 +608,7 @@ where
             BroadcastedTransaction::DeployAccount(deploy_tx) => !deploy_tx.is_query,
         });
         if is_invalid_query_transaction {
-            return Err(StarknetRpcApiError::UnsupportedTxVersion.into());
+            log::error!("Got `is_query`: false. In a future version, this will fail fee estimation with UnsupportedTxVersion");
         }
 
         let substrate_block_hash = self.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {
@@ -627,7 +627,7 @@ where
             let (actual_fee, gas_usage) = self
                 .client
                 .runtime_api()
-                .estimate_fee(substrate_block_hash, tx)
+                .estimate_fee(substrate_block_hash, tx, !is_invalid_query_transaction)
                 .map_err(|e| {
                     error!("Request parameters error: {e}");
                     StarknetRpcApiError::InternalServerError

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -600,13 +600,13 @@ where
         request: Vec<BroadcastedTransaction>,
         block_id: BlockId,
     ) -> RpcResult<Vec<FeeEstimate>> {
-        let is_invalid_query_transaction = request.iter().any(|tx| match tx {
-            BroadcastedTransaction::Invoke(invoke_tx) => !invoke_tx.is_query,
-            BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V1(tx_v1)) => !tx_v1.is_query,
-            BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(tx_v2)) => !tx_v2.is_query,
-            BroadcastedTransaction::DeployAccount(deploy_tx) => !deploy_tx.is_query,
+        let is_query = request.iter().any(|tx| match tx {
+            BroadcastedTransaction::Invoke(invoke_tx) => invoke_tx.is_query,
+            BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V1(tx_v1)) => tx_v1.is_query,
+            BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V2(tx_v2)) => tx_v2.is_query,
+            BroadcastedTransaction::DeployAccount(deploy_tx) => deploy_tx.is_query,
         });
-        if is_invalid_query_transaction {
+        if !is_query {
             log::error!(
                 "Got `is_query`: false. In a future version, this will fail fee estimation with UnsupportedTxVersion"
             );
@@ -628,7 +628,7 @@ where
             let (actual_fee, gas_usage) = self
                 .client
                 .runtime_api()
-                .estimate_fee(substrate_block_hash, tx, !is_invalid_query_transaction)
+                .estimate_fee(substrate_block_hash, tx, is_query)
                 .map_err(|e| {
                     error!("Request parameters error: {e}");
                     StarknetRpcApiError::InternalServerError

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -506,7 +506,6 @@ pub mod pallet {
                     log::error!("failed to execute invoke tx: {:?}", e);
                     Error::<T>::TransactionExecutionFailed
                 })?;
-
             let tx_hash = transaction.tx_hash;
             Self::emit_and_store_tx_and_fees_events(
                 tx_hash,
@@ -1092,7 +1091,7 @@ impl<T: Config> Pallet<T> {
     }
 
     /// Estimate the fee associated with transaction
-    pub fn estimate_fee(transaction: UserTransaction) -> Result<(u64, u64), DispatchError> {
+    pub fn estimate_fee(transaction: UserTransaction, is_query: bool) -> Result<(u64, u64), DispatchError> {
         let chain_id = Self::chain_id();
 
         fn execute_tx_and_rollback<S: State + StateChanges + FeeConfig>(
@@ -1116,20 +1115,20 @@ impl<T: Config> Pallet<T> {
 
         let execution_result = match transaction {
             UserTransaction::Declare(tx, contract_class) => execute_tx_and_rollback(
-                tx.try_into_executable::<T::SystemHash>(chain_id, contract_class, true)
+                tx.try_into_executable::<T::SystemHash>(chain_id, contract_class, is_query)
                     .map_err(|_| Error::<T>::InvalidContractClass)?,
                 &mut blockifier_state_adapter,
                 &block_context,
                 disable_nonce_validation,
             ),
             UserTransaction::DeployAccount(tx) => execute_tx_and_rollback(
-                tx.into_executable::<T::SystemHash>(chain_id, true),
+                tx.into_executable::<T::SystemHash>(chain_id, is_query),
                 &mut blockifier_state_adapter,
                 &block_context,
                 disable_nonce_validation,
             ),
             UserTransaction::Invoke(tx) => execute_tx_and_rollback(
-                tx.into_executable::<T::SystemHash>(chain_id, true),
+                tx.into_executable::<T::SystemHash>(chain_id, is_query),
                 &mut blockifier_state_adapter,
                 &block_context,
                 disable_nonce_validation,

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -506,6 +506,7 @@ pub mod pallet {
                     log::error!("failed to execute invoke tx: {:?}", e);
                     Error::<T>::TransactionExecutionFailed
                 })?;
+                
             let tx_hash = transaction.tx_hash;
             Self::emit_and_store_tx_and_fees_events(
                 tx_hash,

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -506,7 +506,7 @@ pub mod pallet {
                     log::error!("failed to execute invoke tx: {:?}", e);
                     Error::<T>::TransactionExecutionFailed
                 })?;
-                
+
             let tx_hash = transaction.tx_hash;
             Self::emit_and_store_tx_and_fees_events(
                 tx_hash,

--- a/crates/pallets/starknet/src/runtime_api.rs
+++ b/crates/pallets/starknet/src/runtime_api.rs
@@ -42,7 +42,7 @@ sp_api::decl_runtime_apis! {
         /// Returns the chain id.
         fn chain_id() -> Felt252Wrapper;
         /// Returns fee estimate
-        fn estimate_fee(transaction: UserTransaction) -> Result<(u64, u64), DispatchError>;
+        fn estimate_fee(transaction: UserTransaction, is_query: bool) -> Result<(u64, u64), DispatchError>;
         /// Filters extrinsic transactions to return only Starknet transactions
         ///
         /// To support runtime upgrades, the client must be unaware of the specific extrinsic

--- a/crates/pallets/starknet/src/tests/query_tx.rs
+++ b/crates/pallets/starknet/src/tests/query_tx.rs
@@ -17,14 +17,14 @@ fn estimates_tx_fee_successfully_no_validate() {
         let tx = get_invoke_dummy(Felt252Wrapper::ZERO);
         let tx = UserTransaction::Invoke(tx.into());
 
-        let (actual, l1_gas_usage) = Starknet::estimate_fee(tx).unwrap();
+        let (actual, l1_gas_usage) = Starknet::estimate_fee(tx, true).unwrap();
         assert!(actual > 0, "actual fee is missing");
         assert!(l1_gas_usage == 0, "this should not be charged any l1_gas as it does not store nor send messages");
 
         let tx = get_storage_read_write_dummy();
         let tx = UserTransaction::Invoke(tx.into());
 
-        let (actual, l1_gas_usage) = Starknet::estimate_fee(tx).unwrap();
+        let (actual, l1_gas_usage) = Starknet::estimate_fee(tx, true).unwrap();
         assert!(actual > 0, "actual fee is missing");
         assert!(l1_gas_usage > 0, "this should be charged l1_gas as it store a value to storage");
     });
@@ -39,7 +39,7 @@ fn estimates_tx_fee_with_query_version() {
         let pre_storage = Starknet::pending().len();
         let tx = UserTransaction::Invoke(tx.into());
 
-        assert_ok!(Starknet::estimate_fee(tx));
+        assert_ok!(Starknet::estimate_fee(tx, true));
 
         assert!(pre_storage == Starknet::pending().len(), "estimate should not add a tx to pending");
     });
@@ -57,7 +57,7 @@ fn executable_tx_should_not_be_estimable() {
 
         // it should not be valid for estimate calls
         assert_err!(
-            Starknet::estimate_fee(UserTransaction::Invoke(tx.clone().into())),
+            Starknet::estimate_fee(UserTransaction::Invoke(tx.clone().into()), true),
             Error::<MockRuntime>::TransactionExecutionFailed
         );
 
@@ -77,7 +77,7 @@ fn query_tx_should_not_be_executable() {
         tx.signature = sign_message_hash(tx_hash);
 
         // it should be valid for estimate calls
-        assert_ok!(Starknet::estimate_fee(UserTransaction::Invoke(tx.clone().into())),);
+        assert_ok!(Starknet::estimate_fee(UserTransaction::Invoke(tx.clone().into()), true),);
 
         // it should not be executable
         assert_err!(

--- a/crates/primitives/fee/src/lib.rs
+++ b/crates/primitives/fee/src/lib.rs
@@ -48,24 +48,6 @@ pub static VM_RESOURCE_FEE_COSTS: [(&str, FixedU128); 7] = [
     ("ec_op_builtin", FixedU128::from_inner(10_240_000_000_000_000_000)),
 ];
 
-#[cfg(test)]
-mod vm_resource_fee_costs {
-    use super::{FixedU128, HashMap, VM_RESOURCE_FEE_COSTS};
-
-    #[test]
-    fn check_values_as_floats() {
-        let hm = HashMap::from(VM_RESOURCE_FEE_COSTS);
-
-        assert_eq!(hm.get("n_steps"), Some(FixedU128::from_float(0.01)).as_ref());
-        assert_eq!(hm.get("pedersen_builtin"), Some(FixedU128::from_float(0.32)).as_ref());
-        assert_eq!(hm.get("range_check_builtin"), Some(FixedU128::from_float(0.16)).as_ref());
-        assert_eq!(hm.get("ecdsa_builtin"), Some(FixedU128::from_float(20.48)).as_ref());
-        assert_eq!(hm.get("bitwise_builtin"), Some(FixedU128::from_float(0.64)).as_ref());
-        assert_eq!(hm.get("poseidon_builtin"), Some(FixedU128::from_float(0.32)).as_ref());
-        assert_eq!(hm.get("ec_op_builtin"), Some(FixedU128::from_float(10.24)).as_ref());
-    }
-}
-
 /// Gets the transaction resources.
 pub fn compute_transaction_resources<S: State + StateChanges>(
     state: &S,
@@ -225,4 +207,23 @@ pub fn calculate_l1_gas_by_vm_usage(
         .try_fold(FixedU128::zero(), |accum, res| res.map(|v| v.max(accum)))?;
 
     Ok(vm_l1_gas_usage)
+}
+
+
+#[cfg(test)]
+mod vm_resource_fee_costs {
+    use super::{FixedU128, HashMap, VM_RESOURCE_FEE_COSTS};
+
+    #[test]
+    fn check_values_as_floats() {
+        let hm = HashMap::from(VM_RESOURCE_FEE_COSTS);
+
+        assert_eq!(hm.get("n_steps"), Some(FixedU128::from_float(0.01)).as_ref());
+        assert_eq!(hm.get("pedersen_builtin"), Some(FixedU128::from_float(0.32)).as_ref());
+        assert_eq!(hm.get("range_check_builtin"), Some(FixedU128::from_float(0.16)).as_ref());
+        assert_eq!(hm.get("ecdsa_builtin"), Some(FixedU128::from_float(20.48)).as_ref());
+        assert_eq!(hm.get("bitwise_builtin"), Some(FixedU128::from_float(0.64)).as_ref());
+        assert_eq!(hm.get("poseidon_builtin"), Some(FixedU128::from_float(0.32)).as_ref());
+        assert_eq!(hm.get("ec_op_builtin"), Some(FixedU128::from_float(10.24)).as_ref());
+    }
 }

--- a/crates/primitives/fee/src/lib.rs
+++ b/crates/primitives/fee/src/lib.rs
@@ -209,7 +209,6 @@ pub fn calculate_l1_gas_by_vm_usage(
     Ok(vm_l1_gas_usage)
 }
 
-
 #[cfg(test)]
 mod vm_resource_fee_costs {
     use super::{FixedU128, HashMap, VM_RESOURCE_FEE_COSTS};

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -263,8 +263,8 @@ impl_runtime_apis! {
             Starknet::chain_id()
         }
 
-        fn estimate_fee(transaction: UserTransaction) -> Result<(u64, u64), DispatchError> {
-            Starknet::estimate_fee(transaction)
+        fn estimate_fee(transaction: UserTransaction, is_query: bool) -> Result<(u64, u64), DispatchError> {
+            Starknet::estimate_fee(transaction, is_query)
         }
 
         fn get_starknet_events_and_their_associated_tx_hash(block_extrinsics: Vec<<Block as BlockT>::Extrinsic>, chain_id: Felt252Wrapper) -> Vec<(Felt252Wrapper, StarknetEvent)> {


### PR DESCRIPTION
This PR fixes errors which occur when sending transactions through Starknet Foundry/starknet.rs.


## What is the current behavior?

Currently, transactions sent from starknet-rs fail, since starknet-rs sends `is_query: false` for their estimate calls.  

Resolves: #1168 

## What is the new behavior?

- Remove the `is_query` check in the estimate function. According to the chat in the starknet-rs, this will be changed later(see [the discussion](https://t.me/starknet_rs/4880)) so I added an error log indicating this. 
- Consequently, `is_query` can't be defaulted further along the code path since it is used in the construction of the hash used in signing/verifying. We accept the `is_query` value that was sent instead.

## Does this introduce a breaking change?

No, because the `is_query` value which was sent is used.

## Other information

This is also related to https://github.com/keep-starknet-strange/madara/issues/1149. That work will be done in a separate pr