### PR TITLE
dev(StarknetRPC): log error we receive from node before mapping to InternalServerError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next release
 
+- dev(StarknetRPC): log error received from node before mapping to
+  InternalServerError
 - fix: change 'nonce too high' to log in debug instead of info
 - chore: update deps, vm ressource fee cost are now FixedU128, and stored in an
   hashmap

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -465,11 +465,10 @@ where
     /// Returns the chain id.
     fn chain_id(&self) -> RpcResult<Felt> {
         let best_block_hash = self.client.info().best_hash;
-        let chain_id = self
-            .client
-            .runtime_api()
-            .chain_id(best_block_hash)
-            .map_err(|_| StarknetRpcApiError::InternalServerError)?;
+        let chain_id = self.client.runtime_api().chain_id(best_block_hash).map_err(|e| {
+            error!("Failed to fetch chain_id with best_block_hash: {best_block_hash}, error: {e}");
+            StarknetRpcApiError::InternalServerError
+        })?;
 
         Ok(Felt(chain_id.0))
     }
@@ -490,7 +489,7 @@ where
         let best_block_hash = self.client.info().best_hash;
 
         let transaction: UserTransaction = declare_transaction.try_into().map_err(|e| {
-            error!("{e}");
+            error!("Failed to convert BroadcastedDeclareTransaction to UserTransaction, error: {e}");
             StarknetRpcApiError::InternalServerError
         })?;
         let class_hash = match transaction {
@@ -536,7 +535,7 @@ where
         let best_block_hash = self.client.info().best_hash;
 
         let transaction: UserTransaction = invoke_transaction.try_into().map_err(|e| {
-            error!("{e}");
+            error!("Failed to convert BroadcastedInvokeTransaction to UserTransaction: {e}");
             StarknetRpcApiError::InternalServerError
         })?;
 
@@ -566,7 +565,7 @@ where
         let best_block_hash = self.client.info().best_hash;
 
         let transaction: UserTransaction = deploy_account_transaction.try_into().map_err(|e| {
-            error!("{e}");
+            error!("Failed to convert BroadcastedDeployAccountTransaction to UserTransaction, error: {e}",);
             StarknetRpcApiError::InternalServerError
         })?;
 
@@ -621,7 +620,7 @@ where
         let mut estimates = vec![];
         for tx in request {
             let tx = tx.try_into().map_err(|e| {
-                error!("{e}");
+                error!("Failed to convert BroadcastedTransaction to UserTransaction: {e}");
                 StarknetRpcApiError::InternalServerError
             })?;
             let (actual_fee, gas_usage) = self
@@ -679,7 +678,12 @@ where
         for (index, tx) in block.transactions().iter().enumerate() {
             let hash = transaction_hashes
                 .as_ref()
-                .map(|tx_hashes| h256_to_felt(*tx_hashes.get(index).ok_or(StarknetRpcApiError::InternalServerError)?))
+                .map(|tx_hashes| {
+                    h256_to_felt(*tx_hashes.get(index).ok_or_else(|| {
+                        error!("Transaction hash not found at index: {index} in transaction hashes cache.");
+                        StarknetRpcApiError::InternalServerError
+                    })?)
+                })
                 .unwrap_or_else(|| Ok(tx.compute_hash::<H>(chain_id.0.into(), false).0))?;
             transactions.push(to_starknet_core_tx(tx.clone(), hash));
         }
@@ -756,11 +760,14 @@ where
         let api = self.client.runtime_api();
 
         let transactions = api.extrinsic_filter(substrate_block_hash, transactions).map_err(|e| {
-            error!("{:#?}", e);
+            error!("Failed to filter extrinsics. Substrate block hash: {substrate_block_hash}, error: {e}");
             StarknetRpcApiError::InternalServerError
         })?;
 
-        let chain_id = self.chain_id()?;
+        let chain_id = self.chain_id().map_err(|e| {
+            error!("Failed to retrieve chain ID. Error: {e}");
+            StarknetRpcApiError::InternalServerError
+        })?;
 
         let transactions = transactions
             .into_iter()
@@ -902,7 +909,7 @@ where
             .client
             .block_body(substrate_block_hash)
             .map_err(|e| {
-                error!("'{e}'");
+                error!("Failed to get block body. Substrate block hash: {substrate_block_hash}, error: {e}");
                 StarknetRpcApiError::InternalServerError
             })?
             .ok_or(StarknetRpcApiError::BlockNotFound)?;
@@ -913,10 +920,13 @@ where
             .runtime_api()
             .get_events_for_tx_hash(substrate_block_hash, block_extrinsics, chain_id, transaction_hash.into())
             .map_err(|e| {
-                error!("'{e}'");
+                error!(
+                    "Failed to get events for transaction hash. Substrate block hash: {substrate_block_hash}, \
+                     transaction hash: {transaction_hash}, error: {e}"
+                );
                 StarknetRpcApiError::InternalServerError
             })?
-            .expect("the thansaction should be present in the substrate extrinsics");
+            .expect("the transaction should be present in the substrate extrinsics");
 
         let execution_result = {
             let revert_error = self
@@ -924,7 +934,10 @@ where
                 .runtime_api()
                 .get_tx_execution_outcome(substrate_block_hash, Felt252Wrapper(transaction_hash).into())
                 .map_err(|e| {
-                    error!("'{e}'");
+                    error!(
+                        "Failed to get transaction execution outcome. Substrate block hash: {substrate_block_hash}, \
+                         transaction hash: {transaction_hash}, error: {e}"
+                    );
                     StarknetRpcApiError::InternalServerError
                 })?;
 
@@ -1058,8 +1071,8 @@ where
 fn h256_to_felt(h256: H256) -> Result<FieldElement, StarknetRpcApiError> {
     match Felt252Wrapper::try_from(h256) {
         Ok(felt) => Ok(felt.0),
-        Err(err) => {
-            error!("failed to convert H256 to FieldElement: {err}");
+        Err(e) => {
+            error!("failed to convert H256 to FieldElement: {e}");
             Err(StarknetRpcApiError::InternalServerError)
         }
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix
- Feature
- Code style update (formatting, renaming)
-  ✅  Refactoring (no functional changes, no API changes) 
- Build-related changes
- Documentation content changes
- Testing
- Other (please describe):

## What is the current behavior?

StarknetRpcApi's error handling must follow the starknet OpenRPC specifications. Debugging information of what is causing `InternalServerError` is not surfaced to the dev-user.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #1214 

## What is the new behavior?

We add `error!` logging of the inner error, along with a bit of context.

## Does this introduce a breaking change?

No.
<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
