### PR TITLE
estimate fee for bulk transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next release
 
 - dev(compilation): add incremental compilation
+- feat(rpc): add support for bulk estimate fee
 
 ## v0.5.0
 

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -641,8 +641,11 @@ where
                 StarknetRpcApiError::ContractError
             })?;
 
-        let estimates = fee_estimates.into_iter().map(|x| FeeEstimate { gas_price: 0, gas_consumed: x.0, overall_fee: x.1 }).collect();
-        
+        let estimates = fee_estimates
+            .into_iter()
+            .map(|x| FeeEstimate { gas_price: 0, gas_consumed: x.1, overall_fee: x.0 })
+            .collect();
+
         Ok(estimates)
     }
 

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -619,27 +619,30 @@ where
         let best_block_hash = self.client.info().best_hash;
         let chain_id = Felt252Wrapper(self.chain_id()?.0);
 
-        let mut estimates = vec![];
+        let mut transactions = vec![];
         for tx in request {
             let tx = tx.try_into().map_err(|e| {
                 error!("Failed to convert BroadcastedTransaction to UserTransaction: {e}");
                 StarknetRpcApiError::InternalServerError
             })?;
-            let (actual_fee, gas_usage) = self
-                .client
-                .runtime_api()
-                .estimate_fee(substrate_block_hash, tx, is_query)
-                .map_err(|e| {
-                    error!("Request parameters error: {e}");
-                    StarknetRpcApiError::InternalServerError
-                })?
-                .map_err(|e| {
-                    error!("Failed to call function: {:#?}", e);
-                    StarknetRpcApiError::ContractError
-                })?;
-
-            estimates.push(FeeEstimate { gas_price: 0, gas_consumed: gas_usage, overall_fee: actual_fee });
+            transactions.push(tx);
         }
+
+        let fee_estimates = self
+            .client
+            .runtime_api()
+            .estimate_fee(substrate_block_hash, transactions)
+            .map_err(|e| {
+                error!("Request parameters error: {e}");
+                StarknetRpcApiError::InternalServerError
+            })?
+            .map_err(|e| {
+                error!("Failed to call function: {:#?}", e);
+                StarknetRpcApiError::ContractError
+            })?;
+
+        let estimates = fee_estimates.into_iter().map(|x| FeeEstimate { gas_price: 0, gas_consumed: x.0, overall_fee: x.1 }).collect();
+        
         Ok(estimates)
     }
 

--- a/crates/pallets/starknet/src/runtime_api.rs
+++ b/crates/pallets/starknet/src/runtime_api.rs
@@ -46,7 +46,7 @@ sp_api::decl_runtime_apis! {
         /// Returns the chain id.
         fn chain_id() -> Felt252Wrapper;
         /// Returns fee estimate
-        fn estimate_fee(transaction: UserTransaction, is_query: bool) -> Result<(u64, u64), DispatchError>;
+        fn estimate_fee(transactions: Vec<UserTransaction>) -> Result<Vec<(u64, u64)>, DispatchError>;
         /// Filters extrinsic transactions to return only Starknet transactions
         ///
         /// To support runtime upgrades, the client must be unaware of the specific extrinsic

--- a/crates/pallets/starknet/src/tests/query_tx.rs
+++ b/crates/pallets/starknet/src/tests/query_tx.rs
@@ -20,11 +20,9 @@ fn estimates_tx_fee_successfully_no_validate() {
         let tx_2 = get_invoke_dummy(Felt252Wrapper::ONE);
         let tx_2 = UserTransaction::Invoke(tx_2.into());
 
-        let mut tx_vec = Vec::new();
-        tx_vec.push(tx_1.clone());
-        tx_vec.push(tx_2.clone());
+        let txs = vec![tx_1, tx_2];
 
-        let fees = Starknet::estimate_fee(tx_vec).expect("estimate should not fail");
+        let fees = Starknet::estimate_fee(txs).expect("estimate should not fail");
 
         let (actual, l1_gas_usage) = fees[0];
         assert!(actual > 0, "actual fee is missing");
@@ -45,8 +43,7 @@ fn estimates_tx_fee_with_query_version() {
         let pre_storage = Starknet::pending().len();
         let tx = UserTransaction::Invoke(tx.into());
 
-        let mut tx_vec = Vec::new();
-        tx_vec.push(tx.clone());
+        let tx_vec = vec![tx];
 
         assert_ok!(Starknet::estimate_fee(tx_vec));
 
@@ -64,8 +61,7 @@ fn executable_tx_should_not_be_estimable() {
         let tx_hash = tx.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
         tx.signature = sign_message_hash(tx_hash);
 
-        let mut tx_vec = Vec::new();
-        tx_vec.push(UserTransaction::Invoke(tx.clone().into()));
+        let tx_vec = vec![UserTransaction::Invoke(tx.clone().into())];
 
         // it should not be valid for estimate calls
         assert_err!(Starknet::estimate_fee(tx_vec), Error::<MockRuntime>::TransactionExecutionFailed);
@@ -85,8 +81,7 @@ fn query_tx_should_not_be_executable() {
         let tx_hash = tx.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, true);
         tx.signature = sign_message_hash(tx_hash);
 
-        let mut tx_vec = Vec::new();
-        tx_vec.push(UserTransaction::Invoke(tx.clone().into()));
+        let tx_vec = vec![UserTransaction::Invoke(tx.clone().into())];
 
         // it should be valid for estimate calls
         assert_ok!(Starknet::estimate_fee(tx_vec));

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -263,8 +263,8 @@ impl_runtime_apis! {
             Starknet::chain_id()
         }
 
-        fn estimate_fee(transaction: UserTransaction, is_query: bool) -> Result<(u64, u64), DispatchError> {
-            Starknet::estimate_fee(transaction, is_query)
+        fn estimate_fee(transactions: Vec<UserTransaction>) -> Result<Vec<(u64, u64)>, DispatchError> {
+            Starknet::estimate_fee(transactions)
         }
 
         fn get_starknet_events_and_their_associated_tx_hash(block_extrinsics: Vec<<Block as BlockT>::Extrinsic>, chain_id: Felt252Wrapper) -> Vec<(Felt252Wrapper, StarknetEvent)> {

--- a/starknet-rpc-test/estimate_fee.rs
+++ b/starknet-rpc-test/estimate_fee.rs
@@ -101,16 +101,31 @@ async fn works_ok(madara: &ThreadSafeMadaraClient) -> Result<(), anyhow::Error> 
         is_query: true,
     });
 
-    let estimate =
-        rpc.estimate_fee(&vec![invoke_transaction.clone(), invoke_transaction], BlockId::Tag(BlockTag::Latest)).await?;
+    let invoke_transaction_2 = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
+        max_fee: FieldElement::ZERO,
+        signature: vec![],
+        nonce: FieldElement::ONE,
+        sender_address: FieldElement::from_hex_be(ACCOUNT_CONTRACT).unwrap(),
+        calldata: vec![
+            FieldElement::from_hex_be("5a02acdbf218464be3dd787df7a302f71fab586cad5588410ba88b3ed7b3a21").unwrap(),
+            FieldElement::from_hex_be("3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3").unwrap(),
+            FieldElement::from_hex_be("2").unwrap(),
+            FieldElement::from_hex_be("e150b6c2db6ed644483b01685571de46d2045f267d437632b508c19f3eb877").unwrap(),
+            FieldElement::from_hex_be("494196e88ce16bff11180d59f3c75e4ba3475d9fba76249ab5f044bcd25add6").unwrap(),
+        ],
+        is_query: true,
+    });
+
+    let estimates =
+        rpc.estimate_fee(&vec![invoke_transaction, invoke_transaction_2], BlockId::Tag(BlockTag::Latest)).await?;
 
     // TODO: instead execute the tx and check that the actual fee are the same as the estimated ones
-    assert_eq!(estimate.len(), 2);
-    assert_eq!(estimate[0].overall_fee, 410);
-    assert_eq!(estimate[1].overall_fee, 410);
+    assert_eq!(estimates.len(), 2);
+    assert_eq!(estimates[0].overall_fee, 410);
+    assert_eq!(estimates[1].overall_fee, 410);
     // https://starkscan.co/block/5
-    assert_eq!(estimate[0].gas_consumed, 0);
-    assert_eq!(estimate[1].gas_consumed, 0);
+    assert_eq!(estimates[0].gas_consumed, 0);
+    assert_eq!(estimates[1].gas_consumed, 0);
 
     Ok(())
 }

--- a/starknet-rpc-test/estimate_fee.rs
+++ b/starknet-rpc-test/estimate_fee.rs
@@ -84,9 +84,7 @@ async fn fail_if_one_txn_cannot_be_executed(madara: &ThreadSafeMadaraClient) -> 
 async fn works_ok(madara: &ThreadSafeMadaraClient) -> Result<(), anyhow::Error> {
     let rpc = madara.get_starknet_client().await;
 
-    // from mainnet tx: 0x000c52079f33dcb44a58904fac3803fd908ac28d6632b67179ee06f2daccb4b5
-    // https://starkscan.co/tx/0x000c52079f33dcb44a58904fac3803fd908ac28d6632b67179ee06f2daccb4b5
-    let invoke_transaction = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
+    let tx = BroadcastedInvokeTransaction {
         max_fee: FieldElement::ZERO,
         signature: vec![],
         nonce: FieldElement::ZERO,
@@ -99,22 +97,14 @@ async fn works_ok(madara: &ThreadSafeMadaraClient) -> Result<(), anyhow::Error> 
             FieldElement::from_hex_be("494196e88ce16bff11180d59f3c75e4ba3475d9fba76249ab5f044bcd25add6").unwrap(),
         ],
         is_query: true,
-    });
+    };
 
-    let invoke_transaction_2 = BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
-        max_fee: FieldElement::ZERO,
-        signature: vec![],
-        nonce: FieldElement::ONE,
-        sender_address: FieldElement::from_hex_be(ACCOUNT_CONTRACT).unwrap(),
-        calldata: vec![
-            FieldElement::from_hex_be("5a02acdbf218464be3dd787df7a302f71fab586cad5588410ba88b3ed7b3a21").unwrap(),
-            FieldElement::from_hex_be("3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3").unwrap(),
-            FieldElement::from_hex_be("2").unwrap(),
-            FieldElement::from_hex_be("e150b6c2db6ed644483b01685571de46d2045f267d437632b508c19f3eb877").unwrap(),
-            FieldElement::from_hex_be("494196e88ce16bff11180d59f3c75e4ba3475d9fba76249ab5f044bcd25add6").unwrap(),
-        ],
-        is_query: true,
-    });
+    // from mainnet tx: 0x000c52079f33dcb44a58904fac3803fd908ac28d6632b67179ee06f2daccb4b5
+    // https://starkscan.co/tx/0x000c52079f33dcb44a58904fac3803fd908ac28d6632b67179ee06f2daccb4b5
+    let invoke_transaction = BroadcastedTransaction::Invoke(tx.clone());
+
+    let invoke_transaction_2 =
+        BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction { nonce: FieldElement::ONE, ..tx });
 
     let estimates =
         rpc.estimate_fee(&vec![invoke_transaction, invoke_transaction_2], BlockId::Tag(BlockTag::Latest)).await?;


### PR DESCRIPTION
# Pull Request type

- Feature
Allow to pass a vector of transactions for fee estimation. Needed for instance for compatibility with the Argent wallet. 

## What is the current behavior?
Currently we accept only 1 transaction to estimate the fee and the state rolls back to initial state after each estimation. 
Resolves: [issue](https://github.com/keep-starknet-strange/madara/issues/1202)

## What is the new behavior?

We pass a vector of transaction to the `estimate_fee` function 
