### PR TITLE
Update Dockerfile, add `libprotobuf-dev` 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:slim-buster as builder
 RUN apt-get -y update; \
     apt-get install -y --no-install-recommends \
-        libssl-dev make clang-11 g++ llvm protobuf-compiler \
+        libssl-dev make clang-11 g++ llvm protobuf-compiler libprotobuf-dev \
         pkg-config libz-dev zstd git build-essential; \
     apt-get autoremove -y; \
     apt-get clean; \


### PR DESCRIPTION
Add `libprotobuf-dev` to builder stage of Dockerfile.

<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Docker release fails after 0.2.0(https://github.com/keep-starknet-strange/madara/actions/workflows/release.yml) with error message:

```
...
359.7    Compiling scale-decode v0.7.0
360.0 error: failed to run custom build command for `celestia-proto v0.1.0 (https://github.com/eigerco/celestia-node-rs?rev=bd6394b66b11065c543ab3f19fd66000a72b6236#bd6394b6)`
360.0 
360.0 Caused by:
360.0   process didn't exit successfully: `/madara/target/release/build/celestia-proto-54d657cd8f692a98/build-script-build` (exit status: 1)
360.0   --- stderr
360.0   Error: protoc failed: google/protobuf/descriptor.proto: File not found.
360.0   gogoproto/gogo.proto: Import "google/protobuf/descriptor.proto" was not found or had errors.
360.0   gogoproto/gogo.proto:38:8: "google.protobuf.EnumOptions" is not defined.
360.0   gogoproto/gogo.proto: "google.protobuf.EnumOptions" is not defined.
360.0   gogoproto/gogo.proto: "google.protobuf.EnumOptions" is not defined.
360.0   gogoproto/gogo.proto: "google.protobuf.EnumOptions" is not defined.
...
```

So even latest version of madara is 0.5.1(https://github.com/keep-starknet-strange/madara/tags), the docker image on release is only 0.2.0(https://github.com/keep-starknet-strange/madara/pkgs/container/madara).

This problem can be solved by adding  `libprotobuf-dev` to builder.

```
docker build . -t n0vad3v/madara
[+] Building 1509.7s (14/14) FINISHED                                                     docker:default
 => [internal] load build definition from Dockerfile                                                0.0s
 => => transferring dockerfile: 1.44kB                                                              0.0s
 => [internal] load .dockerignore                                                                   0.0s
 => => transferring context: 172B                                                                   0.0s
 => [internal] load metadata for docker.io/library/debian:buster-slim                               3.0s
 => [internal] load metadata for docker.io/library/rust:slim-buster                                 2.9s
 => CACHED [stage-1 1/3] FROM docker.io/library/debian:buster-slim@sha256:df5f318899cdba5fdb0255ed  0.0s
 => CACHED [builder 1/5] FROM docker.io/library/rust:slim-buster@sha256:4104d73f5fc1c5dffb2e8e6c62  0.0s
 => [internal] load build context                                                                   0.0s
 => => transferring context: 2.95MB                                                                 0.0s
 => [builder 2/5] RUN apt-get -y update;     apt-get install -y --no-install-recommends         l  47.3s
 => [builder 3/5] WORKDIR /madara                                                                   0.1s
 => [builder 4/5] COPY . .                                                                          1.0s 
 => [builder 5/5] RUN cargo build --release -Z sparse-registry --config net.git-fetch-with-cli=  1449.0s 
 => [stage-1 2/3] COPY --from=builder /madara/target/release/madara /madara-bin                     0.1s 
 => [stage-1 3/3] RUN apt-get -y update;     apt-get install -y --no-install-recommends         cu  8.3s 
 => exporting to image                                                                              0.4s 
 => => exporting layers                                                                             0.4s 
 => => writing image sha256:e61da28644d189ce5db7466c3c5ff7660a7a30d4fdf3b406d098043b094e9d90        0.0s 
 => => naming to docker.io/n0vad3v/madara                                                        0.0s 
```

```diff
diff --git a/Dockerfile b/Dockerfile
index f3604bd4..3adf7732 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:slim-buster as builder
 RUN apt-get -y update; \
     apt-get install -y --no-install-recommends \
-        libssl-dev make clang-11 g++ llvm protobuf-compiler \
+        libssl-dev make clang-11 g++ llvm protobuf-compiler libprotobuf-dev \
         pkg-config libz-dev zstd git build-essential; \
     apt-get autoremove -y; \
     apt-get clean; \

```

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Docker build will success

## Does this introduce a breaking change?

No

## Other information

Referenced to https://github.com/grpc-ecosystem/grpc-gateway/issues/422#issuecomment-451914824 this issue for solution.
