### PR TITLE
fix(starknet_rpc/get_transaction_receipt): async loop to get pending tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next release
 
+- fix: Wait for 1 minute for transaction to be processed in
+  get_transaction_receipt rpc
 - ci: Fix starknet foundry sncast not found
 - fix: Ensure transaction checks are compatible with starknet-rs
 - ci: Run Starknet Foundry tests against Madara RPC

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6394,6 +6394,7 @@ dependencies = [
  "starknet-ff",
  "starknet_api",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/client/rpc-core/src/lib.rs
+++ b/crates/client/rpc-core/src/lib.rs
@@ -134,5 +134,8 @@ pub trait StarknetRpcApi {
 
     /// Returns the receipt of a transaction by transaction hash.
     #[method(name = "getTransactionReceipt")]
-    fn get_transaction_receipt(&self, transaction_hash: FieldElement) -> RpcResult<MaybePendingTransactionReceipt>;
+    async fn get_transaction_receipt(
+        &self,
+        transaction_hash: FieldElement,
+    ) -> RpcResult<MaybePendingTransactionReceipt>;
 }

--- a/crates/client/rpc/Cargo.toml
+++ b/crates/client/rpc/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/keep-starknet-strange/madara"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-tokio = {workspace = true, default-features = true, features = ["time"]}
+tokio = { workspace = true, default-features = true, features = ["time"] }
 # Madara runtime
 pallet-starknet = { workspace = true, default-features = true }
 # Madara client

--- a/crates/client/rpc/Cargo.toml
+++ b/crates/client/rpc/Cargo.toml
@@ -16,7 +16,6 @@ repository = "https://github.com/keep-starknet-strange/madara"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-tokio = { workspace = true, default-features = true, features = ["time"] }
 # Madara runtime
 pallet-starknet = { workspace = true, default-features = true }
 # Madara client
@@ -56,6 +55,7 @@ mp-hashers = { workspace = true }
 mp-transactions = { workspace = true, features = ["client"] }
 serde_json = { workspace = true, default-features = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, default-features = true, features = ["time"] }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/client/rpc/Cargo.toml
+++ b/crates/client/rpc/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/keep-starknet-strange/madara"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+tokio = {workspace = true, default-features = true, features = ["time"]}
 # Madara runtime
 pallet-starknet = { workspace = true, default-features = true }
 # Madara client

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -904,8 +904,8 @@ where
                     .mapping()
                     .block_hash_from_transaction_hash(H256::from(transaction_hash.to_bytes_be()))
                     .map_err(|e| {
-                        error!("Failed to get transaction's substrate block hash from mapping_db: {e}");
-                        StarknetRpcApiError::TxnHashNotFound
+                        error!("Failed to interact with db backend error: {e}");
+                        StarknetRpcApiError::InternalServerError
                     })?;
 
                 match block_hash_from_db {
@@ -934,7 +934,7 @@ where
                 error!("did not receive tx hash within 1 minute");
                 return Err(StarknetRpcApiError::TxnHashNotFound.into());
             }
-            Ok(tx_hash) => tx_hash,
+            Ok(res) => res,
         }?;
 
         let block: mp_block::Block =

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use errors::StarknetRpcApiError;
 use jsonrpsee::core::{async_trait, RpcResult};
 use log::error;
+use mc_db::Backend as MadaraBackend;
 pub use mc_rpc_core::utils::*;
 use mc_rpc_core::Felt;
 pub use mc_rpc_core::StarknetRpcApiServer;
@@ -888,24 +889,53 @@ where
     /// # Arguments
     ///
     /// * `transaction_hash` - Transaction hash corresponding to the transaction.
-    fn get_transaction_receipt(&self, transaction_hash: FieldElement) -> RpcResult<MaybePendingTransactionReceipt> {
-        let block_hash_from_db = self
-            .backend
-            .mapping()
-            .block_hash_from_transaction_hash(H256::from(transaction_hash.to_bytes_be()))
-            .map_err(|e| {
-                error!("Failed to get transaction's substrate block hash from mapping_db: {e}");
-                StarknetRpcApiError::TxnHashNotFound
-            })?;
+    async fn get_transaction_receipt(
+        &self,
+        transaction_hash: FieldElement,
+    ) -> RpcResult<MaybePendingTransactionReceipt> {
+        async fn wait_for_tx_inclusion<B: sp_api::BlockT>(
+            madara_backend: Arc<MadaraBackend<B>>,
+            transaction_hash: FieldElement,
+        ) -> Result<<B as BlockT>::Hash, StarknetRpcApiError> {
+            let substrate_block_hash;
 
-        let substrate_block_hash = match block_hash_from_db {
-            Some(block_hash) => block_hash,
-            None => {
-                // If the transaction is still in the pool, the receipt
-                // is not available, thus considered as not found.
+            loop {
+                let block_hash_from_db = madara_backend
+                    .mapping()
+                    .block_hash_from_transaction_hash(H256::from(transaction_hash.to_bytes_be()))
+                    .map_err(|e| {
+                        error!("Failed to get transaction's substrate block hash from mapping_db: {e}");
+                        StarknetRpcApiError::TxnHashNotFound
+                    })?;
+
+                match block_hash_from_db {
+                    Some(block_hash) => {
+                        substrate_block_hash = block_hash;
+                        break;
+                    }
+                    None => {
+                        // TODO: hardcoded to match the blocktime; make it dynamic
+                        tokio::time::sleep(std::time::Duration::from_millis(6000)).await;
+                        continue;
+                    }
+                };
+            }
+
+            Ok(substrate_block_hash)
+        }
+
+        let substrate_block_hash = match tokio::time::timeout(
+            std::time::Duration::from_millis(60000),
+            wait_for_tx_inclusion(self.backend.clone(), transaction_hash),
+        )
+        .await
+        {
+            Err(_) => {
+                error!("did not receive tx hash within 1 minute");
                 return Err(StarknetRpcApiError::TxnHashNotFound.into());
             }
-        };
+            Ok(tx_hash) => tx_hash,
+        }?;
 
         let block: mp_block::Block =
             get_block_by_block_hash(self.client.as_ref(), substrate_block_hash).unwrap_or_default();
@@ -921,6 +951,7 @@ where
                 StarknetRpcApiError::InternalServerError
             })?
             .ok_or(StarknetRpcApiError::BlockNotFound)?;
+
         let chain_id = self.chain_id()?.0.into();
 
         let (tx_type, events) = self


### PR DESCRIPTION
## What is the current behavior?

Dojo wasn't aware of pending transactions in the Madara tx pool. Pending tx was returing as not found. 

## What is the new behavior?

We loop for 1 minute to make sure the transaction is processed. 

## Does this introduce a breaking change?

No

