### PR TITLE
chore: remove CI test of the native execution

### DIFF
--- a/.github/workflows/starknet-js-tests.yml
+++ b/.github/workflows/starknet-js-tests.yml
@@ -23,11 +23,11 @@ jobs:
           ./target/release/madara setup --chain=dev --from-local=configs
       - name: Run starknet-js test
         run: |-
-          ./target/release/madara --dev --execution native &
-          NATIVE_RUN_PID=$!
+          ./target/release/madara --dev &
+          MADARA_RUN_PID=$!
           while ! echo exit | nc localhost 9944; do sleep 1; done
           git clone https://github.com/keep-starknet-strange/sequencer-js-compatibility-tests.git
           cd sequencer-js-compatibility-tests
           npm install
           npm test
-          kill $NATIVE_RUN_PID
+          kill $MADARA_RUN_PID

--- a/.github/workflows/starknet-rpc-tests.yml
+++ b/.github/workflows/starknet-rpc-tests.yml
@@ -30,19 +30,11 @@ jobs:
       - name: Setup dev chain
         run: |
           ./target/release/madara setup --chain=dev --from-local=configs
-      - name: Run rpc native test
+      - name: Run rpc test
         run: |-
-          ./target/release/madara --dev --sealing=manual --execution=Native &
-          NATIVE_RUN_PID=$!
+          ./target/release/madara --dev --sealing=manual &
+          MADARA_RUN_PID=$!
           while ! echo exit | nc localhost 9944; do sleep 1; done
           cd starknet-rpc-test
           cargo test
-          kill $NATIVE_RUN_PID
-      - name: Run rpc wasm test
-        run: |-
-          ./target/release/madara --dev --sealing=manual --execution=Wasm &
-          WASM_RUN_PID=$!
-          while ! echo exit | nc localhost 9944; do sleep 1; done
-          cd starknet-rpc-test
-          cargo test
-          kill $WASM_RUN_PID
+          kill $MADARA_RUN_PID

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- chore: remove tests that run in wasm and native, only wasm from now
 - refacto: move starknet runtime api in it's own crate
 - chore: update README.md and getting-started.md
 - chore: remove crates that have been copy-pasted from plkdtSDK

--- a/scripts/run_node.sh
+++ b/scripts/run_node.sh
@@ -3,4 +3,4 @@
 set -e
 
 cargo build --release
-exec ../target/release/madara --dev --tmp --rpc-external --execution native --pool-limit=100000 --pool-kbytes=500000 --rpc-methods=unsafe --rpc-cors=all --in-peers=0 --out-peers=1 --no-telemetry
+exec ../target/release/madara --dev --tmp --rpc-external --pool-limit=100000 --pool-kbytes=500000 --rpc-methods=unsafe --rpc-cors=all --in-peers=0 --out-peers=1 --no-telemetry


### PR DESCRIPTION
https://github.com/paritytech/polkadot-sdk/issues/62

There is no more native runtime