### PR TITLE
build: update blockifier so no more divergent substrate block hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- build: update blockifier, fix divergent substrat block hash
 - chore: remove tests that run in wasm and native, only wasm from now
 - chore: split StarknetRpcApi trait in two, like in openRPC specs
 - refacto: move starknet runtime api in it's own crate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 [[package]]
 name = "blockifier"
 version = "0.1.0-rc2"
-source = "git+https://github.com/keep-starknet-strange/blockifier?branch=no_std-support-7578442#59ab602d50735f01a024b4542f066e6b1a154fcb"
+source = "git+https://github.com/keep-starknet-strange/blockifier?branch=no_std-support-7578442#691f162d0d386cfd731a33a5fb3b7414ed9e86ef"
 dependencies = [
  "ark-ff 0.4.2",
  "ark-secp256k1",
@@ -13725,7 +13725,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 


### PR DESCRIPTION
Hints were serde as vec, instead of BTreeMap in ContractClassV1Internal