### PR TITLE
Use code from pathfinder to create byte array for path to avoid uninitialized memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix: Change seliazation of bitvec to &[u8] in merkle tree to avoid memory uninitialized
 - refacto: substrate/starknet names in rpc library
 - feat(rpc): Added starknet_getTransactionStatus and removed
   starknet_pendingTransactions

--- a/crates/primitives/commitments/src/merkle_patricia_tree/merkle_node.rs
+++ b/crates/primitives/commitments/src/merkle_patricia_tree/merkle_node.rs
@@ -7,6 +7,7 @@
 use bitvec::order::Msb0;
 use bitvec::prelude::BitVec;
 use bitvec::slice::BitSlice;
+use bitvec::view::BitView;
 use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
 use starknet_api::stdlib::collections::HashMap;
@@ -287,10 +288,10 @@ impl EdgeNode {
             None => unreachable!("child node not found"),
         };
 
-        let mut temp_path = self.path.clone();
-        temp_path.force_align();
+        let mut bytes = [0u8; 32];
+        bytes.view_bits_mut::<Msb0>()[256 - self.path.len()..].copy_from_bitslice(&self.path);
 
-        let path = Felt252Wrapper::try_from(temp_path.into_vec().as_slice()).unwrap();
+        let path = Felt252Wrapper::try_from(&bytes).unwrap();
         let mut length = [0; 32];
         // Safe as len() is guaranteed to be <= 251
         length[31] = self.path.len() as u8;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- Bugfix
- Refactoring (no functional changes, no API changes)

## What is the current behavior?

In the merkle tree, in order to convert the path to a sequence of bytes to use it in the hash, the code used `into_vec()` method of bitvec. Following [their doc](https://docs.rs/bitvec/latest/bitvec/vec/struct.BitVec.html#method.into_vec) it's needed to call [.set_uninitialized()](https://docs.rs/bitvec/latest/bitvec/vec/struct.BitVec.html#method.set_uninitialized) before which was not the case in the previous code. This was causing making an hash on random uninitialized bytes and leads to possible wrong hash.

Resolves: #NA

## What is the new behavior?

In Pathfinder this logic as already been modified and so I change the code here using the one of Pathfinder that should produce a coherent output.

## Does this introduce a breaking change?

No

## Other information

/
