### PR TITLE
Fix Dockerfile for image building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -y update; \
 
 WORKDIR /madara
 COPY . .
-RUN cargo build --release -Z sparse-registry --config net.git-fetch-with-cli=true
+RUN cargo build --release
 
 FROM debian:buster-slim
 LABEL description="Madara, a blazing fast Starknet sequencer" \


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix
- Build-related changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently docker image build will fail, example: https://github.com/keep-starknet-strange/madara/actions/runs/7142017251/job/19450403402, causing the latest available docker image is stuck at 0.5.2, while the latest tag is 0.6.0

Error messages are:
```
#13 8.895 warning: flag `-Z sparse-registry` has been stabilized in the 1.68 release, and is no longer necessary
#13 8.895   The sparse protocol is now the default for crates.io
#13 8.895 
#13 8.967     Updating git repository `https://github.com/w3f/ring-vrf?rev=3ddc20`
#13 9.350 fatal: https://github.com/w3f/ring-vrf?rev=3ddc20/info/refs not valid: is this a git repository?
#13 9.354 error: failed to load source for dependency `bandersnatch_vrfs`
#13 9.354 
#13 9.354 Caused by:
#13 9.354   Unable to update https://github.com/w3f/ring-vrf?rev=3ddc20?rev=3ddc20
#13 9.354 
#13 9.354 Caused by:
#13 9.354   failed to clone into: /usr/local/cargo/git/db/ring-vrf-a15187887965fc5a
```

There are two problems here:
1. We should not use `-Z sparse-registry` anymore because it's  no longer necessary
2. Using `--config net.git-fetch-with-cli=true` flag will use system's git command, however it cannot parse `https://github.com/w3f/ring-vrf?rev=3ddc20` address correctly on the bottom of `Cargo.toml`



## What is the new behavior?

- The docker image build will success

![](https://github.com/keep-starknet-strange/madara/assets/24852034/202b5dd5-c5ad-4ca4-a49b-8b06cee23e16)


## Does this introduce a breaking change?

Nope


## Other information

Another suggestion it to change `rust:slim-buster` and `debian:buster-slim` to `rust:slim-bookworm` and `debian:bookworm-slim` which will contain newer version of packages(e,g `git` is 2.20.1 in buster and 2.39.2 in bookworm)
