### PR TITLE
fix: Replace `tempdir` with `tempfile` as suggested in issue #1337

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - fix(rpc-test): incorrect node url
 - feat(settlement): e2e test with Madara node settling on Ethereum contract
 - refactor: use `map` in `estimate_fee` to stop computation on error
+- fix: `tempdir` crate has been deprecated; use `tempfile` instead
 
 ## v0.6.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3975,12 +3975,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8520,19 +8514,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -8574,21 +8555,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -8681,15 +8647,6 @@ dependencies = [
  "ring 0.16.20",
  "time",
  "yasna",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -8808,15 +8765,6 @@ name = "relative-path"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -12128,7 +12076,7 @@ dependencies = [
  "starknet-providers",
  "starknet-signers",
  "starknet_api",
- "tempdir",
+ "tempfile",
  "test-context",
  "thiserror",
  "tokio",
@@ -12626,16 +12574,6 @@ name = "target-lexicon"
 version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
 
 [[package]]
 name = "tempfile"

--- a/starknet-e2e-test/Cargo.toml
+++ b/starknet-e2e-test/Cargo.toml
@@ -15,7 +15,7 @@ reqwest = "0.11.18"
 rstest = "0.18.1"
 serde = { version = "1.0.179", features = ["derive"] }
 serde_json = "1.0.107"
-tempdir = "0.3.7"
+tempfile = "3.2"
 test-context = "0.1.3"
 thiserror = { workspace = true }
 tokio = { version = "1.29.1", features = ["rt", "macros", "parking_lot"] }

--- a/starknet-e2e-test/README.md
+++ b/starknet-e2e-test/README.md
@@ -71,10 +71,10 @@ running Madara instance at a single point of time. In order to avoid concurrent
 access to e.g. config files you can override Madara base path and use unique
 temporary directories for each instance.
 
-Here is how you can do that using `test_context` and `tempdir` crate:
+Here is how you can do that using `test_context` and `tempfile` crate:
 
 ```rust
-use tempdir::TempDir;
+use tempfile::TempDir;
 use test_context::{test_context, AsyncTestContext};
 use async_trait::async_trait;
 use madara_node_runner::MadaraRunner;
@@ -86,7 +86,7 @@ struct Context {
 #[async_trait]
 impl AsyncTestContext for Context {
     async fn setup() -> Self {
-        let madara_path = TempDir::new("madara").expect("Failed to create Madara path");
+        let madara_path = TempDir::with_prefix("madara").expect("Failed to create Madara path");
         Self { madara_path }
     }
 

--- a/starknet-e2e-test/ethereum_e2e_settlement.rs
+++ b/starknet-e2e-test/ethereum_e2e_settlement.rs
@@ -15,7 +15,7 @@ use rstest::rstest;
 use starknet_api::serde_utils::hex_str_from_bytes;
 use starknet_e2e_test::ethereum_sandbox::EthereumSandbox;
 use starknet_e2e_test::starknet_contract::{InitData, StarknetContract};
-use tempdir::TempDir;
+use tempfile::TempDir;
 use test_context::{test_context, AsyncTestContext};
 use tokio::time::sleep;
 
@@ -46,7 +46,7 @@ impl AsyncTestContext for Context {
         let sandbox = EthereumSandbox::new();
         let starknet_contract = StarknetContract::deploy(&sandbox).await;
 
-        let madara_path = TempDir::new("madara").expect("Failed to create Madara path");
+        let madara_path = TempDir::with_prefix("madara").expect("Failed to create Madara path");
         let config_dir = madara_path.path().join("chains/dev"); // data path
         create_dir_all(&config_dir).unwrap();
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type
Bugfix


## What is the current behavior?
`tempdir` crate has been deprecated, as mentioned in issue #1337 

Resolves: use `tempfile` instead

