### PR TITLE
fix: call proving only after update state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix: `prove_current_block` is called after `update_state`
 - ci: add foundry ci task to push workflow
 - fix: first tx for non deployed account is valid
 - fix: incorrect base url for fetching config

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,7 +2522,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-lock 3.2.0",
- "clap 4.4.10",
+ "clap 4.4.11",
  "ethers",
  "flate2",
  "lazy_static",

--- a/crates/node/src/service.rs
+++ b/crates/node/src/service.rs
@@ -18,7 +18,7 @@ use mc_data_availability::celestia::config::CelestiaConfig;
 use mc_data_availability::celestia::CelestiaClient;
 use mc_data_availability::ethereum::config::EthereumConfig;
 use mc_data_availability::ethereum::EthereumClient;
-use mc_data_availability::{DaClient, DaLayer, DataAvailabilityWorker, DataAvailabilityWorkerProving};
+use mc_data_availability::{DaClient, DaLayer, DataAvailabilityWorker};
 use mc_genesis_data_provider::OnDiskGenesisConfig;
 use mc_l1_messages::config::L1MessagesWorkerConfig;
 use mc_mapping_sync::MappingSyncWorker;
@@ -447,21 +447,11 @@ pub fn new_full(
         };
 
         task_manager.spawn_essential_handle().spawn(
-            "da-worker-prove",
-            Some(MADARA_TASK_GROUP),
-            DataAvailabilityWorkerProving::prove_current_block(
-                da_client.get_mode(),
-                commitment_state_diff_rx,
-                madara_backend.clone(),
-            ),
-        );
-
-        task_manager.spawn_essential_handle().spawn(
             "da-worker-update",
             Some(MADARA_TASK_GROUP),
-            DataAvailabilityWorker::<_, _, StarknetHasher>::update_state(
+            DataAvailabilityWorker::<_, StarknetHasher>::update_state(
                 da_client,
-                client.clone(),
+                commitment_state_diff_rx,
                 madara_backend.clone(),
             ),
         );

--- a/docs/rpc-contribution.md
+++ b/docs/rpc-contribution.md
@@ -79,27 +79,27 @@ In the `crates/client` we can find two RPC related packages.
 
    ```rust
    // crates/client/rpc-core/src/lib.rs
-   
+
    // Note here the macro to ensure correct serialization.
    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
    pub struct MyEndpointParams {
        pub some_str: String,
        pub some_u64: u64,
    }
-   
+
    // If needed, define MyEndpointResult for instance.
-   
+
    ...
-   
+
    /// Starknet rpc interface.
    #[rpc(server, namespace = "starknet")]
    pub trait StarknetRpcApi {
        /// Get the most recent accepted block number
        #[method(name = "blockNumber")]
        fn block_number(&self) -> RpcResult<BlockNumber>;
-   
+
        ....
-   
+
        /// My new RPC endpoint.
        #[method(name = "myEndpoint")] // <-- camel case naming.
        fn my_endpoint(&self, my_params: MyEndpointParams) -> RpcResult<String>; // <-- Define struct as needed for params or result.
@@ -111,11 +111,11 @@ In the `crates/client` we can find two RPC related packages.
 
    ```rust
    // crates/client/rpc/src/lib.rs
-   
+
    ...
    use mc_rpc_core::{BlockHashAndNumber, BlockId as StarknetBlockId, MyEndpointParams};
    ...
-   
+
    impl<B, BE, C> StarknetRpcApiServer for Starknet<B, BE, C>
    where
        B: BlockT,
@@ -125,16 +125,16 @@ In the `crates/client` we can find two RPC related packages.
        C::Api: StarknetRuntimeApi<B>,
    {
        ...
-   
+
        /// New endpoint for an amazing feature.
        fn my_endpoint(&self, my_params: MyEndpointParams) -> RpcResult<String> {
            // Here comes the logic to interact with storage, etc...
            Ok(String::from("Let's build the future!"))
-   
+
            // If you need to access the runtime, you can use the following code:
            let runtime_api = self.client.runtime_api();
        }
-   
+
    }
    ```
 
@@ -145,16 +145,16 @@ storage or call internal functions. To do so, follow these steps:
 
    ```rust
    // crates/pallets/starknet/src/runtime_api.rs
-   
+
    use mp_starknet::execution::ContractAddressWrapper;
    use sp_core::{H256, U256};
    pub extern crate alloc;
    use alloc::vec::Vec;
-   
+
    use sp_runtime::DispatchError;
-   
+
    // /!\ You should be using runtime types here.
-   
+
    sp_api::decl_runtime_apis! {
        pub trait StarknetRuntimeApi {
            /// Returns a `Call` response.
@@ -169,13 +169,13 @@ storage or call internal functions. To do so, follow these steps:
 
    ```rust
    // crates/runtime/src/lib.rs
-   
+
    impl pallet_starknet::runtime_api::StarknetRuntimeApi<Block> for Runtime {
-   
+
          fn call(address: ContractAddressWrapper, function_selector: Felt252Wrapper, calldata: Vec<Felt252Wrapper>) -> Result<Vec<Felt252Wrapper>, DispatchError> {
              Starknet::call_contract(address, function_selector, calldata)
          }
-   
+
          fn my_function() -> H256 {
              // Here comes the logic to interact with storage, pallets...
              H256::from_low_u64_be(1234)

--- a/docs/rpc-contribution.md
+++ b/docs/rpc-contribution.md
@@ -77,111 +77,111 @@ In the `crates/client` we can find two RPC related packages.
    must define our endpoint "signature". We need a struct to be (de)serialized
    if some parameters must be passed / returned.
 
-```rust
-// crates/client/rpc-core/src/lib.rs
-
-// Note here the macro to ensure correct serialization.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
-pub struct MyEndpointParams {
-    pub some_str: String,
-    pub some_u64: u64,
-}
-
-// If needed, define MyEndpointResult for instance.
-
-...
-
-/// Starknet rpc interface.
-#[rpc(server, namespace = "starknet")]
-pub trait StarknetRpcApi {
-    /// Get the most recent accepted block number
-    #[method(name = "blockNumber")]
-    fn block_number(&self) -> RpcResult<BlockNumber>;
-
-    ....
-
-    /// My new RPC endpoint.
-    #[method(name = "myEndpoint")] // <-- camel case naming.
-    fn my_endpoint(&self, my_params: MyEndpointParams) -> RpcResult<String>; // <-- Define struct as needed for params or result.
-}
-```
+   ```rust
+   // crates/client/rpc-core/src/lib.rs
+   
+   // Note here the macro to ensure correct serialization.
+   #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
+   pub struct MyEndpointParams {
+       pub some_str: String,
+       pub some_u64: u64,
+   }
+   
+   // If needed, define MyEndpointResult for instance.
+   
+   ...
+   
+   /// Starknet rpc interface.
+   #[rpc(server, namespace = "starknet")]
+   pub trait StarknetRpcApi {
+       /// Get the most recent accepted block number
+       #[method(name = "blockNumber")]
+       fn block_number(&self) -> RpcResult<BlockNumber>;
+   
+       ....
+   
+       /// My new RPC endpoint.
+       #[method(name = "myEndpoint")] // <-- camel case naming.
+       fn my_endpoint(&self, my_params: MyEndpointParams) -> RpcResult<String>; // <-- Define struct as needed for params or result.
+   }
+   ```
 
 2. `rpc`: implements actual RPC logic to process the parameters (if any) and
    return a result.
 
-```rust
-// crates/client/rpc/src/lib.rs
-
-...
-use mc_rpc_core::{BlockHashAndNumber, BlockId as StarknetBlockId, MyEndpointParams};
-...
-
-impl<B, BE, C> StarknetRpcApiServer for Starknet<B, BE, C>
-where
-    B: BlockT,
-    BE: Backend<B> + 'static,
-    C: HeaderBackend<B> + StorageProvider<B, BE> + 'static,
-    C: ProvideRuntimeApi<B>,
-    C::Api: StarknetRuntimeApi<B>,
-{
-    ...
-
-    /// New endpoint for an amazing feature.
-    fn my_endpoint(&self, my_params: MyEndpointParams) -> RpcResult<String> {
-        // Here comes the logic to interact with storage, etc...
-        Ok(String::from("Let's build the future!"))
-
-        // If you need to access the runtime, you can use the following code:
-        let runtime_api = self.client.runtime_api();
-    }
-
-}
-```
+   ```rust
+   // crates/client/rpc/src/lib.rs
+   
+   ...
+   use mc_rpc_core::{BlockHashAndNumber, BlockId as StarknetBlockId, MyEndpointParams};
+   ...
+   
+   impl<B, BE, C> StarknetRpcApiServer for Starknet<B, BE, C>
+   where
+       B: BlockT,
+       BE: Backend<B> + 'static,
+       C: HeaderBackend<B> + StorageProvider<B, BE> + 'static,
+       C: ProvideRuntimeApi<B>,
+       C::Api: StarknetRuntimeApi<B>,
+   {
+       ...
+   
+       /// New endpoint for an amazing feature.
+       fn my_endpoint(&self, my_params: MyEndpointParams) -> RpcResult<String> {
+           // Here comes the logic to interact with storage, etc...
+           Ok(String::from("Let's build the future!"))
+   
+           // If you need to access the runtime, you can use the following code:
+           let runtime_api = self.client.runtime_api();
+       }
+   
+   }
+   ```
 
 Quite often you will need to interact with the runtime, in order to access
 storage or call internal functions. To do so, follow these steps:
 
 1. Add your function signature to the runtime api
 
-```rust
-// crates/pallets/starknet/src/runtime_api.rs
-
-use mp_starknet::execution::ContractAddressWrapper;
-use sp_core::{H256, U256};
-pub extern crate alloc;
-use alloc::vec::Vec;
-
-use sp_runtime::DispatchError;
-
-// /!\ You should be using runtime types here.
-
-sp_api::decl_runtime_apis! {
-    pub trait StarknetRuntimeApi {
-        /// Returns a `Call` response.
-        fn call(address: ContractAddressWrapper, function_selector: Felt252Wrapper, calldata: Vec<Felt252Wrapper>) -> Result<Vec<Felt252Wrapper>, DispatchError>;
-        /// Your new function.
-        fn my_function() -> H256;
-    }
-}
-```
+   ```rust
+   // crates/pallets/starknet/src/runtime_api.rs
+   
+   use mp_starknet::execution::ContractAddressWrapper;
+   use sp_core::{H256, U256};
+   pub extern crate alloc;
+   use alloc::vec::Vec;
+   
+   use sp_runtime::DispatchError;
+   
+   // /!\ You should be using runtime types here.
+   
+   sp_api::decl_runtime_apis! {
+       pub trait StarknetRuntimeApi {
+           /// Returns a `Call` response.
+           fn call(address: ContractAddressWrapper, function_selector: Felt252Wrapper, calldata: Vec<Felt252Wrapper>) -> Result<Vec<Felt252Wrapper>, DispatchError>;
+           /// Your new function.
+           fn my_function() -> H256;
+       }
+   }
+   ```
 
 2. Implement your function in the runtime
 
-```rust
-// crates/runtime/src/lib.rs
-
-impl pallet_starknet::runtime_api::StarknetRuntimeApi<Block> for Runtime {
-
-      fn call(address: ContractAddressWrapper, function_selector: Felt252Wrapper, calldata: Vec<Felt252Wrapper>) -> Result<Vec<Felt252Wrapper>, DispatchError> {
-          Starknet::call_contract(address, function_selector, calldata)
-      }
-
-      fn my_function() -> H256 {
-          // Here comes the logic to interact with storage, pallets...
-          H256::from_low_u64_be(1234)
-      }
-}
-```
+   ```rust
+   // crates/runtime/src/lib.rs
+   
+   impl pallet_starknet::runtime_api::StarknetRuntimeApi<Block> for Runtime {
+   
+         fn call(address: ContractAddressWrapper, function_selector: Felt252Wrapper, calldata: Vec<Felt252Wrapper>) -> Result<Vec<Felt252Wrapper>, DispatchError> {
+             Starknet::call_contract(address, function_selector, calldata)
+         }
+   
+         fn my_function() -> H256 {
+             // Here comes the logic to interact with storage, pallets...
+             H256::from_low_u64_be(1234)
+         }
+   }
+   ```
 
 Great, now it's finally time to write some integration tests to ensure
 everything is working as expected.


### PR DESCRIPTION
There is no ordering between `prove_current_block` and `update_state`, any function can be called first. For context, `prove_current_block` updates the state diff in the db and `update_state` fetches those diffs. 

Case 1: `prove_current_block` is called first, DA works fine `store_state_diff` is called before `state_diff` which gets the state diff
Case 2: `update_state` is called first, DA throws an error as it first calls `state_diff` and then `store_state_diff`.

Since in the validity case, the proof be dependent on the DA, we should be calling `update_state` first. So we need to move the `store_state_diff` to update_state, call it first and then call `prove_current_block` at the end of update state.

