### PR TITLE
fix: reorder DA tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(DA): run the proof first then the state update
 - fix: `prove_current_block` is called after `update_state`
 - ci: add foundry ci task to push workflow
 - fix: first tx for non deployed account is valid

--- a/crates/client/data-availability/src/lib.rs
+++ b/crates/client/data-availability/src/lib.rs
@@ -7,7 +7,7 @@ pub mod utils;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use ethers::types::{I256, U256};
 use futures::channel::mpsc;
@@ -17,10 +17,10 @@ use mp_hashers::HasherT;
 use serde::{Deserialize, Serialize};
 use sp_runtime::traits::Block as BlockT;
 use starknet_api::block::BlockHash;
+use starknet_api::state::ThinStateDiff;
 use utils::state_diff_to_calldata;
 
 pub struct DataAvailabilityWorker<B, H>(PhantomData<(B, H)>);
-pub struct DataAvailabilityWorkerProving<B>(PhantomData<B>);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
@@ -70,89 +70,112 @@ pub trait DaClient: Send + Sync {
     async fn publish_state_diff(&self, state_diff: Vec<U256>) -> Result<()>;
 }
 
-impl<B> DataAvailabilityWorkerProving<B>
-where
-    B: BlockT,
-{
-    pub async fn prove_current_block(da_mode: DaMode, block_hash: BlockHash, madara_backend: Arc<mc_db::Backend<B>>) {
-        log::info!("proving the block {block_hash}");
-
-        match da_mode {
-            DaMode::Validity => {
-                // Submit the Starknet OS PIE
-                // TODO: Validity Impl
-                // run the Starknet OS with the Cairo VM
-                // extract the PIE from the Cairo VM run
-                // pass the PIE to `submit_pie` and zip/base64 internal
-                if let Ok(job_resp) = sharp::submit_pie("TODO") {
-                    log::info!("Job Submitted: {}", job_resp.cairo_job_key);
-                    // Store the cairo job key
-                    if let Err(db_err) = madara_backend.da().update_cairo_job(&block_hash, job_resp.cairo_job_key) {
-                        log::error!("db err: {db_err}");
-                    };
-                }
-            }
-            _ => {
-                log::info!("don't prove in remaining DA modes")
-            }
-        }
-    }
-}
-
+/// The client worker for DA related tasks
+///
+/// Listen to new block state diff and spawn new threads to execute each block flow concurently.
+/// The flow goes as follow:
+/// 1. Prove. Do nothing if node is run in sovereign mode
+/// 2. Updata
 impl<B, H> DataAvailabilityWorker<B, H>
 where
     B: BlockT,
     H: HasherT,
 {
-    pub async fn update_state(
-        da_client: Box<dyn DaClient + Send + Sync>,
+    pub async fn prove_current_block(
+        da_client: Arc<dyn DaClient + Send + Sync>,
         mut state_diffs_rx: mpsc::Receiver<BlockDAData>,
         madara_backend: Arc<mc_db::Backend<B>>,
     ) {
         while let Some(BlockDAData(starknet_block_hash, csd, num_addr_accessed)) = state_diffs_rx.next().await {
             log::info!(
-                "received state diff for block {starknet_block_hash}: {csd:?}. {num_addr_accessed} addresses accessed."
+                "received state diff for block {starknet_block_hash}: {csd:?}.{num_addr_accessed} addresses accessed."
             );
 
-            // store the state diff
-            if let Err(db_err) = madara_backend
-                .da()
-                .store_state_diff(&starknet_block_hash, state_diff_to_calldata(csd, num_addr_accessed))
-            {
-                log::error!("db err: {db_err}");
-            };
-            // Query last written state
-            // TODO: this value will be used to ensure the correct state diff is being written in Validity mode
-            let _last_published_state = match da_client.last_published_state().await {
-                Ok(last_published_state) => last_published_state,
-                Err(e) => {
-                    log::error!("da provider error: {e}");
-                    continue;
+            let da_client = da_client.clone();
+            let madara_backend = madara_backend.clone();
+            tokio::spawn(async move {
+                match prove(da_client.get_mode(), starknet_block_hash, &csd, num_addr_accessed, madara_backend.clone())
+                    .await
+                {
+                    Err(err) => log::error!("proving error: {err}"),
+                    Ok(()) => {}
                 }
-            };
 
-            match da_client.get_mode() {
-                DaMode::Validity => {
-                    // Check the SHARP status of last_proved + 1
-                    // Write the publish state diff of last_proved + 1
-                    log::info!("validity da mode not implemented");
-                }
-                DaMode::Sovereign => match madara_backend.da().state_diff(&starknet_block_hash) {
-                    Ok(state_diff) => {
-                        if let Err(e) = da_client.publish_state_diff(state_diff).await {
-                            log::error!("DA PUBLISH ERROR: {}", e);
-                        }
-                    }
-                    Err(e) => log::error!("could not pull state diff for block {starknet_block_hash}: {e}"),
-                },
-                DaMode::Volition => log::info!("volition da mode not implemented"),
-            }
-
-            tokio::spawn(DataAvailabilityWorkerProving::<B>::prove_current_block(
-                da_client.get_mode(),
-                starknet_block_hash,
-                madara_backend.clone(),
-            ));
+                match update_state::<B, H>(madara_backend, da_client, starknet_block_hash, csd, num_addr_accessed).await
+                {
+                    Err(err) => log::error!("state publishing error: {err}"),
+                    Ok(()) => {}
+                };
+            });
         }
     }
+}
+
+pub async fn prove<B: BlockT>(
+    da_mode: DaMode,
+    block_hash: BlockHash,
+    _state_diff: &ThinStateDiff,
+    _num_addr_accessed: usize,
+    madara_backend: Arc<mc_db::Backend<B>>,
+) -> Result<(), anyhow::Error> {
+    log::info!("proving the block {block_hash}");
+
+    match da_mode {
+        DaMode::Validity => {
+            // Submit the Starknet OS PIE
+            // TODO: Validity Impl
+            // run the Starknet OS with the Cairo VM
+            // extract the PIE from the Cairo VM run
+            // pass the PIE to `submit_pie` and zip/base64 internal
+            if let Ok(job_resp) = sharp::submit_pie("TODO") {
+                log::info!("Job Submitted: {}", job_resp.cairo_job_key);
+                // Store the cairo job key
+                madara_backend
+                    .da()
+                    .update_cairo_job(&block_hash, job_resp.cairo_job_key)
+                    .map_err(|e| anyhow!("{e}"))?;
+            }
+        }
+        _ => {
+            log::info!("don't prove in remaining DA modes")
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn update_state<B: BlockT, H: HasherT>(
+    madara_backend: Arc<mc_db::Backend<B>>,
+    da_client: Arc<dyn DaClient + Send + Sync>,
+    starknet_block_hash: BlockHash,
+    csd: ThinStateDiff,
+    num_addr_accessed: usize,
+) -> Result<(), anyhow::Error> {
+    // store the state diff
+    madara_backend
+        .da()
+        .store_state_diff(&starknet_block_hash, state_diff_to_calldata(csd, num_addr_accessed))
+        .map_err(|e| anyhow!("{e}"))?;
+
+    // Query last written state
+    // TODO: this value will be used to ensure the correct state diff is being written in
+    // Validity mode
+    let _last_published_state = da_client.last_published_state().await?;
+
+    match da_client.get_mode() {
+        DaMode::Validity => {
+            // Check the SHARP status of last_proved + 1
+            // Write the publish state diff of last_proved + 1
+            log::info!("validity da mode not implemented");
+        }
+        DaMode::Sovereign => match madara_backend.da().state_diff(&starknet_block_hash) {
+            Ok(state_diff) => {
+                da_client.publish_state_diff(state_diff).await.map_err(|e| anyhow!("DA PUBLISH ERROR: {e}"))?;
+            }
+            Err(e) => Err(anyhow!("could not pull state diff for block {starknet_block_hash}: {e}"))?,
+        },
+        DaMode::Volition => log::info!("volition da mode not implemented"),
+    };
+
+    Ok(())
 }


### PR DESCRIPTION
## What is the current behavior?

Publish state then prove

Resolves: #NA

prove then publish state, as in validity mode the eth core contracts update_state check for the proof