### PR TITLE
feat: :white_check_mark: Adding test for getNonce RPC Call if Contrac…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,11 +6,11 @@
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:1": {},
-    "ghcr.io/devcontainers-contrib/features/protoc-asdf:1": {}
+    "ghcr.io/devcontainers-contrib/features/protoc-asdf:1": {},
   },
   "hostRequirements": {
     "cpus": 8,
     "memory": "16gb",
-    "storage": "128gb"
-  }
+    "storage": "128gb",
+  },
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - fix: `tempdir` crate has been deprecated; use `tempfile` instead
 - dev: add avail and celestia crates behind a feature flag
 - dev: replace md5 with sha3_256 hash function
+- feat: fixing getNonce Rpc Call and adding a new test
 
 ## v0.6.0
 

--- a/crates/client/storage/src/overrides/schema_v1_override.rs
+++ b/crates/client/storage/src/overrides/schema_v1_override.rs
@@ -117,6 +117,11 @@ where
     }
 
     fn nonce(&self, block_hash: <B as BlockT>::Hash, address: ContractAddress) -> Option<Nonce> {
+        // Check if the contract exists at the given address
+        if self.contract_class_hash_by_address(block_hash, address).is_none() {
+            return None;
+        }
+
         let storage_nonce_prefix = storage_prefix_build(PALLET_STARKNET, STARKNET_NONCE);
         let nonce = self.query_storage::<Nonce>(
             block_hash,
@@ -125,7 +130,7 @@ where
 
         match nonce {
             Some(nonce) => Some(nonce),
-            _ => None,
+            None => Some(Nonce::default()),
         }
     }
 }

--- a/crates/client/storage/src/overrides/schema_v1_override.rs
+++ b/crates/client/storage/src/overrides/schema_v1_override.rs
@@ -117,10 +117,7 @@ where
     }
 
     fn nonce(&self, block_hash: <B as BlockT>::Hash, address: ContractAddress) -> Option<Nonce> {
-        // Check if the contract exists at the given address
-        if self.contract_class_hash_by_address(block_hash, address).is_none() {
-            return None;
-        }
+        self.contract_class_hash_by_address(block_hash, address)?;
 
         let storage_nonce_prefix = storage_prefix_build(PALLET_STARKNET, STARKNET_NONCE);
         let nonce = self.query_storage::<Nonce>(

--- a/crates/client/storage/src/overrides/schema_v1_override.rs
+++ b/crates/client/storage/src/overrides/schema_v1_override.rs
@@ -125,7 +125,7 @@ where
 
         match nonce {
             Some(nonce) => Some(nonce),
-            None => Some(Nonce::default()),
+            _ => None,
         }
     }
 }

--- a/starknet-rpc-test/get_block_with_txs.rs
+++ b/starknet-rpc-test/get_block_with_txs.rs
@@ -108,17 +108,17 @@ async fn works_with_deploy_account_txn(madara: &ThreadSafeMadaraClient) -> Resul
 
         let funding_account = build_single_owner_account(&rpc, SIGNER_PRIVATE, ARGENT_CONTRACT_ADDRESS, true);
         let account_address = account_deploy_txn.address();
-        
+
         // We execute the funding in a different block, because we have no way to guarantee the tx execution
         // order once in the mempool
         madara_write_lock
-        .create_block_with_txs(vec![Transaction::Execution(funding_account.transfer_tokens(
-            account_address,
-            max_fee,
-            None,
-        ))])
-        .await?;
-    
+            .create_block_with_txs(vec![Transaction::Execution(funding_account.transfer_tokens(
+                account_address,
+                max_fee,
+                None,
+            ))])
+            .await?;
+
         let deploy_nonce = rpc.get_nonce(BlockId::Tag(BlockTag::Latest), account_deploy_txn.address()).await?;
         madara_write_lock.create_block_with_txs(vec![Transaction::AccountDeployment(account_deploy_txn)]).await?;
 

--- a/starknet-rpc-test/get_block_with_txs.rs
+++ b/starknet-rpc-test/get_block_with_txs.rs
@@ -108,18 +108,18 @@ async fn works_with_deploy_account_txn(madara: &ThreadSafeMadaraClient) -> Resul
 
         let funding_account = build_single_owner_account(&rpc, SIGNER_PRIVATE, ARGENT_CONTRACT_ADDRESS, true);
         let account_address = account_deploy_txn.address();
-        let deploy_nonce = rpc.get_nonce(BlockId::Tag(BlockTag::Latest), account_deploy_txn.address()).await?;
-
+        
         // We execute the funding in a different block, because we have no way to guarantee the tx execution
         // order once in the mempool
         madara_write_lock
-            .create_block_with_txs(vec![Transaction::Execution(funding_account.transfer_tokens(
-                account_address,
-                max_fee,
-                None,
-            ))])
-            .await?;
-
+        .create_block_with_txs(vec![Transaction::Execution(funding_account.transfer_tokens(
+            account_address,
+            max_fee,
+            None,
+        ))])
+        .await?;
+    
+        let deploy_nonce = rpc.get_nonce(BlockId::Tag(BlockTag::Latest), account_deploy_txn.address()).await?;
         madara_write_lock.create_block_with_txs(vec![Transaction::AccountDeployment(account_deploy_txn)]).await?;
 
         let block = match rpc.get_block_with_txs(BlockId::Tag(BlockTag::Latest)).await.unwrap() {

--- a/starknet-rpc-test/get_block_with_txs.rs
+++ b/starknet-rpc-test/get_block_with_txs.rs
@@ -101,14 +101,15 @@ async fn works_with_deploy_account_txn(madara: &ThreadSafeMadaraClient) -> Resul
     let contract_address_salt = FieldElement::ONE;
     let max_fee = FieldElement::from_hex_be(MAX_FEE_OVERRIDE).unwrap();
 
-    let (_deploy_nonce, block) = {
+    let (block) = {
         let mut madara_write_lock = madara.write().await;
         let oz_factory = build_oz_account_factory(&rpc, "0x123", class_hash).await;
         let account_deploy_txn = build_deploy_account_tx(&oz_factory, FieldElement::ONE);
 
         let funding_account = build_single_owner_account(&rpc, SIGNER_PRIVATE, ARGENT_CONTRACT_ADDRESS, true);
         let account_address = account_deploy_txn.address();
-        let deploy_nonce = rpc.get_nonce(BlockId::Tag(BlockTag::Latest), account_deploy_txn.address()).await?;
+        // let deploy_nonce = rpc.get_nonce(BlockId::Tag(BlockTag::Latest),
+        // account_deploy_txn.address()).await?;
 
         // We execute the funding in a different block, because we have no way to guarantee the tx execution
         // order once in the mempool
@@ -127,7 +128,7 @@ async fn works_with_deploy_account_txn(madara: &ThreadSafeMadaraClient) -> Resul
             MaybePendingBlockWithTxs::PendingBlock(_) => return Err(anyhow!("Expected block, got pending block")),
         };
 
-        (deploy_nonce, block)
+        (block)
     };
 
     assert_eq!(block.transactions.len(), 1);

--- a/starknet-rpc-test/get_nonce.rs
+++ b/starknet-rpc-test/get_nonce.rs
@@ -54,23 +54,6 @@ async fn fail_non_existing_contract(madara: &ThreadSafeMadaraClient) -> Result<(
 
 #[rstest]
 #[tokio::test]
-async fn work_ok_non_used_contract_address(madara: &ThreadSafeMadaraClient) -> Result<(), anyhow::Error> {
-    let rpc = madara.get_starknet_client().await;
-
-    assert_eq!(
-        rpc.get_nonce(
-            BlockId::Number(0),
-            FieldElement::from_hex_be("0x4269DEADBEEF").expect("Invalid Contract Address")
-        )
-        .await?,
-        FieldElement::ZERO
-    );
-
-    Ok(())
-}
-
-#[rstest]
-#[tokio::test]
 async fn work_ok_non_account_contract(madara: &ThreadSafeMadaraClient) -> Result<(), anyhow::Error> {
     let rpc = madara.get_starknet_client().await;
 

--- a/starknet-rpc-test/get_nonce.rs
+++ b/starknet-rpc-test/get_nonce.rs
@@ -48,7 +48,7 @@ async fn fail_non_existing_contract(madara: &ThreadSafeMadaraClient) -> Result<(
         .await,
         Err(ProviderError::StarknetError(StarknetErrorWithMessage { code: MaybeUnknownErrorCode::Known(code), .. })) if code == StarknetError::ContractNotFound
     );
-    
+
     Ok(())
 }
 

--- a/starknet-rpc-test/get_nonce.rs
+++ b/starknet-rpc-test/get_nonce.rs
@@ -36,6 +36,24 @@ async fn fail_non_existing_block(madara: &ThreadSafeMadaraClient) -> Result<(), 
 
 #[rstest]
 #[tokio::test]
+async fn fail_non_existing_contract(madara: &ThreadSafeMadaraClient) -> Result<(), anyhow::Error> {
+    let rpc = madara.get_starknet_client().await;
+
+    assert_matches!(
+        rpc
+        .get_nonce(
+            BlockId::Tag(BlockTag::Latest),
+            FieldElement::from_hex_be("0x51e59c2c182a58fb0a74349bfa4769cbbcba32547591dd3fb1def8623997d00").unwrap(),
+        )
+        .await,
+        Err(ProviderError::StarknetError(StarknetErrorWithMessage { code: MaybeUnknownErrorCode::Known(code), .. })) if code == StarknetError::ContractNotFound
+    );
+    
+    Ok(())
+}
+
+#[rstest]
+#[tokio::test]
 async fn work_ok_non_used_contract_address(madara: &ThreadSafeMadaraClient) -> Result<(), anyhow::Error> {
     let rpc = madara.get_starknet_client().await;
 


### PR DESCRIPTION
# Description

Solve issue : #1373 

Adding a test for getNonce RPC call in case the contract doesnt exist/ is invalid. 
I Also changed the "nonce" function in order to return None instead of a Nonce::Default().
The precedent version of Madara, when a invalid contract was tested, didnt produce any error and was
just return a default Nonce, equal to 0, which is a valid nonce on Starknet. 
By this return, the ContractError was never triggered, resulting with a valid nonce return.


# Pull Request type

- Bugfix
- Testing

## What is the new behavior?

By changing the nonce return in case of error and adding a test in case of an invalid contract,
its return the right error.

## Does this introduce a breaking change?

No

## Other information

