### PR TITLE
use cache for receipts and event txs

### DIFF
--- a/.github/workflows/starknet-rpc-tests.yml
+++ b/.github/workflows/starknet-rpc-tests.yml
@@ -31,9 +31,17 @@ jobs:
       - name: Setup dev chain
         run: |
           ./target/release/madara setup --chain=dev --from-local=configs
-      - name: Run rpc test
+      - name: Run rpc test without cache
         run: |-
           ./target/release/madara --dev --sealing=manual &
+          MADARA_RUN_PID=$!
+          while ! echo exit | nc localhost 9944; do sleep 1; done
+          cd starknet-rpc-test
+          cargo test
+          kill $MADARA_RUN_PID
+      - name: Run rpc test with cache
+        run: |-
+          ./target/release/madara --dev --sealing=manual --cache &
           MADARA_RUN_PID=$!
           while ! echo exit | nc localhost 9944; do sleep 1; done
           cd starknet-rpc-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- chore: add cache usage for `getEvents` and `getTransactionReceipt`
 - fix: cairo1 contracts should be identified by their sierra class hash
 - fix(cli): repair broken cli for da conf
 - feat(client): on `add_declare_transaction` store sierra contract classes in

--- a/crates/client/rpc/src/events/mod.rs
+++ b/crates/client/rpc/src/events/mod.rs
@@ -90,28 +90,8 @@ where
         let mut tx_hash_and_events: Vec<(Felt252Wrapper, starknet_api::transaction::Event)> = vec![];
         for (index, event) in index_and_events {
             let tx_index = index as usize - inherent_count;
-            if let Some(txn_hashes) = &txn_hashes {
-                let tx_hash = (&txn_hashes
-                    .get(tx_index)
-                    .ok_or_else(|| {
-                        error!("Failed to retrieve transaction hash from cache, invalid index {}", tx_index);
-                        StarknetRpcApiError::InternalServerError
-                    })?
-                    .0)
-                    .try_into()
-                    .map_err(|_| {
-                        error!("Failed to convert transaction hash");
-                        StarknetRpcApiError::InternalServerError
-                    })?;
-                tx_hash_and_events.push((tx_hash, event));
-            } else {
-                let transaction = &starknet_txs.get(tx_index).ok_or_else(|| {
-                    error!("Failed to retrieve transaction hash from starknet txs, invalid index {}", tx_index);
-                    StarknetRpcApiError::InternalServerError
-                })?;
-                let tx_hash = transaction.compute_hash::<H>(chain_id, false);
-                tx_hash_and_events.push((tx_hash, event));
-            }
+            let tx_hash = self.try_txn_hash_from_cache(tx_index, &txn_hashes, &starknet_txs, chain_id)?;
+            tx_hash_and_events.push((tx_hash, event));
         }
 
         let starknet_block = get_block_by_block_hash(self.client.as_ref(), substrate_block_hash)

--- a/crates/client/rpc/src/events/mod.rs
+++ b/crates/client/rpc/src/events/mod.rs
@@ -9,7 +9,7 @@ use log::error;
 use mc_rpc_core::utils::get_block_by_block_hash;
 use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
-use mp_transactions::compute_hash::ComputeTransactionHash;
+
 use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;

--- a/crates/client/rpc/src/events/mod.rs
+++ b/crates/client/rpc/src/events/mod.rs
@@ -9,7 +9,6 @@ use log::error;
 use mc_rpc_core::utils::get_block_by_block_hash;
 use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
-
 use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;

--- a/crates/client/rpc/src/events/mod.rs
+++ b/crates/client/rpc/src/events/mod.rs
@@ -122,8 +122,8 @@ where
             .into_iter()
             .map(|(tx_hash, event)| EmittedEvent {
                 from_address: Felt252Wrapper::from(event.from_address).0,
-                keys: event.content.keys.clone().into_iter().map(|felt| Felt252Wrapper::from(felt).0).collect(),
-                data: event.content.data.0.clone().into_iter().map(|felt| Felt252Wrapper::from(felt).0).collect(),
+                keys: event.content.keys.into_iter().map(|felt| Felt252Wrapper::from(felt).0).collect(),
+                data: event.content.data.0.into_iter().map(|felt| Felt252Wrapper::from(felt).0).collect(),
                 block_hash: block_hash.0,
                 block_number,
                 transaction_hash: tx_hash.0,

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -199,7 +199,7 @@ where
         &self,
         tx_index: usize,
         cached_transactions: &Option<Vec<H256>>,
-        transactions: &Vec<mp_transactions::Transaction>,
+        transactions: &[mp_transactions::Transaction],
         chain_id: Felt252Wrapper,
     ) -> Result<Felt252Wrapper, StarknetRpcApiError> {
         if let Some(txn_hashes) = &cached_transactions {

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -190,7 +190,7 @@ where
     /// * `block_hash` - The hash of the block containing the transactions (starknet block).
     fn get_cached_transaction_hashes(&self, block_hash: H256) -> Option<Vec<H256>> {
         self.backend.mapping().cached_transaction_hashes_from_block_hash(block_hash).unwrap_or_else(|err| {
-            error!("{err}");
+            error!("Failed to read from cache: {err}");
             None
         })
     }

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -1483,7 +1483,7 @@ where
                 break;
             }
         }
-        if tx_index == None || transaction == None {
+        if tx_index.is_none() || transaction.is_none() {
             error!(
                 "Failed to find transaction hash in block. Substrate block hash: {substrate_block_hash}, transaction \
                  hash: {transaction_hash}"

--- a/crates/pallets/starknet/runtime_api/src/lib.rs
+++ b/crates/pallets/starknet/runtime_api/src/lib.rs
@@ -76,7 +76,7 @@ sp_api::decl_runtime_apis! {
         /// Return the list of StarknetEvent evmitted during this block, along with the hash of the starknet transaction they bellong to
         ///
         /// `block_extrinsics` is the list of all the extrinsic executed during this block, it is used in order to match
-        fn get_starknet_events_and_their_associated_tx_hash(block_extrinsics: Vec<<Block as BlockT>::Extrinsic>, chain_id: Felt252Wrapper) -> Vec<(Felt252Wrapper, StarknetEvent)>;
+        fn get_starknet_events_and_their_associated_tx_index() -> Vec<(u32, StarknetEvent)>;
         /// Return the outcome of the tx execution
         fn get_tx_execution_outcome(tx_hash: TransactionHash) -> Option<Vec<u8>>;
         /// Return the block context

--- a/crates/pallets/starknet/runtime_api/src/lib.rs
+++ b/crates/pallets/starknet/runtime_api/src/lib.rs
@@ -69,8 +69,7 @@ sp_api::decl_runtime_apis! {
         /// the runtime itself, accomplished through the extrinsic_filter method. This enables the
         /// client to operate seamlessly while abstracting the extrinsic complexity.
         fn extrinsic_filter(xts: Vec<<Block as BlockT>::Extrinsic>) -> Vec<Transaction>;
-        fn get_index_and_tx_for_tx_hash(xts: Vec<<Block as BlockT>::Extrinsic>, chain_id: Felt252Wrapper, tx_hash: Felt252Wrapper) -> Option<(u32, Transaction)>;
-        /// Returns events, call with index from get_index_and_tx_for_tx_hash method
+        /// Returns events, call with extrinsic index
         fn get_events_for_tx_by_index(tx_index: u32) -> Option<Vec<StarknetEvent>>;
 
         /// Return the list of StarknetEvent evmitted during this block, along with the hash of the starknet transaction they bellong to


### PR DESCRIPTION
Modifies code to use the cache for `getEvents` and `getTransactionReceipt` for reading txn_hashes if `cache` flag is enabled.