### PR TITLE
fix: update outdated links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix: updating outdated links to external resources in documentation
 - feat(client/data-availability): implement custom error handling
 - fix: get_block_by_block_hash then default rather than error
 - feat(rpc): added `get_state_update` real values from DA db

--- a/docs/genesis.md
+++ b/docs/genesis.md
@@ -1,7 +1,7 @@
 # Genesis
 
 The genesis of the chain can be found in the [configs]
-(<https://github.com/keep-starknet-strange/madara/tree/main/configs/genesis_assets>)
+(<https://github.com/keep-starknet-strange/madara/tree/main/configs/genesis-assets>)
 folder. The genesis is defined in the form of a JSON file containing the
 following:
 
@@ -17,11 +17,11 @@ following:
 - storage: list of tuples containing the storage key and the storage value.
   Please note that the storage key is itself a tuple, containing the contract
   address for which storage is set and the
-  [Starknet storage key](https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-storage/#storage_variables).
+  [Starknet storage key](https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/contract-storage/#storage_variables).
 
 The below defines all hardcoded values set in the geneses:
 
-## Node genesis [link](https://github.com/keep-starknet-strange/madara/tree/main/crates/node/src/genesis_assets/genesis.json)
+## Node genesis [link](https://github.com/keep-starknet-strange/madara/tree/main/configs/genesis-assets/genesis.json)
 
 ### Contract classes node genesis
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -25,7 +25,7 @@ Madara node exposes a number of capabilities:
   the state of the network. Substrate makes it possible to supply custom
   consensus engines and also ships with several consensus mechanisms that have
   been built on top of
-  [Web3 Foundation research](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html).
+  [Web3 Foundation research](https://research.web3.foundation/Polkadot/protocols/NPoS).
 - RPC Server: A remote procedure call (RPC) server is used to interact with
   Substrate nodes.
 


### PR DESCRIPTION
# Pull Request type

- Documentation content changes

## What is the current behavior?

I've found that some of links in the documentation are outdated. The linked resource are not approachable. 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
- Working links to the original resources.
## Does this introduce a breaking change?
No.
## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
