### PR TITLE
feat: move StarkEvents to storage 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - feat: add transparent representation to `Felt252Wrapper`
 - feat(rpc/trace_api): add `trace_block_transaction`
 - chore(db): changed the way hashes are encoded
+- feat(runtime): moved StarkEvents from Substrate events to runtime storage
 
 ## v0.7.0
 

--- a/crates/client/rpc/src/events/mod.rs
+++ b/crates/client/rpc/src/events/mod.rs
@@ -16,8 +16,10 @@ use sc_transaction_pool::ChainApi;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::Block as BlockT;
+use starknet_api::transaction::TransactionHash;
 use starknet_core::types::{BlockId, EmittedEvent, EventsPage};
 use starknet_ff::FieldElement;
+use mp_transactions::compute_hash::ComputeTransactionHash;
 
 use crate::errors::StarknetRpcApiError;
 use crate::types::{ContinuationToken, RpcEventFilter};
@@ -49,69 +51,70 @@ where
                 StarknetRpcApiError::BlockNotFound
             })?;
 
-        let block_extrinsics = self
-            .client
-            .block_body(substrate_block_hash)
-            .map_err(|e| {
-                error!("Failed to retrieve block body. Substrate block hash: {substrate_block_hash}, error: {e}");
-                StarknetRpcApiError::InternalServerError
-            })?
-            .ok_or(StarknetRpcApiError::BlockNotFound)?;
-
         let chain_id = self.client.runtime_api().chain_id(substrate_block_hash).map_err(|_| {
             error!("Failed to retrieve chain id");
             StarknetRpcApiError::InternalServerError
         })?;
 
-        let index_and_events =
-            self.client.runtime_api().get_starknet_events_and_their_associated_tx_index(substrate_block_hash).map_err(
-                |e| {
-                    error!(
-                        "Failed to retrieve starknet events and their associated transaction index. Substrate block \
-                         hash: {substrate_block_hash}, chain ID: {chain_id:?}, error: {e}"
-                    );
-                    StarknetRpcApiError::InternalServerError
-                },
-            )?;
-
         let starknet_block = get_block_by_block_hash(self.client.as_ref(), substrate_block_hash).map_err(|e| {
             error!("Failed to retrieve starknet block from substrate block hash: error: {e}");
             StarknetRpcApiError::InternalServerError
         })?;
-        let txn_hashes = self.get_cached_transaction_hashes(starknet_block.header().hash::<H>().into());
-        let block_extrinsics_len = block_extrinsics.len();
-        let starknet_txs =
-            self.client.runtime_api().extrinsic_filter(substrate_block_hash, block_extrinsics).map_err(|e| {
-                error!("Failed to filter extrinsics. Substrate block hash: {substrate_block_hash}, error: {e}");
-                StarknetRpcApiError::InternalServerError
-            })?;
-        let inherent_count = block_extrinsics_len - starknet_txs.len();
-        let mut tx_hash_and_events: Vec<(Felt252Wrapper, starknet_api::transaction::Event)> = vec![];
-        for (index, event) in index_and_events {
-            let tx_index = index as usize - inherent_count;
-            let tx_hash = self.try_txn_hash_from_cache(tx_index, &txn_hashes, &starknet_txs, chain_id)?;
-            tx_hash_and_events.push((tx_hash, event));
-        }
-
-        let starknet_block = match get_block_by_block_hash(self.client.as_ref(), substrate_block_hash) {
-            Ok(block) => block,
-            Err(_) => return Err(StarknetRpcApiError::BlockNotFound),
-        };
+        let txn_hashes =
+            if let Some(tx_hashes) = self.get_cached_transaction_hashes(starknet_block.header().hash::<H>().into()) {
+                tx_hashes
+            } else {
+                starknet_block
+                    .transactions()
+                    .iter()
+                    .map(|tx| tx.compute_hash::<H>(chain_id, false).into())
+                    .collect()
+            };
+        let runtime_api = self.client.runtime_api();
 
         let block_hash = starknet_block.header().hash::<H>();
 
-        let emitted_events = tx_hash_and_events
-            .into_iter()
-            .map(|(tx_hash, event)| EmittedEvent {
-                from_address: Felt252Wrapper::from(event.from_address).0,
-                keys: event.content.keys.into_iter().map(|felt| Felt252Wrapper::from(felt).0).collect(),
-                data: event.content.data.0.into_iter().map(|felt| Felt252Wrapper::from(felt).0).collect(),
-                block_hash: block_hash.0,
-                block_number,
-                transaction_hash: tx_hash.0,
-            })
-            .collect();
+        let mut emitted_events: Vec<EmittedEvent> = vec![];
+        for tx_hash in txn_hashes {
+            let _ = runtime_api.get_events_for_tx_by_hash(substrate_block_hash, TransactionHash(tx_hash))
+                .map_err(|e| {
+                    error!("Failed to retrieve starknet events for transaction: error: {e}");
+                    StarknetRpcApiError::InternalServerError
+                })?
+                .into_iter()
+                .map(|event| EmittedEvent {
+                    from_address: Felt252Wrapper::from(event.from_address).0,
+                    keys: event.content.keys.into_iter().map(|felt| Felt252Wrapper::from(felt).0).collect(),
+                    data: event.content.data.0.into_iter().map(|felt| Felt252Wrapper::from(felt).0).collect(),
+                    block_hash: block_hash.0,
+                    block_number,
+                    transaction_hash: tx_hash.into(), // todo into
+                })
+                .map(|event| emitted_events.push(event))
+                .collect::<Vec<_>>();
+        }; //.into_iter().flatten().collect();
 
+        // let emitted_events = txn_hashes
+        //     .into_iter()
+        //     .flat_map(|tx_hash|
+        //         runtime_api.get_events_for_tx_by_hash(substrate_block_hash, TransactionHash(tx_hash))
+        //             .map_err(|e| {
+        //                 error!("Failed to retrieve starknet events for transaction: error: {e}");
+        //                 StarknetRpcApiError::InternalServerError
+        //             })?
+        //             .into_iter()
+        //             .map(|event| EmittedEvent {
+        //                 from_address: Felt252Wrapper::from(event.from_address).0,
+        //                 keys: event.content.keys.into_iter().map(|felt| Felt252Wrapper::from(felt).0).collect(),
+        //                 data: event.content.data.0.into_iter().map(|felt| Felt252Wrapper::from(felt).0).collect(),
+        //                 block_hash: block_hash.0,
+        //                 block_number,
+        //                 transaction_hash: tx_hash.into(), // into
+        //             })
+        //             .collect::<Vec<_>>()
+        //     )
+        //     .collect();
+        //
         Ok(emitted_events)
     }
 

--- a/crates/client/rpc/src/events/mod.rs
+++ b/crates/client/rpc/src/events/mod.rs
@@ -92,29 +92,8 @@ where
                 })
                 .map(|event| emitted_events.push(event))
                 .collect::<Vec<_>>();
-        }; //.into_iter().flatten().collect();
+        };
 
-        // let emitted_events = txn_hashes
-        //     .into_iter()
-        //     .flat_map(|tx_hash|
-        //         runtime_api.get_events_for_tx_by_hash(substrate_block_hash, TransactionHash(tx_hash))
-        //             .map_err(|e| {
-        //                 error!("Failed to retrieve starknet events for transaction: error: {e}");
-        //                 StarknetRpcApiError::InternalServerError
-        //             })?
-        //             .into_iter()
-        //             .map(|event| EmittedEvent {
-        //                 from_address: Felt252Wrapper::from(event.from_address).0,
-        //                 keys: event.content.keys.into_iter().map(|felt| Felt252Wrapper::from(felt).0).collect(),
-        //                 data: event.content.data.0.into_iter().map(|felt| Felt252Wrapper::from(felt).0).collect(),
-        //                 block_hash: block_hash.0,
-        //                 block_number,
-        //                 transaction_hash: tx_hash.into(), // into
-        //             })
-        //             .collect::<Vec<_>>()
-        //     )
-        //     .collect();
-        //
         Ok(emitted_events)
     }
 

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -1498,9 +1498,9 @@ where
             .get_events_for_tx_by_hash(substrate_block_hash, Felt252Wrapper(transaction_hash).into())
             .map_err(|e| {
                 error!(
-                        "Failed to get transaction events. Substrate block hash: {substrate_block_hash}, \
-                         transaction hash: {transaction_hash}, error: {e}"
-                    );
+                    "Failed to get transaction events. Substrate block hash: {substrate_block_hash}, transaction \
+                     hash: {transaction_hash}, error: {e}"
+                );
                 StarknetRpcApiError::InternalServerError
             })?;
 

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -1543,7 +1543,6 @@ where
 
         let fee_disabled = self.is_transaction_fee_disabled(substrate_block_hash)?;
 
-        let block_extrinsics_len = block_extrinsics.len();
         let transactions = self.filter_extrinsics(substrate_block_hash, block_extrinsics)?;
         let txn_hashes = self.get_cached_transaction_hashes(starknet_block.header().hash::<H>().into());
         let mut transaction = None;
@@ -1671,9 +1670,7 @@ where
         substrate_block_hash: B::Hash,
         tx_hash: TransactionHash,
     ) -> Result<Vec<starknet_api::transaction::Event>, StarknetRpcApiError> {
-        let events = self
-            .do_get_events_for_tx_by_hash(substrate_block_hash, tx_hash)?
-            .expect("the transaction should be present in the substrate extrinsics"); // not reachable
+        let events = self.do_get_events_for_tx_by_hash(substrate_block_hash, tx_hash)?;
         Ok(events)
     }
 

--- a/crates/client/storage/src/overrides/mod.rs
+++ b/crates/client/storage/src/overrides/mod.rs
@@ -13,6 +13,8 @@ use sp_runtime::traits::Block as BlockT;
 use starknet_api::api_core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
+use starknet_api::transaction::{TransactionHash, Event as StarknetEvent};
+
 
 mod schema_v1_override;
 
@@ -75,6 +77,8 @@ pub trait StorageOverride<B: BlockT>: Send + Sync {
     ) -> Option<ContractClass>;
     /// Returns the nonce for a provided contract address and block hash.
     fn nonce(&self, block_hash: B::Hash, address: ContractAddress) -> Option<Nonce>;
+
+    fn get_events_for_tx_by_hash(&self, block_hash: <B as BlockT>::Hash, tx_hash: TransactionHash) -> Option<Vec<StarknetEvent>>;
 }
 
 /// Returns the storage prefix given the pallet module name and the storage name
@@ -179,5 +183,9 @@ where
     /// * `Some(nonce)` - The nonce for the provided contract address and block hash
     fn nonce(&self, block_hash: <B as BlockT>::Hash, contract_address: ContractAddress) -> Option<Nonce> {
         self.client.runtime_api().nonce(block_hash, contract_address).ok()
+    }
+
+    fn get_events_for_tx_by_hash(&self, block_hash: <B as BlockT>::Hash, tx_hash: TransactionHash) -> Option<Vec<StarknetEvent>> {
+        self.client.runtime_api().get_events_for_tx_by_hash(block_hash, tx_hash).ok()
     }
 }

--- a/crates/client/storage/src/overrides/mod.rs
+++ b/crates/client/storage/src/overrides/mod.rs
@@ -13,8 +13,7 @@ use sp_runtime::traits::Block as BlockT;
 use starknet_api::api_core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
-use starknet_api::transaction::{TransactionHash, Event as StarknetEvent};
-
+use starknet_api::transaction::{Event as StarknetEvent, TransactionHash};
 
 mod schema_v1_override;
 
@@ -78,7 +77,11 @@ pub trait StorageOverride<B: BlockT>: Send + Sync {
     /// Returns the nonce for a provided contract address and block hash.
     fn nonce(&self, block_hash: B::Hash, address: ContractAddress) -> Option<Nonce>;
 
-    fn get_events_for_tx_by_hash(&self, block_hash: <B as BlockT>::Hash, tx_hash: TransactionHash) -> Option<Vec<StarknetEvent>>;
+    fn get_events_for_tx_by_hash(
+        &self,
+        block_hash: <B as BlockT>::Hash,
+        tx_hash: TransactionHash,
+    ) -> Option<Vec<StarknetEvent>>;
 }
 
 /// Returns the storage prefix given the pallet module name and the storage name
@@ -185,7 +188,11 @@ where
         self.client.runtime_api().nonce(block_hash, contract_address).ok()
     }
 
-    fn get_events_for_tx_by_hash(&self, block_hash: <B as BlockT>::Hash, tx_hash: TransactionHash) -> Option<Vec<StarknetEvent>> {
+    fn get_events_for_tx_by_hash(
+        &self,
+        block_hash: <B as BlockT>::Hash,
+        tx_hash: TransactionHash,
+    ) -> Option<Vec<StarknetEvent>> {
         self.client.runtime_api().get_events_for_tx_by_hash(block_hash, tx_hash).ok()
     }
 }

--- a/crates/client/storage/src/overrides/schema_v1_override.rs
+++ b/crates/client/storage/src/overrides/schema_v1_override.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use blockifier::execution::contract_class::ContractClass;
 use mp_storage::{
-    PALLET_STARKNET, STARKNET_CONTRACT_CLASS, STARKNET_CONTRACT_CLASS_HASH, STARKNET_NONCE, STARKNET_STORAGE,
+    PALLET_STARKNET, STARKNET_CONTRACT_CLASS, STARKNET_CONTRACT_CLASS_HASH, STARKNET_NONCE, STARKNET_STORAGE, STARKNET_TX_EVENTS
 };
 use parity_scale_codec::{Decode, Encode};
 // Substrate
@@ -132,6 +132,11 @@ where
         }
     }
 
-    fn get_events_for_tx_by_hash(&self, block_hash: <B as BlockT>::Hash, tx_hash: TransactionHash) -> Option<Vec<StarknetEvent>> {}
+    fn get_events_for_tx_by_hash(&self, block_hash: <B as BlockT>::Hash, tx_hash: TransactionHash) -> Option<Vec<StarknetEvent>> {
+        let storage_tx_events_prefix = storage_prefix_build(PALLET_STARKNET, STARKNET_TX_EVENTS);
+        self.query_storage::<Vec<StarknetEvent>>(
+            block_hash,
+            &StorageKey(storage_key_build(storage_tx_events_prefix, &self.encode_storage_key(&tx_hash))),
+        )
     }
 }

--- a/crates/client/storage/src/overrides/schema_v1_override.rs
+++ b/crates/client/storage/src/overrides/schema_v1_override.rs
@@ -14,6 +14,7 @@ use sp_storage::StorageKey;
 use starknet_api::api_core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey as StarknetStorageKey;
+use starknet_api::transaction::{TransactionHash, Event as StarknetEvent};
 
 use super::{storage_key_build, storage_prefix_build, StorageOverride};
 
@@ -129,5 +130,8 @@ where
             Some(nonce) => Some(nonce),
             None => Some(Nonce::default()),
         }
+    }
+
+    fn get_events_for_tx_by_hash(&self, block_hash: <B as BlockT>::Hash, tx_hash: TransactionHash) -> Option<Vec<StarknetEvent>> {}
     }
 }

--- a/crates/client/storage/src/overrides/schema_v1_override.rs
+++ b/crates/client/storage/src/overrides/schema_v1_override.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 
 use blockifier::execution::contract_class::ContractClass;
 use mp_storage::{
-    PALLET_STARKNET, STARKNET_CONTRACT_CLASS, STARKNET_CONTRACT_CLASS_HASH, STARKNET_NONCE, STARKNET_STORAGE, STARKNET_TX_EVENTS
+    PALLET_STARKNET, STARKNET_CONTRACT_CLASS, STARKNET_CONTRACT_CLASS_HASH, STARKNET_NONCE, STARKNET_STORAGE,
+    STARKNET_TX_EVENTS,
 };
 use parity_scale_codec::{Decode, Encode};
 // Substrate
@@ -14,7 +15,7 @@ use sp_storage::StorageKey;
 use starknet_api::api_core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey as StarknetStorageKey;
-use starknet_api::transaction::{TransactionHash, Event as StarknetEvent};
+use starknet_api::transaction::{Event as StarknetEvent, TransactionHash};
 
 use super::{storage_key_build, storage_prefix_build, StorageOverride};
 
@@ -132,7 +133,11 @@ where
         }
     }
 
-    fn get_events_for_tx_by_hash(&self, block_hash: <B as BlockT>::Hash, tx_hash: TransactionHash) -> Option<Vec<StarknetEvent>> {
+    fn get_events_for_tx_by_hash(
+        &self,
+        block_hash: <B as BlockT>::Hash,
+        tx_hash: TransactionHash,
+    ) -> Option<Vec<StarknetEvent>> {
         let storage_tx_events_prefix = storage_prefix_build(PALLET_STARKNET, STARKNET_TX_EVENTS);
         self.query_storage::<Vec<StarknetEvent>>(
             block_hash,

--- a/crates/pallets/starknet/runtime_api/src/lib.rs
+++ b/crates/pallets/starknet/runtime_api/src/lib.rs
@@ -72,13 +72,8 @@ sp_api::decl_runtime_apis! {
         fn re_execute_transactions(transactions: Vec<UserOrL1HandlerTransaction>) -> Result<Result<Vec<TransactionExecutionInfo>, PlaceHolderErrorTypeForFailedStarknetExecution>, DispatchError>;
 
         fn get_index_and_tx_for_tx_hash(xts: Vec<<Block as BlockT>::Extrinsic>, chain_id: Felt252Wrapper, tx_hash: Felt252Wrapper) -> Option<(u32, Transaction)>;
-        /// Returns events, call with index from get_index_and_tx_for_tx_hash method
-        fn get_events_for_tx_by_index(tx_index: u32) -> Option<Vec<StarknetEvent>>;
 
-        /// Return the list of StarknetEvent evmitted during this block, along with the hash of the starknet transaction they bellong to
-        ///
-        /// `block_extrinsics` is the list of all the extrinsic executed during this block, it is used in order to match
-        fn get_starknet_events_and_their_associated_tx_index() -> Vec<(u32, StarknetEvent)>;
+        fn get_events_for_tx_by_hash(tx_hash: TransactionHash) -> Vec<StarknetEvent>;
         /// Return the outcome of the tx execution
         fn get_tx_execution_outcome(tx_hash: TransactionHash) -> Option<Vec<u8>>;
         /// Return the block context

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -986,7 +986,7 @@ impl<T: Config> Pallet<T> {
         BlockHash::<T>::insert(block_number, blockhash);
 
         // Kill pending storage.
-        // There is no need to kill `TxEvents` as we use them.
+        // There is no need to kill `TxEvents` as we store them.
         Pending::<T>::kill();
         PendingHashes::<T>::kill();
 

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -4,7 +4,7 @@
 //! The code consists of the following sections:
 //! 1. Config: The trait Config is defined, which is used to configure the pallet by specifying the
 //! parameters and types on which it depends. The trait also includes associated types for
-//! RuntimeEvent, StateRoot, SystemHash, and TimestampProvider.
+//! StateRoot, SystemHash, and TimestampProvider.
 //!
 //! 2. Hooks: The Hooks trait is implemented for the pallet, which includes methods to be executed
 //! during the block lifecycle: on_finalize, on_initialize, on_runtime_upgrade, and offchain_worker.
@@ -131,8 +131,6 @@ pub mod pallet {
     /// mechanism and comply with starknet which uses an ER20 as fee token
     #[pallet::config]
     pub trait Config: frame_system::Config {
-        /// Because this pallet emits events, it depends on the runtime's definition of an event.
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
         /// The hashing function to use.
         type SystemHash: HasherT;
         /// The block time

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -886,10 +886,7 @@ impl<T: Config> Pallet<T> {
     /// Get the number of events in the block.
     #[inline(always)]
     pub fn event_count() -> u128 {
-        Self::pending_hashes()
-            .iter()
-            .map(|tx_hash| TxEvents::<T>::get(tx_hash).len() as u128)
-            .sum()
+        Self::pending_hashes().iter().map(|tx_hash| TxEvents::<T>::get(tx_hash).len() as u128).sum()
     }
 
     /// Call a smart contract function.
@@ -960,10 +957,7 @@ impl<T: Config> Pallet<T> {
         let transaction_count = transactions.len();
 
         let parent_block_hash = Self::parent_block_hash(&block_number);
-        let events_count = transaction_hashes
-            .iter()
-            .map(|tx_hash| TxEvents::<T>::get(tx_hash).len() as u128)
-            .sum();
+        let events_count = transaction_hashes.iter().map(|tx_hash| TxEvents::<T>::get(tx_hash).len() as u128).sum();
 
         let sequencer_address = Self::sequencer_address();
         let block_timestamp = Self::block_timestamp();

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -405,22 +405,6 @@ pub mod pallet {
         }
     }
 
-    /// The Starknet pallet events.
-    /// EVENTS
-    /// See: `<https://docs.substrate.io/main-docs/build/events-errors/>`
-    #[pallet::event]
-    // #[pallet::generate_deposit(pub(super) fn deposit_event)]
-    pub enum Event<T: Config> {
-        KeepStarknetStrange,
-        /// Emitted when fee token address is changed.
-        /// This is emitted by the `set_fee_token_address` extrinsic.
-        /// [old_fee_token_address, new_fee_token_address]
-        FeeTokenAddressChanged {
-            old_fee_token_address: ContractAddress,
-            new_fee_token_address: ContractAddress,
-        },
-    }
-
     /// The Starknet pallet custom errors.
     /// ERRORS
     #[pallet::error]
@@ -986,7 +970,6 @@ impl<T: Config> Pallet<T> {
         BlockHash::<T>::insert(block_number, blockhash);
 
         // Kill pending storage.
-        // There is no need to kill `TxEvents` as we store them.
         Pending::<T>::kill();
         PendingHashes::<T>::kill();
 

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -409,7 +409,7 @@ pub mod pallet {
     /// EVENTS
     /// See: `<https://docs.substrate.io/main-docs/build/events-errors/>`
     #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    // #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
         KeepStarknetStrange,
         /// Emitted when fee token address is changed.

--- a/crates/pallets/starknet/src/tests/deploy_account_tx.rs
+++ b/crates/pallets/starknet/src/tests/deploy_account_tx.rs
@@ -53,7 +53,7 @@ fn given_contract_run_deploy_account_tx_works() {
                     Felt252Wrapper::from(get_selector_from_name(mp_fee::TRANSFER_SELECTOR_NAME).unwrap()).into(),
                 )],
                 data: EventData(vec![
-                    address.0.0,                                 // From
+                    address.0.0,                            // From
                     StarkFelt::try_from("0xdead").unwrap(), // To
                     StarkFelt::try_from("0x195a").unwrap(), // Amount low
                     StarkFelt::from(0u128),                 // Amount high

--- a/crates/pallets/starknet/src/tests/deploy_account_tx.rs
+++ b/crates/pallets/starknet/src/tests/deploy_account_tx.rs
@@ -6,7 +6,7 @@ use sp_runtime::traits::ValidateUnsigned;
 use sp_runtime::transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidityError};
 use starknet_api::api_core::{ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
-use starknet_api::transaction::{Event as StarknetEvent, EventContent, EventData, EventKey};
+use starknet_api::transaction::{Event as StarknetEvent, EventContent, EventData, EventKey, TransactionHash};
 use starknet_core::utils::get_selector_from_name;
 use starknet_crypto::FieldElement;
 
@@ -15,7 +15,7 @@ use super::mock::*;
 use super::utils::{sign_message_hash, sign_message_hash_braavos};
 use crate::tests::constants::{ACCOUNT_PUBLIC_KEY, SALT};
 use crate::tests::{get_deploy_account_dummy, set_infinite_tokens, set_nonce};
-use crate::{Config, Error, Event, StorageView};
+use crate::{Config, Error, StorageView};
 
 #[test]
 fn given_contract_run_deploy_account_tx_works() {
@@ -41,25 +41,29 @@ fn given_contract_run_deploy_account_tx_works() {
         let address = deploy_tx.account_address().into();
         set_infinite_tokens::<MockRuntime>(&address);
 
+        let chain_id = Starknet::chain_id();
+        let tx_hash = deploy_tx.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
+
         assert_ok!(Starknet::deploy_account(none_origin, deploy_tx));
         assert_eq!(Starknet::contract_class_hash_by_address(address), account_class_hash);
 
-        let expected_fee_transfer_event = Event::StarknetEvent(StarknetEvent {
+        let expected_fee_transfer_event = StarknetEvent {
             content: EventContent {
                 keys: vec![EventKey(
                     Felt252Wrapper::from(get_selector_from_name(mp_fee::TRANSFER_SELECTOR_NAME).unwrap()).into(),
                 )],
                 data: EventData(vec![
-                    address.0.0,                            // From
+                    address.0.0,                                 // From
                     StarkFelt::try_from("0xdead").unwrap(), // To
                     StarkFelt::try_from("0x195a").unwrap(), // Amount low
                     StarkFelt::from(0u128),                 // Amount high
                 ]),
             },
             from_address: Starknet::fee_token_address(),
-        })
-        .into();
-        System::assert_last_event(expected_fee_transfer_event)
+        };
+
+        let events = Starknet::tx_events(TransactionHash::from(tx_hash));
+        assert_eq!(expected_fee_transfer_event, events.last().unwrap().clone());
     });
 }
 
@@ -212,7 +216,7 @@ fn given_contract_run_deploy_account_argent_tx_works() {
 
         let chain_id = Starknet::chain_id();
         let tx_hash = deploy_tx.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
-        deploy_tx.signature = sign_message_hash(tx_hash);
+        deploy_tx.signature = sign_message_hash(tx_hash.into());
 
         let address = deploy_tx.account_address().into();
         set_infinite_tokens::<MockRuntime>(&address);

--- a/crates/pallets/starknet/src/tests/deploy_account_tx.rs
+++ b/crates/pallets/starknet/src/tests/deploy_account_tx.rs
@@ -216,7 +216,7 @@ fn given_contract_run_deploy_account_argent_tx_works() {
 
         let chain_id = Starknet::chain_id();
         let tx_hash = deploy_tx.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
-        deploy_tx.signature = sign_message_hash(tx_hash.into());
+        deploy_tx.signature = sign_message_hash(tx_hash);
 
         let address = deploy_tx.account_address().into();
         set_infinite_tokens::<MockRuntime>(&address);

--- a/crates/pallets/starknet/src/tests/erc20.rs
+++ b/crates/pallets/starknet/src/tests/erc20.rs
@@ -197,7 +197,7 @@ fn given_erc20_transfer_when_invoke_then_it_works() {
             )),
         };
 
-        pretty_assertions::assert_eq!(expected_event, events[events.len() - 2]); //.event.clone().try_into().unwrap()
+        pretty_assertions::assert_eq!(expected_event, events[events.len() - 2]);
         // Check fee transfer.
         let expected_fee_transfer_event = StarknetEvent {
             content: EventContent {
@@ -205,7 +205,7 @@ fn given_erc20_transfer_when_invoke_then_it_works() {
                     StarkFelt::try_from(Felt252Wrapper::from(get_selector_from_name(mp_fee::TRANSFER_SELECTOR_NAME).unwrap())).unwrap(),
                 )],
                 data: EventData(vec![
-                    sender_account.0 .0,                         // From
+                    sender_account.0 .0,                    // From
                     StarkFelt::try_from("0xdead").unwrap(), // Sequencer address
                     StarkFelt::try_from("0xf118").unwrap(), // Amount low
                     StarkFelt::from(0u128),                 // Amount high

--- a/crates/pallets/starknet/src/tests/erc20.rs
+++ b/crates/pallets/starknet/src/tests/erc20.rs
@@ -2,13 +2,13 @@ use blockifier::execution::contract_class::ContractClass;
 use frame_support::assert_ok;
 use lazy_static::lazy_static;
 use mp_felt::Felt252Wrapper;
+use mp_transactions::compute_hash::ComputeTransactionHash;
 use mp_transactions::InvokeTransactionV1;
 use starknet_api::api_core::{ContractAddress, PatriciaKey};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
 use starknet_api::transaction::{Event as StarknetEvent, EventContent, EventData, EventKey, TransactionHash};
 use starknet_core::utils::get_selector_from_name;
-use mp_transactions::compute_hash::ComputeTransactionHash;
 
 use super::mock::default_mock::*;
 use super::mock::*;

--- a/crates/pallets/starknet/src/tests/erc20.rs
+++ b/crates/pallets/starknet/src/tests/erc20.rs
@@ -6,15 +6,16 @@ use mp_transactions::InvokeTransactionV1;
 use starknet_api::api_core::{ContractAddress, PatriciaKey};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
-use starknet_api::transaction::{Event as StarknetEvent, EventContent, EventData, EventKey};
+use starknet_api::transaction::{Event as StarknetEvent, EventContent, EventData, EventKey, TransactionHash};
 use starknet_core::utils::get_selector_from_name;
+use mp_transactions::compute_hash::ComputeTransactionHash;
 
 use super::mock::default_mock::*;
 use super::mock::*;
 use crate::tests::constants::TOKEN_CONTRACT_CLASS_HASH;
 use crate::tests::utils::{build_transfer_invoke_transaction, get_contract_class};
 use crate::types::BuildTransferInvokeTransaction;
-use crate::Event;
+use crate::Config;
 
 lazy_static! {
     static ref ERC20_CONTRACT_CLASS: ContractClass = get_contract_class("ERC20.json", 0);
@@ -55,8 +56,12 @@ fn given_erc20_transfer_when_invoke_then_it_works() {
         let expected_erc20_address =
             StarkFelt::try_from("0x00dc58c1280862c95964106ef9eba5d9ed8c0c16d05883093e4540f22b829dff").unwrap();
 
+        let chain_id = Starknet::chain_id();
+        let tx_hash = deploy_transaction.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
+
         assert_ok!(Starknet::invoke(origin.clone(), deploy_transaction.into()));
-        let events = System::events();
+
+        let events: Vec<StarknetEvent> = Starknet::tx_events(TransactionHash::from(tx_hash));
         // Expected events:
         // ERC20 -> Transfer
         // NoValidateAccount -> ContractDeployed
@@ -64,7 +69,7 @@ fn given_erc20_transfer_when_invoke_then_it_works() {
 
         // Check transaction event (deployment)
         pretty_assertions::assert_eq!(
-            Event::<MockRuntime>::StarknetEvent(StarknetEvent {
+            StarknetEvent {
                 content: EventContent {
                     keys: vec![EventKey(
                         StarkFelt::try_from("0x026b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d")
@@ -94,10 +99,10 @@ fn given_erc20_transfer_when_invoke_then_it_works() {
                     ]),
                 },
                 from_address: sender_account,
-            }),
-            events[1].event.clone().try_into().unwrap(),
+            },
+            events[1].clone().try_into().unwrap(),
         );
-        let expected_fee_transfer_event = Event::StarknetEvent(StarknetEvent {
+        let expected_fee_transfer_event = StarknetEvent {
             content: EventContent {
                 keys: vec![EventKey(
                     Felt252Wrapper::from(get_selector_from_name(mp_fee::TRANSFER_SELECTOR_NAME).unwrap()).into(),
@@ -110,11 +115,11 @@ fn given_erc20_transfer_when_invoke_then_it_works() {
                 ]),
             },
             from_address: Starknet::fee_token_address(),
-        });
+        };
         // Check fee transfer event
         pretty_assertions::assert_eq!(
             expected_fee_transfer_event,
-            events.last().unwrap().event.clone().try_into().unwrap()
+            events.last().unwrap().clone()
         );
         // TODO: use dynamic values to craft invoke transaction
         // Transfer some token
@@ -126,6 +131,9 @@ fn given_erc20_transfer_when_invoke_then_it_works() {
             amount_high: Felt252Wrapper::ZERO,
             nonce: Felt252Wrapper::ONE,
         });
+
+        let chain_id = Starknet::chain_id();
+        let tx_hash = transfer_transaction.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
 
         // Also asserts that the deployment has been saved.
         assert_ok!(Starknet::invoke(origin, transfer_transaction));
@@ -166,13 +174,13 @@ fn given_erc20_transfer_when_invoke_then_it_works() {
             StarkFelt::from(0u128)
         );
 
-        let events = System::events();
+        let events: Vec<StarknetEvent> = Starknet::tx_events(TransactionHash::from(tx_hash));
         // Expected events: (added on top of the past ones)
         // ERC20 -> Transfer
         // FeeToken -> Transfer
 
         // Check regular event.
-        let expected_event = Event::StarknetEvent(StarknetEvent {
+        let expected_event = StarknetEvent {
             content: EventContent {
                 keys: vec![EventKey(
                     StarkFelt::try_from(Felt252Wrapper::from(get_selector_from_name(mp_fee::TRANSFER_SELECTOR_NAME).unwrap())).unwrap(),
@@ -187,27 +195,27 @@ fn given_erc20_transfer_when_invoke_then_it_works() {
             from_address: ContractAddress(PatriciaKey(
                 StarkFelt::try_from("0x00dc58c1280862c95964106ef9eba5d9ed8c0c16d05883093e4540f22b829dff").unwrap(),
             )),
-        });
+        };
 
-        pretty_assertions::assert_eq!(expected_event, events[events.len() - 2].event.clone().try_into().unwrap());
+        pretty_assertions::assert_eq!(expected_event, events[events.len() - 2]); //.event.clone().try_into().unwrap()
         // Check fee transfer.
-        let expected_fee_transfer_event = Event::StarknetEvent(StarknetEvent {
+        let expected_fee_transfer_event = StarknetEvent {
             content: EventContent {
                 keys: vec![EventKey(
                     StarkFelt::try_from(Felt252Wrapper::from(get_selector_from_name(mp_fee::TRANSFER_SELECTOR_NAME).unwrap())).unwrap(),
                 )],
                 data: EventData(vec![
-                    sender_account.0 .0,                    // From
+                    sender_account.0 .0,                         // From
                     StarkFelt::try_from("0xdead").unwrap(), // Sequencer address
                     StarkFelt::try_from("0xf118").unwrap(), // Amount low
                     StarkFelt::from(0u128),                 // Amount high
                 ]),
             },
             from_address: Starknet::fee_token_address(),
-        });
+        };
         pretty_assertions::assert_eq!(
             expected_fee_transfer_event,
-            events.last().unwrap().event.clone().try_into().unwrap()
+            events.last().unwrap().clone()
         );
     })
 }

--- a/crates/pallets/starknet/src/tests/erc20.rs
+++ b/crates/pallets/starknet/src/tests/erc20.rs
@@ -100,7 +100,7 @@ fn given_erc20_transfer_when_invoke_then_it_works() {
                 },
                 from_address: sender_account,
             },
-            events[1].clone().try_into().unwrap(),
+            events[1],
         );
         let expected_fee_transfer_event = StarknetEvent {
             content: EventContent {

--- a/crates/pallets/starknet/src/tests/events.rs
+++ b/crates/pallets/starknet/src/tests/events.rs
@@ -43,7 +43,6 @@ fn internal_and_external_events_are_emitted_in_the_right_order() {
 
         let chain_id = Starknet::chain_id();
         let tx_hash = emit_event_transaction.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
-        // todo
         let events = Starknet::tx_events(TransactionHash::from(tx_hash));
         let event_emitters: Vec<Felt252Wrapper> =
             events.iter().map(|event| Felt252Wrapper::from(event.from_address)).collect();

--- a/crates/pallets/starknet/src/tests/events.rs
+++ b/crates/pallets/starknet/src/tests/events.rs
@@ -43,6 +43,7 @@ fn internal_and_external_events_are_emitted_in_the_right_order() {
 
         let chain_id = Starknet::chain_id();
         let tx_hash = emit_event_transaction.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
+        // todo
         let events = Starknet::tx_events(TransactionHash::from(tx_hash));
         let event_emitters: Vec<Felt252Wrapper> =
             events.iter().map(|event| Felt252Wrapper::from(event.from_address)).collect();

--- a/crates/pallets/starknet/src/tests/invoke_tx.rs
+++ b/crates/pallets/starknet/src/tests/invoke_tx.rs
@@ -23,7 +23,7 @@ use crate::tests::{
     get_invoke_argent_dummy, get_invoke_braavos_dummy, get_invoke_dummy, get_invoke_emit_event_dummy,
     get_invoke_nonce_dummy, get_invoke_openzeppelin_dummy, get_storage_read_write_dummy, set_nonce,
 };
-use crate::{Call, Config, Error, Event, StorageView};
+use crate::{Call, Config, Error, StorageView};
 
 #[test]
 fn given_hardcoded_contract_run_invoke_tx_fails_sender_not_deployed() {
@@ -64,35 +64,33 @@ fn given_hardcoded_contract_run_invoke_tx_then_it_works() {
         pretty_assertions::assert_eq!(pending_txs.len(), 1);
         let pending_hashes = Starknet::pending_hashes();
         pretty_assertions::assert_eq!(pending_hashes.len(), 1);
+        let tx_hash = TransactionHash(StarkFelt::try_from("0x02dfd0ded452658d67535279591c1ed9898431e1eafad7896239f0bfa68493d6").unwrap());
 
         assert_eq!(
             pending_hashes[0],
-            TransactionHash(
-                StarkFelt::try_from("0x02dfd0ded452658d67535279591c1ed9898431e1eafad7896239f0bfa68493d6").unwrap()
-            )
+            tx_hash
         );
-        assert!(System::events().into_iter().map(|event_record| event_record.event).any(|e| match e {
-            RuntimeEvent::Starknet(Event::StarknetEvent(e)) => {
-                e == StarknetEvent {
-                    from_address: Starknet::fee_token_address(),
-                    content: EventContent {
-                        keys: vec![EventKey(
-                            Felt252Wrapper::from(get_selector_from_name(mp_fee::TRANSFER_SELECTOR_NAME).unwrap())
-                                .into(),
-                        )],
-                        data: EventData(vec![
-                            StarkFelt::try_from(BLOCKIFIER_ACCOUNT_ADDRESS).unwrap(),
-                            StarkFelt::try_from("0x000000000000000000000000000000000000000000000000000000000000dead")
-                                .unwrap(),
-                            StarkFelt::try_from("0x00000000000000000000000000000000000000000000000000000000000001a4")
-                                .unwrap(),
-                            StarkFelt::from(0u128),
-                        ]),
-                    },
-                }
-            }
-            _ => false,
-        }));
+        let events: Vec<StarknetEvent> = Starknet::tx_events(tx_hash);
+
+        assert!(events.into_iter().any(|e|
+            e == StarknetEvent {
+                from_address: Starknet::fee_token_address(),
+                content: EventContent {
+                    keys: vec![EventKey(
+                        Felt252Wrapper::from(get_selector_from_name(mp_fee::TRANSFER_SELECTOR_NAME).unwrap())
+                            .into(),
+                    )],
+                    data: EventData(vec![
+                        StarkFelt::try_from(BLOCKIFIER_ACCOUNT_ADDRESS).unwrap(),
+                        StarkFelt::try_from("0x000000000000000000000000000000000000000000000000000000000000dead")
+                            .unwrap(),
+                        StarkFelt::try_from("0x00000000000000000000000000000000000000000000000000000000000001a4")
+                            .unwrap(),
+                        StarkFelt::from(0u128),
+                    ]),
+                },
+            },
+        ));
     });
 }
 
@@ -104,6 +102,10 @@ fn given_hardcoded_contract_run_invoke_tx_then_event_is_emitted() {
         let none_origin = RuntimeOrigin::none();
 
         let transaction: InvokeTransaction = get_invoke_emit_event_dummy().into();
+
+        let chain_id = Starknet::chain_id();
+        let tx_hash =
+            transaction.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
 
         assert_ok!(Starknet::invoke(none_origin, transaction));
 
@@ -132,17 +134,17 @@ fn given_hardcoded_contract_run_invoke_tx_then_event_is_emitted() {
                 ]),
             },
         };
-        let events = System::events();
+        let events: Vec<StarknetEvent> = Starknet::tx_events(TransactionHash::from(tx_hash));
 
         // Actual event.
         pretty_assertions::assert_eq!(
-            Event::StarknetEvent(emitted_event.clone()),
-            events[events.len() - 2].event.clone().try_into().unwrap()
+            emitted_event.clone(),
+            events[events.len() - 2]
         );
         // Fee transfer event.
         pretty_assertions::assert_eq!(
-            Event::StarknetEvent(expected_fee_transfer_event.clone()),
-            events.last().unwrap().event.clone().try_into().unwrap(),
+            expected_fee_transfer_event.clone(),
+            events.last().unwrap().clone()
         );
     });
 }
@@ -177,13 +179,13 @@ fn given_hardcoded_contract_run_invoke_tx_then_multiple_events_is_emitted() {
 
         let none_origin = RuntimeOrigin::none();
 
+        let chain_id = Starknet::chain_id();
+        let tx_hash= emit_internal_event_transaction.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
+
         assert_ok!(Starknet::invoke(none_origin, emit_internal_event_transaction.into()));
 
-        let mut events = System::events().into_iter().filter_map(|event_record| match event_record.event {
-            RuntimeEvent::Starknet(Event::StarknetEvent(e)) => Some(e),
-            _ => None,
-        });
-        let first_event = events.next();
+        let events: Vec<StarknetEvent> = Starknet::tx_events(TransactionHash::from(tx_hash));
+        let first_event = events.first();
         assert_eq!(
             first_event.and_then(|e| e.content.keys.get(0).cloned()).unwrap(),
             EventKey(Felt252Wrapper::from(expected_emitted_internal_event_hash).into())
@@ -207,9 +209,9 @@ fn given_hardcoded_contract_run_invoke_tx_then_multiple_events_is_emitted() {
         assert_ok!(Starknet::invoke(none_origin, do_two_event_transaction.clone().into()));
 
         let chain_id = Starknet::chain_id();
-        let do_two_hash: TransactionHash =
-            do_two_event_transaction.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false).into();
-        let events = Starknet::tx_events(do_two_hash);
+        let tx_hash =
+            do_two_event_transaction.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
+        let events = Starknet::tx_events(TransactionHash::from(tx_hash));
         assert_eq!(
             events[0].content.keys[0],
             EventKey(Felt252Wrapper::from(expected_emitted_external_event_hash).into())

--- a/crates/pallets/starknet/src/tests/invoke_tx.rs
+++ b/crates/pallets/starknet/src/tests/invoke_tx.rs
@@ -64,21 +64,19 @@ fn given_hardcoded_contract_run_invoke_tx_then_it_works() {
         pretty_assertions::assert_eq!(pending_txs.len(), 1);
         let pending_hashes = Starknet::pending_hashes();
         pretty_assertions::assert_eq!(pending_hashes.len(), 1);
-        let tx_hash = TransactionHash(StarkFelt::try_from("0x02dfd0ded452658d67535279591c1ed9898431e1eafad7896239f0bfa68493d6").unwrap());
-
-        assert_eq!(
-            pending_hashes[0],
-            tx_hash
+        let tx_hash = TransactionHash(
+            StarkFelt::try_from("0x02dfd0ded452658d67535279591c1ed9898431e1eafad7896239f0bfa68493d6").unwrap(),
         );
+
+        assert_eq!(pending_hashes[0], tx_hash);
         let events: Vec<StarknetEvent> = Starknet::tx_events(tx_hash);
 
-        assert!(events.into_iter().any(|e|
-            e == StarknetEvent {
+        assert!(events.into_iter().any(|e| e
+            == StarknetEvent {
                 from_address: Starknet::fee_token_address(),
                 content: EventContent {
                     keys: vec![EventKey(
-                        Felt252Wrapper::from(get_selector_from_name(mp_fee::TRANSFER_SELECTOR_NAME).unwrap())
-                            .into(),
+                        Felt252Wrapper::from(get_selector_from_name(mp_fee::TRANSFER_SELECTOR_NAME).unwrap()).into(),
                     )],
                     data: EventData(vec![
                         StarkFelt::try_from(BLOCKIFIER_ACCOUNT_ADDRESS).unwrap(),
@@ -89,8 +87,7 @@ fn given_hardcoded_contract_run_invoke_tx_then_it_works() {
                         StarkFelt::from(0u128),
                     ]),
                 },
-            },
-        ));
+            },));
     });
 }
 
@@ -180,7 +177,8 @@ fn given_hardcoded_contract_run_invoke_tx_then_multiple_events_is_emitted() {
         let none_origin = RuntimeOrigin::none();
 
         let chain_id = Starknet::chain_id();
-        let tx_hash= emit_internal_event_transaction.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
+        let tx_hash =
+            emit_internal_event_transaction.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
 
         assert_ok!(Starknet::invoke(none_origin, emit_internal_event_transaction.into()));
 
@@ -209,8 +207,7 @@ fn given_hardcoded_contract_run_invoke_tx_then_multiple_events_is_emitted() {
         assert_ok!(Starknet::invoke(none_origin, do_two_event_transaction.clone().into()));
 
         let chain_id = Starknet::chain_id();
-        let tx_hash =
-            do_two_event_transaction.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
+        let tx_hash = do_two_event_transaction.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
         let events = Starknet::tx_events(TransactionHash::from(tx_hash));
         assert_eq!(
             events[0].content.keys[0],

--- a/crates/pallets/starknet/src/tests/mock/setup_mock.rs
+++ b/crates/pallets/starknet/src/tests/mock/setup_mock.rs
@@ -79,7 +79,6 @@ macro_rules! mock_runtime {
             }
 
 			impl pallet_starknet::Config for MockRuntime {
-				type RuntimeEvent = RuntimeEvent;
 				type SystemHash = mp_hashers::pedersen::PedersenHasher;
 				type TimestampProvider = Timestamp;
 				type UnsignedPriority = UnsignedPriority;

--- a/crates/primitives/storage/src/lib.rs
+++ b/crates/primitives/storage/src/lib.rs
@@ -31,6 +31,8 @@ pub const STARKNET_NONCE: &[u8] = b"Nonces";
 pub const STARKNET_STORAGE: &[u8] = b"StorageView";
 /// Compiled class hashes
 pub const STARKNET_COMPILED_CLASS_HASH: &[u8] = b"CompiledClassHashes";
+/// Starknet events
+pub const STARKNET_TX_EVENTS: &[u8] = b"TxEvents";
 
 lazy_static! {
     pub static ref SN_NONCE_PREFIX: Vec<u8> = [twox_128(PALLET_STARKNET), twox_128(STARKNET_NONCE)].concat();

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -292,21 +292,6 @@ impl_runtime_apis! {
             Starknet::simulate_transactions(transactions, &simulation_flags)
         }
 
-        fn get_starknet_events_and_their_associated_tx_index() -> Vec<(u32, StarknetEvent)> {
-            System::read_events_no_consensus().filter_map(|event_record| {
-                let (phase, event) = match *event_record {
-                    EventRecord { event: RuntimeEvent::Starknet(Event::StarknetEvent(event)), phase, .. } => (phase, event),
-                    _ => return None,
-                };
-                let index = match phase {
-                    Phase::ApplyExtrinsic(idx) => {idx},
-                    _ => return None
-
-                };
-                Some((index, event))
-            }).collect()
-        }
-
         fn extrinsic_filter(xts: Vec<<Block as BlockT>::Extrinsic>) -> Vec<Transaction> {
             xts.into_iter().filter_map(|xt| match xt.function {
                 RuntimeCall::Starknet( invoke { transaction }) => Some(Transaction::Invoke(transaction)),
@@ -342,40 +327,12 @@ impl_runtime_apis! {
             Some((tx_index, transaction))
         }
 
-        fn get_events_for_tx_by_index(tx_index: u32) -> Option<Vec<StarknetEvent>> {
-
-            // Skip all the events that are not related to our tx
-            let event_iter = System::read_events_no_consensus().filter_map(|event| {
-                match *event {
-                    EventRecord { event: RuntimeEvent::Starknet(Event::StarknetEvent(event)), phase, .. } => Some((phase, event)),
-                    _ => None,
-                }
-            }).skip_while(|(phase, _)| {
-                let index = match phase {
-                    Phase::ApplyExtrinsic(idx) => *idx,
-                    _ => return true
-                };
-
-                tx_index != index
-             });
-
-            // Collect all the events related to our tx
-            // Event from the same transaction are stored one after another
-            // so we can use take_while rather and early exit rather than filtering
-            let events = event_iter.take_while(|(phase, _)| {
-                let index = match phase {
-                    Phase::ApplyExtrinsic(idx) => *idx,
-                    _ => panic!("The previous iteration made sure at this point phase is of ApplyExtrinsic variant"),
-                };
-
-                tx_index == index
-            }).map(|(_, event)| event).collect();
-
-            Some(events)
-        }
-
         fn get_tx_messages_to_l1(tx_hash: TransactionHash) -> Vec<MessageToL1> {
             Starknet::tx_messages(tx_hash)
+        }
+
+        fn get_events_for_tx_by_hash(tx_hash: TransactionHash) -> Vec<StarknetEvent> {
+            Starknet::tx_events(tx_hash)
         }
 
         fn get_tx_execution_outcome(tx_hash: TransactionHash) -> Option<Vec<u8>> {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -27,7 +27,6 @@ pub use frame_support::weights::constants::{
 pub use frame_support::weights::{IdentityFee, Weight};
 pub use frame_support::{construct_runtime, parameter_types, StorageValue};
 pub use frame_system::Call as SystemCall;
-use frame_system::{EventRecord, Phase};
 use mp_felt::Felt252Wrapper;
 use mp_simulations::{PlaceHolderErrorTypeForFailedStarknetExecution, SimulationFlags};
 use mp_transactions::compute_hash::ComputeTransactionHash;
@@ -37,7 +36,6 @@ use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId, AuthorityList as G
 pub use pallet_starknet;
 use pallet_starknet::pallet::Error as PalletError;
 use pallet_starknet::Call::{consume_l1_message, declare, deploy_account, invoke};
-use pallet_starknet::Event;
 use pallet_starknet_runtime_api::StarknetTransactionExecutionError;
 pub use pallet_timestamp::Call as TimestampCall;
 use sp_api::impl_runtime_apis;

--- a/crates/runtime/src/pallets.rs
+++ b/crates/runtime/src/pallets.rs
@@ -33,7 +33,6 @@ use crate::*;
 
 /// Configure the Starknet pallet in pallets/starknet.
 impl pallet_starknet::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
     type SystemHash = StarknetHasher;
     type TimestampProvider = Timestamp;
     type UnsignedPriority = UnsignedPriority;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Feature

## What is the current behavior?

We store Starknet events in Substrate events which is not pretty convenient and infate [block size](https://github.com/paritytech/substrate/blob/033d4e86cc7eff0066cd376b9375f815761d653c/frame/system/src/lib.rs#L627)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `TxEvents` are not deleted after storing block, so that it's main storage for starknet events
- `StarkEvent`s does not stored in Substrate events

## Does this introduce a breaking change?

<!-- Yes or No -->
No
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
