### PR TITLE
refactor: [#ignore] removed from work_ok_retrieving_class_for_contract_version_1 test, issue #1056

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next release
 
+- refactor: test ignore removed from
+  work_ok_retrieving_class_for_contract_version_1 test
 - feat(rpc): add tests for estimateMessageFee RPC call
 - refacto: rename braavos call aggregator contract
 - fix: updating outdated links to external resources in documentation

--- a/starknet-rpc-test/get_class.rs
+++ b/starknet-rpc-test/get_class.rs
@@ -89,7 +89,6 @@ async fn work_ok_retrieving_class_for_contract_version_0(madara: &ThreadSafeMada
     Ok(())
 }
 
-#[ignore = "conversion between contract class types is incomplete"]
 #[rstest]
 #[tokio::test]
 async fn work_ok_retrieving_class_for_contract_version_1(madara: &ThreadSafeMadaraClient) -> Result<(), anyhow::Error> {

--- a/starknet-rpc-test/get_class_at.rs
+++ b/starknet-rpc-test/get_class_at.rs
@@ -87,7 +87,6 @@ async fn work_ok_retrieving_class_for_contract_version_0(madara: &ThreadSafeMada
 }
 
 #[rstest]
-#[ignore]
 #[tokio::test]
 async fn work_ok_retrieving_class_for_contract_version_1(madara: &ThreadSafeMadaraClient) -> Result<(), anyhow::Error> {
     let rpc = madara.get_starknet_client().await;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type



<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:


- Refactoring (no functional changes, no API changes)


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- work_ok_retrieving_class_for_contract_version_1 test was getting ignored as it was dependent on issue #992.  

Resolves: #NA

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Since issue #992 is merged, so as per issue #1056 removing the [#ignore] before the test in starknet-rpc-test/{get_class,get_class_at}.rs 


## Does this introduce a breaking change?

No
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
