### PR TITLE
chore: remove use of dispatchError in RuntimeAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- chore(runtime_api): remove the use of `DispatchError`
 - chore(rpc): clean trace api
 - feat(rpc): added state diff real value in trace api
 - chore: update cairo-vm commit and update gas per op

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6908,6 +6908,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "starknet-core",
+ "starknet_api",
 ]
 
 [[package]]

--- a/crates/client/rpc/src/errors.rs
+++ b/crates/client/rpc/src/errors.rs
@@ -1,5 +1,4 @@
 use jsonrpsee::types::error::{CallError, ErrorObject};
-use pallet_starknet_runtime_api::StarknetTransactionExecutionError;
 
 // Comes from the RPC Spec:
 // https://github.com/starkware-libs/starknet-specs/blob/0e859ff905795f789f1dfd6f7340cdaf5015acc8/api/starknet_write_api.json#L227
@@ -45,14 +44,15 @@ pub enum StarknetRpcApiError {
     ProofLimitExceeded = 10000,
 }
 
-impl From<StarknetTransactionExecutionError> for StarknetRpcApiError {
-    fn from(err: StarknetTransactionExecutionError) -> Self {
-        match err {
-            StarknetTransactionExecutionError::ContractNotFound => StarknetRpcApiError::ContractNotFound,
-            StarknetTransactionExecutionError::ClassAlreadyDeclared => StarknetRpcApiError::ClassAlreadyDeclared,
-            StarknetTransactionExecutionError::ClassHashNotFound => StarknetRpcApiError::ClassHashNotFound,
-            StarknetTransactionExecutionError::InvalidContractClass => StarknetRpcApiError::InvalidContractClass,
-            StarknetTransactionExecutionError::ContractError => StarknetRpcApiError::ContractError,
+impl From<mp_simulations::Error> for StarknetRpcApiError {
+    fn from(value: mp_simulations::Error) -> Self {
+        match value {
+            mp_simulations::Error::ContractNotFound(_) => StarknetRpcApiError::ContractNotFound,
+            mp_simulations::Error::TransactionExecutionFailed => StarknetRpcApiError::ContractError,
+            mp_simulations::Error::MissingL1GasUsage => StarknetRpcApiError::InternalServerError,
+            mp_simulations::Error::FailedToCreateATransactionalStorageExecution => {
+                StarknetRpcApiError::InternalServerError
+            }
         }
     }
 }

--- a/crates/client/rpc/src/runtime_api.rs
+++ b/crates/client/rpc/src/runtime_api.rs
@@ -9,15 +9,12 @@ use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
 use mp_simulations::SimulationFlags;
 use mp_transactions::{HandleL1MessageTransaction, Transaction, UserTransaction};
-use pallet_starknet_runtime_api::{
-    ConvertTransactionRuntimeApi, StarknetRuntimeApi, StarknetTransactionExecutionError,
-};
+use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
 use sc_client_api::backend::Backend;
 use sc_transaction_pool::ChainApi;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::Block as BlockT;
-use sp_runtime::DispatchError;
 use starknet_api::api_core::{ContractAddress, EntryPointSelector};
 use starknet_api::transaction::{Calldata, Event, TransactionHash};
 use starknet_core::types::FieldElement;
@@ -42,7 +39,7 @@ where
         contract_address: ContractAddress,
         entry_point_selector: EntryPointSelector,
         calldata: Calldata,
-    ) -> RpcApiResult<Result<Vec<Felt252Wrapper>, sp_runtime::DispatchError>> {
+    ) -> RpcApiResult<Result<Vec<Felt252Wrapper>, mp_simulations::Error>> {
         self.client.runtime_api().call(best_block_hash, contract_address, entry_point_selector, calldata).map_err(|e| {
             error!("Request parameters error: {e}");
             StarknetRpcApiError::InternalServerError
@@ -91,17 +88,6 @@ where
                 "Failed to get events for transaction hash. Substrate block hash: {block_hash}, transaction hash: \
                  {tx_hash}, error: {e}"
             );
-            StarknetRpcApiError::InternalServerError
-        })
-    }
-
-    pub fn convert_dispatch_error(
-        &self,
-        best_block_hash: B::Hash,
-        error: DispatchError,
-    ) -> RpcApiResult<StarknetTransactionExecutionError> {
-        self.client.runtime_api().convert_error(best_block_hash, error).map_err(|e| {
-            error!("Failed to convert dispatch error: {:?}", e);
             StarknetRpcApiError::InternalServerError
         })
     }

--- a/crates/pallets/starknet/runtime_api/src/lib.rs
+++ b/crates/pallets/starknet/runtime_api/src/lib.rs
@@ -17,31 +17,23 @@ pub extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use mp_simulations::{PlaceHolderErrorTypeForFailedStarknetExecution, SimulationFlags, TransactionSimulationResult};
-use sp_runtime::DispatchError;
+use mp_simulations::{
+    Error, PlaceHolderErrorTypeForFailedStarknetExecution, SimulationFlags, TransactionSimulationResult,
+};
 use starknet_api::api_core::{ChainId, ClassHash, ContractAddress, EntryPointSelector, Nonce};
 use starknet_api::block::{BlockNumber, BlockTimestamp};
 use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::state::StorageKey;
 use starknet_api::transaction::{Calldata, Event as StarknetEvent, Fee, MessageToL1, TransactionHash};
 
-#[derive(parity_scale_codec::Encode, parity_scale_codec::Decode, scale_info::TypeInfo)]
-pub enum StarknetTransactionExecutionError {
-    ContractNotFound,
-    ClassAlreadyDeclared,
-    ClassHashNotFound,
-    InvalidContractClass,
-    ContractError,
-}
-
 sp_api::decl_runtime_apis! {
     pub trait StarknetRuntimeApi {
         /// Returns the nonce associated with the given address in the given block
         fn nonce(contract_address: ContractAddress) -> Nonce;
         /// Returns a storage slot value
-        fn get_storage_at(address: ContractAddress, key: StorageKey) -> Result<StarkFelt, DispatchError>;
+        fn get_storage_at(address: ContractAddress, key: StorageKey) -> Result<StarkFelt, Error>;
         /// Returns a `Call` response.
-        fn call(address: ContractAddress, function_selector: EntryPointSelector, calldata: Calldata) -> Result<Vec<Felt252Wrapper>, DispatchError>;
+        fn call(address: ContractAddress, function_selector: EntryPointSelector, calldata: Calldata) -> Result<Vec<Felt252Wrapper>, Error>;
         /// Returns the contract class hash at the given address.
         fn contract_class_hash_by_address(address: ContractAddress) -> ClassHash;
         /// Returns the contract class for the given class hash.
@@ -55,13 +47,13 @@ sp_api::decl_runtime_apis! {
         /// Returns the fee token address.
         fn fee_token_address() -> ContractAddress;
         /// Returns fee estimate
-        fn estimate_fee(transactions: Vec<UserTransaction>) -> Result<Vec<(u64, u64)>, DispatchError>;
+        fn estimate_fee(transactions: Vec<UserTransaction>) -> Result<Vec<(u64, u64)>, Error>;
         /// Returns message fee estimate
-        fn estimate_message_fee(message: HandleL1MessageTransaction) -> Result<(u128, u64, u64), DispatchError>;
+        fn estimate_message_fee(message: HandleL1MessageTransaction) -> Result<(u128, u64, u64), Error>;
         /// Simulates single L1 Message and returns its trace
-        fn simulate_message(message: HandleL1MessageTransaction, simulation_flags: SimulationFlags) -> Result<Result<TransactionExecutionInfo, PlaceHolderErrorTypeForFailedStarknetExecution>, DispatchError>;
+        fn simulate_message(message: HandleL1MessageTransaction, simulation_flags: SimulationFlags) -> Result<Result<TransactionExecutionInfo, PlaceHolderErrorTypeForFailedStarknetExecution>, Error>;
         /// Simulates transactions and returns their trace
-        fn simulate_transactions(transactions: Vec<UserTransaction>, simulation_flags: SimulationFlags) -> Result<Vec<(CommitmentStateDiff, TransactionSimulationResult)>, DispatchError>;
+        fn simulate_transactions(transactions: Vec<UserTransaction>, simulation_flags: SimulationFlags) -> Result<Vec<(CommitmentStateDiff, TransactionSimulationResult)>, Error>;
         /// Filters extrinsic transactions to return only Starknet transactions
         ///
         /// To support runtime upgrades, the client must be unaware of the specific extrinsic
@@ -72,7 +64,7 @@ sp_api::decl_runtime_apis! {
         /// client to operate seamlessly while abstracting the extrinsic complexity.
         fn extrinsic_filter(xts: Vec<<Block as BlockT>::Extrinsic>) -> Vec<Transaction>;
         /// Re-execute a block and return the TransactionExecutionInfos of every transaction in it, in the same order
-        fn re_execute_transactions(transactions: Vec<UserOrL1HandlerTransaction>) -> Result<Result<Vec<(TransactionExecutionInfo, CommitmentStateDiff)>, PlaceHolderErrorTypeForFailedStarknetExecution>, DispatchError>;
+        fn re_execute_transactions(transactions: Vec<UserOrL1HandlerTransaction>) -> Result<Result<Vec<(TransactionExecutionInfo, CommitmentStateDiff)>, PlaceHolderErrorTypeForFailedStarknetExecution>, Error>;
 
         fn get_index_and_tx_for_tx_hash(xts: Vec<<Block as BlockT>::Extrinsic>, chain_id: Felt252Wrapper, tx_hash: Felt252Wrapper) -> Option<(u32, Transaction)>;
 
@@ -95,9 +87,6 @@ sp_api::decl_runtime_apis! {
 
         /// Converts the L1 Message transaction to an UncheckedExtrinsic for submission to the pool.
         fn convert_l1_transaction(transaction: HandleL1MessageTransaction, fee: Fee) -> <Block as BlockT>::Extrinsic;
-
-        /// Converts the DispatchError to an understandable error for the client
-        fn convert_error(error: DispatchError) -> StarknetTransactionExecutionError;
     }
 }
 

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -880,11 +880,12 @@ impl<T: Config> Pallet<T> {
         address: ContractAddress,
         function_selector: EntryPointSelector,
         calldata: Calldata,
-    ) -> Result<Vec<Felt252Wrapper>, DispatchError> {
+    ) -> Result<Vec<Felt252Wrapper>, mp_simulations::Error> {
         // Get current block context
         let block_context = Self::get_block_context();
         // Get class hash
-        let class_hash = ContractClassHashes::<T>::try_get(address).map_err(|_| Error::<T>::ContractNotFound)?;
+        let class_hash =
+            ContractClassHashes::<T>::try_get(address).map_err(|_| mp_simulations::Error::ContractNotFound(address))?;
 
         let entrypoint = CallEntryPoint {
             class_hash: Some(class_hash),
@@ -915,15 +916,21 @@ impl<T: Config> Pallet<T> {
             }
             Err(e) => {
                 log!(error, "failed to call smart contract {:?}", e);
-                Err(Error::<T>::TransactionExecutionFailed.into())
+                Err(mp_simulations::Error::TransactionExecutionFailed)
             }
         }
     }
 
     /// Get storage value at
-    pub fn get_storage_at(contract_address: ContractAddress, key: StorageKey) -> Result<StarkFelt, DispatchError> {
+    pub fn get_storage_at(
+        contract_address: ContractAddress,
+        key: StorageKey,
+    ) -> Result<StarkFelt, mp_simulations::Error> {
         // Get state
-        ensure!(ContractClassHashes::<T>::contains_key(contract_address), Error::<T>::ContractNotFound);
+        ensure!(
+            ContractClassHashes::<T>::contains_key(contract_address),
+            mp_simulations::Error::ContractNotFound(contract_address)
+        );
         Ok(Self::storage((contract_address, key)))
     }
 

--- a/crates/pallets/starknet/src/simulations.rs
+++ b/crates/pallets/starknet/src/simulations.rs
@@ -16,19 +16,22 @@ use starknet_api::transaction::Fee;
 
 use crate::blockifier_state_adapter::{BlockifierStateAdapter, CachedBlockifierStateAdapter};
 use crate::execution_config::RuntimeExecutionConfigBuilder;
-use crate::{Config, Error, Pallet};
+use crate::{Config, Pallet};
 
 impl<T: Config> Pallet<T> {
-    pub fn estimate_fee(transactions: Vec<UserTransaction>) -> Result<Vec<(u64, u64)>, DispatchError> {
+    pub fn estimate_fee(transactions: Vec<UserTransaction>) -> Result<Vec<(u64, u64)>, mp_simulations::Error> {
+        let mut res = None;
+
         storage::transactional::with_transaction(|| {
-            storage::TransactionOutcome::Rollback(Result::<_, DispatchError>::Ok(Self::estimate_fee_inner(
-                transactions,
-            )))
+            res = Some(Self::estimate_fee_inner(transactions));
+            storage::TransactionOutcome::Rollback(Result::<_, DispatchError>::Ok(()))
         })
-        .map_err(|_| Error::<T>::FailedToCreateATransactionalStorageExecution)?
+        .map_err(|_| mp_simulations::Error::FailedToCreateATransactionalStorageExecution)?;
+
+        res.expect("`res` should have been set to `Some` at this point")
     }
 
-    fn estimate_fee_inner(transactions: Vec<UserTransaction>) -> Result<Vec<(u64, u64)>, DispatchError> {
+    fn estimate_fee_inner(transactions: Vec<UserTransaction>) -> Result<Vec<(u64, u64)>, mp_simulations::Error> {
         let transactions_len = transactions.len();
         let chain_id = Self::chain_id();
         let block_context = Self::get_block_context();
@@ -43,7 +46,7 @@ impl<T: Config> Pallet<T> {
                     Ok(execution_info) if !execution_info.is_reverted() => Ok(execution_info),
                     Err(e) => {
                         log::error!("Transaction execution failed during fee estimation: {e}");
-                        Err(Error::<T>::TransactionExecutionFailed)
+                        Err(mp_simulations::Error::TransactionExecutionFailed)
                     }
                     Ok(execution_info) => {
                         log::error!(
@@ -51,7 +54,7 @@ impl<T: Config> Pallet<T> {
                             // Safe due to the `match` branch order
                             execution_info.revert_error.unwrap()
                         );
-                        Err(Error::<T>::TransactionExecutionFailed)
+                        Err(mp_simulations::Error::TransactionExecutionFailed)
                     }
                 }
             })
@@ -61,7 +64,7 @@ impl<T: Config> Pallet<T> {
                         .actual_resources
                         .0
                         .get("l1_gas_usage")
-                        .ok_or_else(|| DispatchError::from(Error::<T>::MissingL1GasUsage))
+                        .ok_or(mp_simulations::Error::MissingL1GasUsage)
                         .map(|l1_gas_usage| (exec_info.actual_fee.0 as u64, *l1_gas_usage))
                 })
             });
@@ -76,20 +79,22 @@ impl<T: Config> Pallet<T> {
     pub fn simulate_transactions(
         transactions: Vec<UserTransaction>,
         simulation_flags: &SimulationFlags,
-    ) -> Result<Vec<(CommitmentStateDiff, TransactionSimulationResult)>, DispatchError> {
+    ) -> Result<Vec<(CommitmentStateDiff, TransactionSimulationResult)>, mp_simulations::Error> {
+        let mut res = None;
+
         storage::transactional::with_transaction(|| {
-            storage::TransactionOutcome::Rollback(Result::<_, DispatchError>::Ok(Self::simulate_transactions_inner(
-                transactions,
-                simulation_flags,
-            )))
+            res = Some(Self::simulate_transactions_inner(transactions, simulation_flags));
+            storage::TransactionOutcome::Rollback(Result::<_, DispatchError>::Ok(()))
         })
-        .map_err(|_| Error::<T>::FailedToCreateATransactionalStorageExecution)?
+        .map_err(|_| mp_simulations::Error::FailedToCreateATransactionalStorageExecution)?;
+
+        Ok(res.expect("`res` should have been set to `Some` at this point"))
     }
 
     fn simulate_transactions_inner(
         transactions: Vec<UserTransaction>,
         simulation_flags: &SimulationFlags,
-    ) -> Result<Vec<(CommitmentStateDiff, TransactionSimulationResult)>, DispatchError> {
+    ) -> Vec<(CommitmentStateDiff, TransactionSimulationResult)> {
         let chain_id = Self::chain_id();
         let block_context = Self::get_block_context();
         let mut execution_config =
@@ -109,26 +114,29 @@ impl<T: Config> Pallet<T> {
             })
             .collect();
 
-        Ok(tx_execution_results)
+        tx_execution_results
     }
 
     pub fn simulate_message(
         message: HandleL1MessageTransaction,
         simulation_flags: &SimulationFlags,
-    ) -> Result<Result<TransactionExecutionInfo, PlaceHolderErrorTypeForFailedStarknetExecution>, DispatchError> {
+    ) -> Result<Result<TransactionExecutionInfo, PlaceHolderErrorTypeForFailedStarknetExecution>, mp_simulations::Error>
+    {
+        let mut res = None;
+
         storage::transactional::with_transaction(|| {
-            storage::TransactionOutcome::Rollback(Result::<_, DispatchError>::Ok(Self::simulate_message_inner(
-                message,
-                simulation_flags,
-            )))
+            res = Some(Self::simulate_message_inner(message, simulation_flags));
+            storage::TransactionOutcome::Rollback(Result::<_, DispatchError>::Ok(()))
         })
-        .map_err(|_| Error::<T>::FailedToCreateATransactionalStorageExecution)?
+        .map_err(|_| mp_simulations::Error::FailedToCreateATransactionalStorageExecution)?;
+
+        Ok(res.expect("`res` should have been set to `Some` at this point"))
     }
 
     fn simulate_message_inner(
         message: HandleL1MessageTransaction,
         simulation_flags: &SimulationFlags,
-    ) -> Result<Result<TransactionExecutionInfo, PlaceHolderErrorTypeForFailedStarknetExecution>, DispatchError> {
+    ) -> Result<TransactionExecutionInfo, PlaceHolderErrorTypeForFailedStarknetExecution> {
         let chain_id = Self::chain_id();
         let block_context = Self::get_block_context();
         let mut execution_config =
@@ -136,25 +144,30 @@ impl<T: Config> Pallet<T> {
 
         // Follow `offset` from Pallet Starknet where it is set to false
         execution_config.set_offset_version(false);
-        let tx_execution_result =
-            Self::execute_message(message, chain_id, &block_context, &execution_config).map_err(|e| {
-                log::error!("Transaction execution failed during simulation: {e}");
-                PlaceHolderErrorTypeForFailedStarknetExecution
-            });
 
-        Ok(tx_execution_result)
-    }
-
-    pub fn estimate_message_fee(message: HandleL1MessageTransaction) -> Result<(u128, u64, u64), DispatchError> {
-        storage::transactional::with_transaction(|| {
-            storage::TransactionOutcome::Rollback(Result::<_, DispatchError>::Ok(Self::estimate_message_fee_inner(
-                message,
-            )))
+        Self::execute_message(message, chain_id, &block_context, &execution_config).map_err(|e| {
+            log::error!("Transaction execution failed during simulation: {e}");
+            PlaceHolderErrorTypeForFailedStarknetExecution
         })
-        .map_err(|_| Error::<T>::FailedToCreateATransactionalStorageExecution)?
     }
 
-    fn estimate_message_fee_inner(message: HandleL1MessageTransaction) -> Result<(u128, u64, u64), DispatchError> {
+    pub fn estimate_message_fee(
+        message: HandleL1MessageTransaction,
+    ) -> Result<(u128, u64, u64), mp_simulations::Error> {
+        let mut res = None;
+
+        storage::transactional::with_transaction(|| {
+            res = Some(Self::estimate_message_fee_inner(message));
+            storage::TransactionOutcome::Rollback(Result::<_, DispatchError>::Ok(()))
+        })
+        .map_err(|_| mp_simulations::Error::FailedToCreateATransactionalStorageExecution)?;
+
+        res.expect("`res` should have been set to `Some` at this point")
+    }
+
+    fn estimate_message_fee_inner(
+        message: HandleL1MessageTransaction,
+    ) -> Result<(u128, u64, u64), mp_simulations::Error> {
         let chain_id = Self::chain_id();
 
         // Follow `offset` from Pallet Starknet where it is set to false
@@ -170,7 +183,7 @@ impl<T: Config> Pallet<T> {
                         "Transaction execution failed during fee estimation: {e} {:?}",
                         std::error::Error::source(&e)
                     );
-                    Err(Error::<T>::TransactionExecutionFailed)
+                    Err(mp_simulations::Error::TransactionExecutionFailed)
                 }
                 Ok(execution_info) => {
                     log::error!(
@@ -178,14 +191,14 @@ impl<T: Config> Pallet<T> {
                         // Safe due to the `match` branch order
                         execution_info.revert_error.unwrap()
                     );
-                    Err(Error::<T>::TransactionExecutionFailed)
+                    Err(mp_simulations::Error::TransactionExecutionFailed)
                 }
             }?;
 
         if let Some(l1_gas_usage) = tx_execution_infos.actual_resources.0.get("l1_gas_usage") {
             Ok((T::L1GasPrice::get().price_in_wei, tx_execution_infos.actual_fee.0 as u64, *l1_gas_usage))
         } else {
-            Err(Error::<T>::MissingL1GasUsage.into())
+            Err(mp_simulations::Error::MissingL1GasUsage)
         }
     }
 
@@ -193,21 +206,24 @@ impl<T: Config> Pallet<T> {
         transactions: Vec<UserOrL1HandlerTransaction>,
     ) -> Result<
         Result<Vec<(TransactionExecutionInfo, CommitmentStateDiff)>, PlaceHolderErrorTypeForFailedStarknetExecution>,
-        DispatchError,
+        mp_simulations::Error,
     > {
+        let mut res = None;
+
         storage::transactional::with_transaction(|| {
-            storage::TransactionOutcome::Rollback(Result::<_, DispatchError>::Ok(Self::re_execute_transactions_inner(
-                transactions,
-            )))
+            res = Some(Self::re_execute_transactions_inner(transactions));
+            storage::TransactionOutcome::Rollback(Result::<_, DispatchError>::Ok(()))
         })
-        .map_err(|_| Error::<T>::FailedToCreateATransactionalStorageExecution)?
+        .map_err(|_| mp_simulations::Error::FailedToCreateATransactionalStorageExecution)?;
+
+        res.expect("`res` should have been set to `Some` at this point")
     }
 
     fn re_execute_transactions_inner(
         transactions: Vec<UserOrL1HandlerTransaction>,
     ) -> Result<
         Result<Vec<(TransactionExecutionInfo, CommitmentStateDiff)>, PlaceHolderErrorTypeForFailedStarknetExecution>,
-        DispatchError,
+        mp_simulations::Error,
     > {
         let chain_id = Self::chain_id();
         let block_context = Self::get_block_context();

--- a/crates/primitives/simulations/Cargo.toml
+++ b/crates/primitives/simulations/Cargo.toml
@@ -25,7 +25,10 @@ scale-info = { workspace = true, optional = true }
 
 [features]
 default = ["std"]
-parity-scale-codec = ["dep:parity-scale-codec", "starknet_api/parity-scale-codec"]
+parity-scale-codec = [
+  "dep:parity-scale-codec",
+  "starknet_api/parity-scale-codec",
+]
 scale-info = ["dep:scale-info", "starknet_api/scale-info"]
 std = [
   "starknet-core/std",

--- a/crates/primitives/simulations/Cargo.toml
+++ b/crates/primitives/simulations/Cargo.toml
@@ -16,6 +16,8 @@ derive_more = { workspace = true, features = ["constructor"] }
 mp-felt = { workspace = true }
 mp-transactions = { workspace = true }
 starknet-core = { workspace = true }
+starknet_api = { workspace = true }
+
 
 # Optional dependencies
 parity-scale-codec = { workspace = true, optional = true }
@@ -23,10 +25,11 @@ scale-info = { workspace = true, optional = true }
 
 [features]
 default = ["std"]
-parity-scale-codec = ["dep:parity-scale-codec"]
-scale-info = ["dep:scale-info"]
+parity-scale-codec = ["dep:parity-scale-codec", "starknet_api/parity-scale-codec"]
+scale-info = ["dep:scale-info", "starknet_api/scale-info"]
 std = [
   "starknet-core/std",
+  "starknet_api/std",
   # Optional
   "parity-scale-codec?/std",
   "scale-info?/std",

--- a/crates/primitives/simulations/src/lib.rs
+++ b/crates/primitives/simulations/src/lib.rs
@@ -6,6 +6,7 @@ pub extern crate alloc;
 use alloc::vec::Vec;
 
 use blockifier::transaction::objects::TransactionExecutionInfo;
+use starknet_api::api_core::ContractAddress;
 use starknet_core::types::SimulationFlag;
 
 // TODO: This is a placeholder
@@ -44,4 +45,14 @@ impl From<Vec<SimulationFlag>> for SimulationFlags {
 
         Self { skip_validate, skip_fee_charge }
     }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "scale-info", derive(scale_info::TypeInfo))]
+#[cfg_attr(feature = "parity-scale-codec", derive(parity_scale_codec::Encode, parity_scale_codec::Decode))]
+pub enum Error {
+    ContractNotFound(ContractAddress),
+    TransactionExecutionFailed,
+    MissingL1GasUsage,
+    FailedToCreateATransactionalStorageExecution,
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -35,9 +35,7 @@ use mp_transactions::{HandleL1MessageTransaction, Transaction, UserOrL1HandlerTr
 use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
 /// Import the Starknet pallet.
 pub use pallet_starknet;
-use pallet_starknet::pallet::Error as PalletError;
 use pallet_starknet::Call::{consume_l1_message, declare, deploy_account, invoke};
-use pallet_starknet_runtime_api::StarknetTransactionExecutionError;
 pub use pallet_timestamp::Call as TimestampCall;
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -47,7 +45,7 @@ use sp_runtime::traits::{BlakeTwo256, Block as BlockT, NumberFor};
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity};
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
-use sp_runtime::{generic, ApplyExtrinsicResult, DispatchError};
+use sp_runtime::{generic, ApplyExtrinsicResult};
 pub use sp_runtime::{Perbill, Permill};
 use sp_std::prelude::*;
 use sp_version::RuntimeVersion;
@@ -235,11 +233,11 @@ impl_runtime_apis! {
 
     impl pallet_starknet_runtime_api::StarknetRuntimeApi<Block> for Runtime {
 
-        fn get_storage_at(address: ContractAddress, key: StorageKey) -> Result<StarkFelt, DispatchError> {
+        fn get_storage_at(address: ContractAddress, key: StorageKey) -> Result<StarkFelt, mp_simulations::Error> {
             Starknet::get_storage_at(address, key)
         }
 
-        fn call(address: ContractAddress, function_selector: EntryPointSelector, calldata: Calldata) -> Result<Vec<Felt252Wrapper>, DispatchError> {
+        fn call(address: ContractAddress, function_selector: EntryPointSelector, calldata: Calldata) -> Result<Vec<Felt252Wrapper>, mp_simulations::Error> {
             Starknet::call_contract(address, function_selector, calldata)
         }
 
@@ -275,23 +273,23 @@ impl_runtime_apis! {
             Starknet::is_transaction_fee_disabled()
         }
 
-        fn estimate_fee(transactions: Vec<UserTransaction>) -> Result<Vec<(u64, u64)>, DispatchError> {
+        fn estimate_fee(transactions: Vec<UserTransaction>) -> Result<Vec<(u64, u64)>, mp_simulations::Error> {
             Starknet::estimate_fee(transactions)
         }
 
-        fn re_execute_transactions(transactions: Vec<UserOrL1HandlerTransaction>) -> Result<Result<Vec<(TransactionExecutionInfo, CommitmentStateDiff)>, PlaceHolderErrorTypeForFailedStarknetExecution>, DispatchError> {
+        fn re_execute_transactions(transactions: Vec<UserOrL1HandlerTransaction>) -> Result<Result<Vec<(TransactionExecutionInfo, CommitmentStateDiff)>, PlaceHolderErrorTypeForFailedStarknetExecution>, mp_simulations::Error> {
             Starknet::re_execute_transactions(transactions)
         }
 
-        fn estimate_message_fee(message: HandleL1MessageTransaction) -> Result<(u128, u64, u64), DispatchError> {
+        fn estimate_message_fee(message: HandleL1MessageTransaction) -> Result<(u128, u64, u64), mp_simulations::Error> {
             Starknet::estimate_message_fee(message)
         }
 
-        fn simulate_transactions(transactions: Vec<UserTransaction>, simulation_flags: SimulationFlags) -> Result<Vec<(CommitmentStateDiff, TransactionSimulationResult)>, DispatchError> {
+        fn simulate_transactions(transactions: Vec<UserTransaction>, simulation_flags: SimulationFlags) -> Result<Vec<(CommitmentStateDiff, TransactionSimulationResult)>, mp_simulations::Error> {
             Starknet::simulate_transactions(transactions, &simulation_flags)
         }
 
-        fn simulate_message(message: HandleL1MessageTransaction, simulation_flags: SimulationFlags) -> Result<Result<TransactionExecutionInfo, PlaceHolderErrorTypeForFailedStarknetExecution>, DispatchError> {
+        fn simulate_message(message: HandleL1MessageTransaction, simulation_flags: SimulationFlags) -> Result<Result<TransactionExecutionInfo, PlaceHolderErrorTypeForFailedStarknetExecution>, mp_simulations::Error> {
             Starknet::simulate_message(message, &simulation_flags)
         }
 
@@ -372,23 +370,6 @@ impl_runtime_apis! {
             let call =  pallet_starknet::Call::<Runtime>::consume_l1_message { transaction, paid_fee_on_l1: fee };
 
             UncheckedExtrinsic::new_unsigned(call.into())
-        }
-
-        fn convert_error(error: DispatchError) -> StarknetTransactionExecutionError {
-            if error == PalletError::<Runtime>::ContractNotFound.into() {
-                return StarknetTransactionExecutionError::ContractNotFound;
-            }
-            if error == PalletError::<Runtime>::ClassHashAlreadyDeclared.into() {
-                return StarknetTransactionExecutionError::ClassAlreadyDeclared;
-            }
-            if error == PalletError::<Runtime>::ContractClassHashUnknown.into() {
-                return StarknetTransactionExecutionError::ClassHashNotFound;
-            }
-            if error == PalletError::<Runtime>::InvalidContractClass.into() {
-                return StarknetTransactionExecutionError::InvalidContractClass;
-            }
-
-            StarknetTransactionExecutionError::ContractError
         }
     }
 


### PR DESCRIPTION
The use of `DispatchError` as error type is only required for the extrinsics. For the RuntimeAPI we can use whatever type we want (as long as it implements scale and type-info). 
Using such a custom type allow us to return richer information and participate into our will to move away from substrate