### PR TITLE
feat(RPC): estimate fee Error returns with transaction context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- feat(RPC): estimate fee Error returns with transaction context
 - Fix(node): Fix creating a local testnet with multiple nodes fails using only
   cli flags
 - dev: change `Vec::new` to `Vec::with_capacity` where possible.

--- a/crates/client/rpc/src/errors.rs
+++ b/crates/client/rpc/src/errors.rs
@@ -62,3 +62,15 @@ impl From<StarknetRpcApiError> for jsonrpsee::core::Error {
         jsonrpsee::core::Error::Call(CallError::Custom(ErrorObject::owned(err as i32, err.to_string(), None::<()>)))
     }
 }
+
+pub fn rpc_error_with_data<T: sp_runtime::Serialize>(
+    err: StarknetRpcApiError,
+    data: T,
+    msg: String,
+) -> jsonrpsee::core::Error {
+    jsonrpsee::core::Error::Call(CallError::Custom(ErrorObject::owned(
+        err as i32,
+        format!("{}{msg}", err.to_string()),
+        serde_json::to_value(data).ok(),
+    )))
+}

--- a/crates/client/rpc/src/errors.rs
+++ b/crates/client/rpc/src/errors.rs
@@ -70,7 +70,7 @@ pub fn rpc_error_with_data<T: sp_runtime::Serialize>(
 ) -> jsonrpsee::core::Error {
     jsonrpsee::core::Error::Call(CallError::Custom(ErrorObject::owned(
         err as i32,
-        format!("{}{msg}", err.to_string()),
+        format!("{err}{msg}"),
         serde_json::to_value(data).ok(),
     )))
 }

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -409,6 +409,7 @@ pub mod pallet {
     pub enum Error<T> {
         AccountNotDeployed,
         TransactionExecutionFailed,
+        TransactionExecutionReverted,
         ClassHashAlreadyDeclared,
         ContractClassHashUnknown,
         ContractClassAlreadyAssociated,

--- a/crates/primitives/felt/src/lib.rs
+++ b/crates/primitives/felt/src/lib.rs
@@ -343,6 +343,8 @@ pub enum Felt252WrapperError {
 
 use alloc::borrow::Cow;
 
+use serde::ser::SerializeSeq;
+
 impl From<Felt252WrapperError> for Cow<'static, str> {
     fn from(err: Felt252WrapperError) -> Self {
         match err {
@@ -374,6 +376,18 @@ impl From<FromStrError> for Felt252WrapperError {
             FromStrError::OutOfRange => Self::OutOfRange,
         }
     }
+}
+
+pub fn felt_to_hex<S>(felt_list: &[Felt252Wrapper], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let mut seq = serializer.serialize_seq(Some(felt_list.len()))?;
+    for felt in felt_list {
+        let hex_string = format!("0x{:x}", felt.0);
+        seq.serialize_element(&hex_string)?;
+    }
+    seq.end()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Feature: Enhanced error handling for `estimate_fee` calls, including specific transaction hash in error data for failed and reverted transactions

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When requesting a fee estimate, the call expects a list of transactions. However, if the call fails, it returns an error without context, making it difficult to identify which specific transaction caused the failure.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `Error` enum has been updated to distinguish between transactions that `failed` and those that were `reverted`.
- If an error occurs, the hash of the transaction is now returned in the data field of the `ContractError`, distinguishing whether it is `reverted` or `rejected`.
- This change makes it clear which transaction caused the error, allowing you to preview executable transactions by simulating the transaction list.

## Does this introduce a breaking change?

<!-- Yes or No -->
No
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
