### PR TITLE
BugFix: Madara Docker Build failing due to incorrect Madara binary location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - ci: add gomu gomu no gatling perfomrance test
 - feat(runtime): moved StarkEvents from Substrate
 - feat(rpc/trace_api): add `trace_transaction`
+- fix(docker): fix dockerfile for `madara-node`
 
 ## v0.7.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ LABEL description="Madara, a blazing fast Starknet sequencer" \
   documentation="https://docs.madara.zone/"
 
 # TODO: change the way chain-specs are copied on the node
-COPY --from=builder /madara/target/production/madara /madara-bin
+COPY --from=builder /madara/target/release/madara /madara-bin
 
 RUN apt-get -y update; \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
# Pull Request type
- Bugfix:  Madara Docker Build failing due to incorrect Madara binary file location
## What is the current behavior?

Madara Docker build fails due to incorrect madara bin location 

Resolves: 
Building of madara Docker image 

## What is the new behavior?
In Madara docker file, it is building Madara with --release tag 
But in COPY cmd, it  tries to copy it from production folder instead of release that throws file no found error. 

## Does this introduce a breaking change?

No


## Other information

