### PR TITLE
Removing generic hasher from block hash computation, using pedersen -…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
 - refactor: use Zaun crate for Starknet core contract bindings
 - refactor: use Anvil sandbox from Zaun crate
 - feat(rpc) : estimateMessageFee RPC call implementation
+- feat: Remove generic hasher from block hash computation
 
 ## v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - feat(runtime): moved StarkEvents from Substrate
 - feat(rpc/trace_api): add `trace_transaction`
 - fix(docker): fix dockerfile for `madara-node`
+- feat: Remove generic hasher from block hash computation
 
 ## v0.7.0
 
@@ -118,7 +119,6 @@
 - refactor: use Zaun crate for Starknet core contract bindings
 - refactor: use Anvil sandbox from Zaun crate
 - feat(rpc) : estimateMessageFee RPC call implementation
-- feat: Remove generic hasher from block hash computation
 
 ## v0.6.0
 

--- a/crates/client/commitment-state-diff/src/lib.rs
+++ b/crates/client/commitment-state-diff/src/lib.rs
@@ -235,7 +235,7 @@ where
     let config_hash = client.runtime_api().config_hash(storage_notification.block)?;
 
     Ok(BlockDAData {
-        block_hash: current_block.header().hash::<H>().into(),
+        block_hash: current_block.header().hash().into(),
         state_diff: commitment_state_diff,
         num_addr_accessed: accessed_addrs.len(),
         block_number: current_block.header().block_number,

--- a/crates/client/commitment-state-diff/src/lib.rs
+++ b/crates/client/commitment-state-diff/src/lib.rs
@@ -26,7 +26,6 @@ pub struct BlockDAData {
     pub state_diff: ThinStateDiff,
     pub num_addr_accessed: usize,
     pub block_number: u64,
-    pub config_hash: StarkHash,
     pub new_state_root: StarkHash,
     pub previous_state_root: StarkHash,
 }
@@ -231,14 +230,11 @@ where
         mp_digest_log::find_starknet_block(digest)?
     };
 
-    let config_hash = client.runtime_api().config_hash(storage_notification.block)?;
-
     Ok(BlockDAData {
         block_hash: current_block.header().hash().into(),
         state_diff: commitment_state_diff,
         num_addr_accessed: accessed_addrs.len(),
         block_number: current_block.header().block_number,
-        config_hash,
         // TODO: fix when we implement state root
         new_state_root: backend.temporary_global_state_root_getter(),
         previous_state_root: backend.temporary_global_state_root_getter(),

--- a/crates/client/commitment-state-diff/src/lib.rs
+++ b/crates/client/commitment-state-diff/src/lib.rs
@@ -76,7 +76,7 @@ where
                 Poll::Ready(Some(storage_notification)) => {
                     let block_hash = storage_notification.block;
 
-                    match build_commitment_state_diff::<B, C, H>(
+                    match build_commitment_state_diff::<B, C>(
                         self_as_mut.client.clone(),
                         self_as_mut.backend.clone(),
                         storage_notification,
@@ -137,7 +137,7 @@ enum BuildCommitmentStateDiffError {
     FailedToGetConfigHash(#[from] sp_api::ApiError),
 }
 
-fn build_commitment_state_diff<B: BlockT, C, H>(
+fn build_commitment_state_diff<B: BlockT, C>(
     client: Arc<C>,
     backend: Arc<mc_db::Backend<B>>,
     storage_notification: StorageNotification<B::Hash>,
@@ -145,8 +145,7 @@ fn build_commitment_state_diff<B: BlockT, C, H>(
 where
     C: ProvideRuntimeApi<B>,
     C::Api: StarknetRuntimeApi<B>,
-    C: HeaderBackend<B>,
-    H: HasherT,
+    C: HeaderBackend<B>
 {
     let mut accessed_addrs: IndexSet<ContractAddress> = IndexSet::new();
     let mut commitment_state_diff = ThinStateDiff {

--- a/crates/client/commitment-state-diff/src/lib.rs
+++ b/crates/client/commitment-state-diff/src/lib.rs
@@ -145,7 +145,7 @@ fn build_commitment_state_diff<B: BlockT, C>(
 where
     C: ProvideRuntimeApi<B>,
     C::Api: StarknetRuntimeApi<B>,
-    C: HeaderBackend<B>
+    C: HeaderBackend<B>,
 {
     let mut accessed_addrs: IndexSet<ContractAddress> = IndexSet::new();
     let mut commitment_state_diff = ThinStateDiff {

--- a/crates/client/mapping-sync/src/lib.rs
+++ b/crates/client/mapping-sync/src/lib.rs
@@ -123,7 +123,7 @@ where
         if fire {
             self.inner_delay = None;
 
-            match sync_blocks::sync_blocks::<_, _, _, H>(
+            match sync_blocks::sync_blocks::<_, _, _>(
                 self.client.as_ref(),
                 self.substrate_backend.as_ref(),
                 self.madara_backend.as_ref(),

--- a/crates/client/mapping-sync/src/sync_blocks.rs
+++ b/crates/client/mapping-sync/src/sync_blocks.rs
@@ -98,14 +98,10 @@ where
     }
 }
 
-fn sync_genesis_block<B: BlockT, C>(
-    _client: &C,
-    backend: &mc_db::Backend<B>,
-    header: &B::Header,
-) -> anyhow::Result<()>
+fn sync_genesis_block<B: BlockT, C>(_client: &C, backend: &mc_db::Backend<B>, header: &B::Header) -> anyhow::Result<()>
 where
     C: HeaderBackend<B>,
-    B: BlockT
+    B: BlockT,
 {
     let substrate_block_hash = header.hash();
 

--- a/crates/client/mapping-sync/src/sync_blocks.rs
+++ b/crates/client/mapping-sync/src/sync_blocks.rs
@@ -36,8 +36,8 @@ where
             let opt_storage_starknet_block = get_block_by_block_hash(client, substrate_block_hash);
             match opt_storage_starknet_block {
                 Ok(storage_starknet_block) => {
-                    let digest_starknet_block_hash = digest_starknet_block.header().hash::<H>();
-                    let storage_starknet_block_hash = storage_starknet_block.header().hash::<H>();
+                    let digest_starknet_block_hash = digest_starknet_block.header().hash();
+                    let storage_starknet_block_hash = storage_starknet_block.header().hash();
                     // Ensure the two blocks sources (chain storage and block digest) agree on the block content
                     if digest_starknet_block_hash != storage_starknet_block_hash {
                         Err(anyhow::anyhow!(
@@ -119,7 +119,7 @@ where
         }
         Err(FindLogError::MultipleLogs) => return Err(anyhow::anyhow!("Multiple logs found")),
     };
-    let block_hash = block.header().hash::<H>();
+    let block_hash = block.header().hash();
     let mapping_commitment = mc_db::MappingCommitment::<B> {
         block_hash: substrate_block_hash,
         starknet_block_hash: block_hash.into(),

--- a/crates/client/rpc/src/events/mod.rs
+++ b/crates/client/rpc/src/events/mod.rs
@@ -57,7 +57,7 @@ where
             StarknetRpcApiError::InternalServerError
         })?;
 
-        let block_hash = starknet_block.header().hash::<H>();
+        let block_hash = starknet_block.header().hash();
 
         let mut emitted_events: Vec<EmittedEvent> = vec![];
         for tx_hash in starknet_block.transactions_hashes() {

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -161,7 +161,7 @@ where
             Ok(block) => block,
             Err(_) => return Err(StarknetRpcApiError::BlockNotFound),
         };
-        Ok(starknet_block.header().hash::<H>().into())
+        Ok(starknet_block.header().hash().into())
     }
 
     /// Returns the substrate block hash corresponding to the given Starknet block id
@@ -742,13 +742,13 @@ where
                 if starting_block.is_ok() && current_block.is_ok() && highest_block.is_ok() {
                     // Convert block numbers and hashes to the respective type required by the `syncing` endpoint.
                     let starting_block_num = UniqueSaturatedInto::<u64>::unique_saturated_into(self.starting_block);
-                    let starting_block_hash = starting_block?.header().hash::<H>().0;
+                    let starting_block_hash = starting_block?.header().hash().0;
 
                     let current_block_num = UniqueSaturatedInto::<u64>::unique_saturated_into(best_number);
-                    let current_block_hash = current_block?.header().hash::<H>().0;
+                    let current_block_hash = current_block?.header().hash().0;
 
                     let highest_block_num = UniqueSaturatedInto::<u64>::unique_saturated_into(highest_number);
-                    let highest_block_hash = highest_block?.header().hash::<H>().0;
+                    let highest_block_hash = highest_block?.header().hash().0;
 
                     // Build the `SyncStatus` struct with the respective syn information
                     Ok(SyncStatusType::Syncing(SyncStatus {
@@ -835,7 +835,7 @@ where
 
         let starknet_block = get_block_by_block_hash(self.client.as_ref(), substrate_block_hash)?;
         let starknet_version = starknet_block.header().protocol_version;
-        let block_hash = starknet_block.header().hash::<H>();
+        let block_hash = starknet_block.header().hash();
 
         let transaction_hashes =
             starknet_block.transactions_hashes().map(|txh| Felt252Wrapper::from(*txh).into()).collect();
@@ -1096,7 +1096,7 @@ where
 
         let starknet_block = get_block_by_block_hash(self.client.as_ref(), substrate_block_hash)?;
 
-        let block_hash = starknet_block.header().hash::<H>();
+        let block_hash = starknet_block.header().hash();
         let starknet_version = starknet_block.header().protocol_version;
         let transactions = starknet_block.transactions().iter().map(|tx| to_starknet_core_tx(tx.clone())).collect();
 
@@ -1166,7 +1166,7 @@ where
             FieldElement::default()
         };
 
-        let starknet_block_hash = BlockHash(starknet_block.header().hash::<H>().into());
+        let starknet_block_hash = BlockHash(starknet_block.header().hash().into());
 
         let state_diff = self.get_state_diff(&starknet_block_hash).map_err(|e| {
             error!("Failed to get state diff. Starknet block hash: {starknet_block_hash}, error: {e}");
@@ -1174,7 +1174,7 @@ where
         })?;
 
         let state_update = StateUpdate {
-            block_hash: starknet_block.header().hash::<H>().into(),
+            block_hash: starknet_block.header().hash().into(),
             new_root: Felt252Wrapper::from(self.backend.temporary_global_state_root_getter()).into(),
             old_root,
             state_diff,
@@ -1379,7 +1379,7 @@ where
             transactions: transaction_hashes,
             // TODO: fill real prices
             l1_gas_price: ResourcePrice { price_in_fri: Default::default(), price_in_wei: Default::default() },
-            parent_hash: latest_block_header.hash::<H>().into(),
+            parent_hash: latest_block_header.hash().into(),
             sequencer_address: Felt252Wrapper::from(latest_block_header.sequencer_address).into(),
             starknet_version: latest_block_header.protocol_version.to_string(),
             timestamp: calculate_pending_block_timestamp(),
@@ -1400,7 +1400,7 @@ where
             transactions,
             // TODO: fill real prices
             l1_gas_price: ResourcePrice { price_in_fri: Default::default(), price_in_wei: Default::default() },
-            parent_hash: latest_block_header.hash::<H>().into(),
+            parent_hash: latest_block_header.hash().into(),
             sequencer_address: Felt252Wrapper::from(latest_block_header.sequencer_address).into(),
             starknet_version: latest_block_header.protocol_version.to_string(),
             timestamp: calculate_pending_block_timestamp(),
@@ -1432,7 +1432,7 @@ where
         let starknet_block: mp_block::Block = get_block_by_block_hash(self.client.as_ref(), substrate_block_hash)
             .map_err(|_e| StarknetRpcApiError::BlockNotFound)?;
         let block_header = starknet_block.header();
-        let block_hash = block_header.hash::<H>().into();
+        let block_hash = block_header.hash().into();
         let block_number = block_header.block_number;
 
         let transaction =

--- a/crates/pallets/starknet/runtime_api/src/lib.rs
+++ b/crates/pallets/starknet/runtime_api/src/lib.rs
@@ -17,7 +17,7 @@ use mp_simulations::{PlaceHolderErrorTypeForFailedStarknetExecution, SimulationF
 use sp_api::BlockT;
 use sp_runtime::DispatchError;
 use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, Nonce};
-use starknet_api::hash::{StarkFelt, StarkHash};
+use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
 use starknet_api::transaction::{Calldata, Event as StarknetEvent, MessageToL1, TransactionHash};
 
@@ -51,8 +51,6 @@ sp_api::decl_runtime_apis! {
         fn chain_id() -> Felt252Wrapper;
         /// Returns the Starknet OS Cairo program hash.
         fn program_hash() -> Felt252Wrapper;
-        /// Returns the Starknet config hash.
-        fn config_hash() -> StarkHash;
         /// Returns the fee token address.
         fn fee_token_addresses() -> FeeTokenAddresses;
         /// Returns fee estimate

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -1007,7 +1007,7 @@ impl<T: Config> Pallet<T> {
         // Safe because it could only failed if `transaction_count` does not match `transactions.len()`
         .unwrap();
         // Save the block number <> hash mapping.
-        let blockhash = block.header().hash::<T::SystemHash>();
+        let blockhash = block.header().hash();
         BlockHash::<T>::insert(block_number, blockhash);
 
         // Kill pending storage.

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -78,7 +78,6 @@ use mp_block::{Block as StarknetBlock, Header as StarknetHeader};
 use mp_chain_id::MADARA_CHAIN_ID;
 use mp_digest_log::MADARA_ENGINE_ID;
 use mp_felt::Felt252Wrapper;
-use mp_hashers::HasherT;
 use mp_sequencer_address::{InherentError, InherentType, DEFAULT_SEQUENCER_ADDRESS, INHERENT_IDENTIFIER};
 use mp_storage::{StarknetStorageSchemaVersion, PALLET_STARKNET_SCHEMA};
 use mp_transactions::execution::{
@@ -90,7 +89,7 @@ use sp_runtime::DigestItem;
 use starknet_api::block::{BlockNumber, BlockTimestamp};
 use starknet_api::core::{ChainId, ClassHash, CompiledClassHash, ContractAddress, EntryPointSelector, Nonce};
 use starknet_api::deprecated_contract_class::EntryPointType;
-use starknet_api::hash::{StarkFelt, StarkHash};
+use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
 use starknet_api::transaction::{
     Calldata, Event as StarknetEvent, Fee, MessageToL1, TransactionHash, TransactionVersion,
@@ -129,8 +128,6 @@ pub mod pallet {
     /// mechanism and comply with starknet which uses an ER20 as fee token
     #[pallet::config]
     pub trait Config: frame_system::Config {
-        /// The hashing function to use.
-        type SystemHash: HasherT;
         /// The block time
         type TimestampProvider: Time;
         /// The gas price
@@ -1136,15 +1133,6 @@ impl<T: Config> Pallet<T> {
 
     pub fn program_hash() -> Felt252Wrapper {
         T::ProgramHash::get()
-    }
-
-    pub fn config_hash() -> StarkHash {
-        Felt252Wrapper(T::SystemHash::compute_hash_on_elements(&[
-            FieldElement::from_byte_slice_be(SN_OS_CONFIG_HASH_VERSION.as_bytes()).unwrap(),
-            Self::chain_id().into(),
-            Felt252Wrapper::from(Self::fee_token_addresses().eth_fee_token_address.0.0).0,
-        ]))
-        .into()
     }
 
     pub fn is_transaction_fee_disabled() -> bool {

--- a/crates/pallets/starknet/src/tests/block.rs
+++ b/crates/pallets/starknet/src/tests/block.rs
@@ -14,7 +14,7 @@ use super::mock::default_mock::*;
 use super::mock::*;
 use crate::tests::constants::FEE_TOKEN_ADDRESS;
 use crate::tests::get_invoke_dummy;
-use crate::{Config, SeqAddrUpdate, SequencerAddress};
+use crate::{SeqAddrUpdate, SequencerAddress};
 
 #[test]
 fn store_block_no_pending_transactions_works() {

--- a/crates/pallets/starknet/src/tests/block.rs
+++ b/crates/pallets/starknet/src/tests/block.rs
@@ -34,7 +34,7 @@ fn store_block_no_pending_transactions_works() {
         assert_eq!(0, block.transactions().len());
 
         // check BlockHash correct
-        let blockhash = block.header().hash::<<MockRuntime as Config>::SystemHash>();
+        let blockhash = block.header().hash();
         assert_eq!(blockhash, Starknet::block_hash(BLOCK_NUMBER));
         // check pending storage killed
         assert_eq!(0, Starknet::pending().len());
@@ -77,7 +77,7 @@ fn store_block_with_pending_transactions_works() {
         assert_eq!(2, block.transactions().len());
 
         // check BlockHash correct
-        let blockhash = block.header().hash::<<MockRuntime as Config>::SystemHash>();
+        let blockhash = block.header().hash();
         assert_eq!(blockhash, Starknet::block_hash(BLOCK_NUMBER));
         // check pending storage killed
         assert_eq!(0, Starknet::pending().len());

--- a/crates/pallets/starknet/src/tests/mock/setup_mock.rs
+++ b/crates/pallets/starknet/src/tests/mock/setup_mock.rs
@@ -76,7 +76,6 @@ macro_rules! mock_runtime {
             }
 
 			impl pallet_starknet::Config for MockRuntime {
-				type SystemHash = mp_hashers::pedersen::PedersenHasher;
 				type TimestampProvider = Timestamp;
 				type UnsignedPriority = UnsignedPriority;
 				type TransactionLongevity = TransactionLongevity;

--- a/crates/primitives/block/src/header.rs
+++ b/crates/primitives/block/src/header.rs
@@ -1,10 +1,10 @@
 use blockifier::blockifier::block::GasPrices;
 use mp_felt::Felt252Wrapper;
+use mp_hashers::pedersen::PedersenHasher;
 use mp_hashers::HasherT;
 use sp_core::U256;
 use starknet_api::core::ContractAddress;
 use starknet_api::hash::StarkHash;
-use mp_hashers::pedersen::PedersenHasher;
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/primitives/block/src/header.rs
+++ b/crates/primitives/block/src/header.rs
@@ -60,7 +60,7 @@ impl Header {
         }
     }
 
-    // Computing the hash using the Pedersen hasher.
+    /// Compute the hash using the Pedersen hasher according to [the Starknet protocol specification](https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/header/#block_hash).  
     pub fn hash(&self) -> Felt252Wrapper {
         let data: &[Felt252Wrapper] = &[
             self.block_number.into(),

--- a/crates/primitives/block/src/header.rs
+++ b/crates/primitives/block/src/header.rs
@@ -60,22 +60,6 @@ impl Header {
         }
     }
 
-    /// Compute the hash of the header.
-    // pub fn hash<H: HasherT>(&self) -> Felt252Wrapper {
-    //     let data: &[Felt252Wrapper] = &[
-    //         self.block_number.into(),
-    //         self.sequencer_address.0.0.into(),
-    //         self.block_timestamp.into(),
-    //         self.transaction_count.into(),
-    //         self.event_count.into(),
-    //         self.protocol_version.into(),
-    //         Felt252Wrapper::ZERO,
-    //         self.parent_block_hash.into(),
-    //     ];
-
-    //     H::compute_hash_on_wrappers(data)
-    // }
-
     // Computing the hash using the Pedersen hasher.
     pub fn hash(&self) -> Felt252Wrapper {
         let data: &[Felt252Wrapper] = &[

--- a/crates/primitives/block/src/header.rs
+++ b/crates/primitives/block/src/header.rs
@@ -4,6 +4,7 @@ use mp_hashers::HasherT;
 use sp_core::U256;
 use starknet_api::core::ContractAddress;
 use starknet_api::hash::StarkHash;
+use mp_hashers::pedersen::PedersenHasher;
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -60,7 +61,23 @@ impl Header {
     }
 
     /// Compute the hash of the header.
-    pub fn hash<H: HasherT>(&self) -> Felt252Wrapper {
+    // pub fn hash<H: HasherT>(&self) -> Felt252Wrapper {
+    //     let data: &[Felt252Wrapper] = &[
+    //         self.block_number.into(),
+    //         self.sequencer_address.0.0.into(),
+    //         self.block_timestamp.into(),
+    //         self.transaction_count.into(),
+    //         self.event_count.into(),
+    //         self.protocol_version.into(),
+    //         Felt252Wrapper::ZERO,
+    //         self.parent_block_hash.into(),
+    //     ];
+
+    //     H::compute_hash_on_wrappers(data)
+    // }
+
+    // Computing the hash using the Pedersen hasher.
+    pub fn hash(&self) -> Felt252Wrapper {
         let data: &[Felt252Wrapper] = &[
             self.block_number.into(),
             self.sequencer_address.0.0.into(),
@@ -72,6 +89,6 @@ impl Header {
             self.parent_block_hash.into(),
         ];
 
-        H::compute_hash_on_wrappers(data)
+        PedersenHasher::compute_hash_on_wrappers(data)
     }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -55,7 +55,7 @@ pub use sp_runtime::{Perbill, Permill};
 use sp_std::prelude::*;
 use sp_version::RuntimeVersion;
 use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, Nonce};
-use starknet_api::hash::{StarkFelt, StarkHash};
+use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
 use starknet_api::transaction::{Calldata, Event as StarknetEvent, MessageToL1, TransactionHash};
 /// Import the types.
@@ -264,10 +264,6 @@ impl_runtime_apis! {
 
         fn program_hash() -> Felt252Wrapper {
             Starknet::program_hash()
-        }
-
-        fn config_hash() -> StarkHash {
-            Starknet::config_hash()
         }
 
         fn fee_token_addresses() -> FeeTokenAddresses {

--- a/crates/runtime/src/pallets.rs
+++ b/crates/runtime/src/pallets.rs
@@ -35,7 +35,6 @@ use crate::*;
 
 /// Configure the Starknet pallet in pallets/starknet.
 impl pallet_starknet::Config for Runtime {
-    type SystemHash = StarknetHasher;
     type TimestampProvider = Timestamp;
     type UnsignedPriority = UnsignedPriority;
     type TransactionLongevity = TransactionLongevity;


### PR DESCRIPTION
This PR is related to issue  #1572

Here are the two actions that were performed : 
- Updated the hash() function from generic to support Pedersen
- Cleaned all the issues that resulted from that change.

# Pull Request type

Refactoring (no functional changes, no API changes)

## What is the current behavior?

Using the `hash` function located in `crates/primitives/block/src/headers.rs`, one can specify any hasher function.

Resolves: #NA

## What is the new behavior?

In this refactor, we can only use `pedersen` hasher function.


## Does this introduce a breaking change?

Yes but everything is fixed.

## Other information

NA
