### PR TITLE
fix: remove unecessary checks before tx execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- feat(runtime): remove custom checks before tx execution
 - test: Adding txv3 tests
 - feat: L1 gas price/fix
 

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -509,14 +509,6 @@ pub mod pallet {
             // This ensures that the function can only be called via unsigned transaction.
             ensure_none(origin)?;
 
-            let sender_address = match &transaction.tx {
-                starknet_api::transaction::InvokeTransaction::V0(tx) => tx.contract_address,
-                starknet_api::transaction::InvokeTransaction::V1(tx) => tx.sender_address,
-                starknet_api::transaction::InvokeTransaction::V3(tx) => tx.sender_address,
-            };
-            // Check if contract is deployed
-            ensure!(ContractClassHashes::<T>::contains_key(sender_address), Error::<T>::AccountNotDeployed);
-
             // Init caches
             let mut state = BlockifierStateAdapter::<T>::default();
             let block_context = Self::get_block_context();
@@ -576,17 +568,6 @@ pub mod pallet {
             // This ensures that the function can only be called via unsigned transaction.
             ensure_none(origin)?;
 
-            // Check class hash is not already declared
-            ensure!(
-                !ContractClasses::<T>::contains_key(transaction.tx().class_hash().0),
-                Error::<T>::ClassHashAlreadyDeclared
-            );
-            // Check if contract is deployed
-            ensure!(
-                ContractClassHashes::<T>::contains_key(transaction.tx().sender_address()),
-                Error::<T>::AccountNotDeployed
-            );
-
             let mut state = BlockifierStateAdapter::<T>::default();
             let charge_fee = !<T as Config>::DisableTransactionFee::get();
 
@@ -632,12 +613,6 @@ pub mod pallet {
             ensure!(!transaction.only_query, Error::<T>::QueryTransactionCannotBeExecuted);
             // This ensures that the function can only be called via unsigned transaction.
             ensure_none(origin)?;
-
-            // Check if contract is deployed
-            ensure!(
-                !ContractClassHashes::<T>::contains_key(transaction.contract_address),
-                Error::<T>::AccountAlreadyDeployed
-            );
 
             let mut state = BlockifierStateAdapter::<T>::default();
             let charge_fee = !<T as Config>::DisableTransactionFee::get();

--- a/crates/pallets/starknet/src/tests/declare_tx.rs
+++ b/crates/pallets/starknet/src/tests/declare_tx.rs
@@ -146,7 +146,7 @@ fn given_contract_declare_tx_works_once_not_twice() {
         assert_eq!(Starknet::contract_class_by_class_hash(class_hash.0).unwrap(), contract_class);
         // TODO: Uncomment once we have ABI support
         // assert_eq!(Starknet::contract_class_by_class_hash(erc20_class_hash), erc20_class);
-        assert_err!(Starknet::declare(none_origin, transaction), Error::<MockRuntime>::ClassHashAlreadyDeclared);
+        assert_err!(Starknet::declare(none_origin, transaction), Error::<MockRuntime>::TransactionExecutionFailed);
     });
 }
 
@@ -170,7 +170,7 @@ fn given_contract_declare_tx_fails_sender_not_deployed() {
             None,
             None,
         );
-        assert_err!(Starknet::declare(none_origin, transaction), Error::<MockRuntime>::AccountNotDeployed);
+        assert_err!(Starknet::declare(none_origin, transaction), Error::<MockRuntime>::TransactionExecutionFailed);
     })
 }
 

--- a/crates/pallets/starknet/src/tests/deploy_account_tx.rs
+++ b/crates/pallets/starknet/src/tests/deploy_account_tx.rs
@@ -159,7 +159,7 @@ fn given_contract_run_deploy_account_tx_twice_fails() {
         assert_eq!(Starknet::contract_class_hash_by_address(deploy_tx.contract_address), account_class_hash.0);
         assert_err!(
             Starknet::deploy_account(RuntimeOrigin::none(), deploy_tx),
-            Error::<MockRuntime>::AccountAlreadyDeployed
+            Error::<MockRuntime>::TransactionExecutionFailed
         );
     });
 }

--- a/crates/pallets/starknet/src/tests/invoke_tx.rs
+++ b/crates/pallets/starknet/src/tests/invoke_tx.rs
@@ -59,7 +59,7 @@ fn given_hardcoded_contract_run_invoke_tx_fails_sender_not_deployed() {
             tx.sender_address = contract_address;
         };
 
-        assert_err!(Starknet::invoke(none_origin, transaction), Error::<MockRuntime>::AccountNotDeployed);
+        assert_err!(Starknet::invoke(none_origin, transaction), Error::<MockRuntime>::TransactionExecutionFailed);
     })
 }
 


### PR DESCRIPTION
By removing those checks we will return same errors are Starknet rather than our customs ones (when we will be able to return complex errors from runtime)