### PR TITLE
Add getter pending block extrinsics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3347,7 +3347,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3370,7 +3370,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3395,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.2",
@@ -3443,7 +3443,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3473,7 +3473,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "futures",
  "indicatif",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "aquamarine",
  "bitflags 1.3.2",
@@ -3534,7 +3534,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.1.3",
@@ -3565,7 +3565,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3575,7 +3575,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "cfg-if",
  "frame-support",
@@ -3594,7 +3594,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3609,7 +3609,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5542,6 +5542,7 @@ dependencies = [
  "pallet-starknet-runtime-api",
  "reqwest",
  "sc-basic-authorship",
+ "sc-block-builder",
  "sc-cli",
  "sc-client-api",
  "sc-consensus",
@@ -5820,6 +5821,7 @@ dependencies = [
  "pallet-starknet-runtime-api",
  "pretty_assertions",
  "rstest 0.18.2",
+ "sc-block-builder",
  "sc-client-api",
  "sc-network-sync",
  "sc-transaction-pool",
@@ -6798,7 +6800,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6815,7 +6817,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6829,7 +6831,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6852,7 +6854,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6925,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8410,7 +8412,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "log",
  "sp-core",
@@ -8421,7 +8423,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8444,9 +8446,10 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "parity-scale-codec",
+ "parking_lot 0.12.1",
  "sc-client-api",
  "sp-api",
  "sp-block-builder",
@@ -8459,7 +8462,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -8478,7 +8481,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
@@ -8489,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "array-bytes 6.2.2",
  "chrono",
@@ -8529,7 +8532,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "fnv",
  "futures",
@@ -8556,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -8582,7 +8585,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "futures",
@@ -8607,7 +8610,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "futures",
@@ -8636,7 +8639,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -8671,7 +8674,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -8684,7 +8687,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "ahash 0.8.6",
  "array-bytes 6.2.2",
@@ -8725,7 +8728,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -8760,7 +8763,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "futures",
@@ -8783,7 +8786,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -8805,7 +8808,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -8817,7 +8820,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8835,7 +8838,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "ansi_term",
  "futures",
@@ -8851,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "array-bytes 6.2.2",
  "parking_lot 0.12.1",
@@ -8865,7 +8868,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.1.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "array-bytes 4.2.0",
  "arrayvec 0.7.4",
@@ -8893,7 +8896,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel",
@@ -8934,7 +8937,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-channel",
  "cid",
@@ -8954,7 +8957,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -8971,7 +8974,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "ahash 0.8.6",
  "futures",
@@ -8989,7 +8992,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel",
@@ -9010,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel",
@@ -9045,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "array-bytes 6.2.2",
  "futures",
@@ -9063,7 +9066,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "array-bytes 6.2.2",
  "bytes",
@@ -9097,7 +9100,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -9106,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9138,7 +9141,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9158,7 +9161,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -9173,7 +9176,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "array-bytes 6.2.2",
  "futures",
@@ -9201,7 +9204,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "directories",
@@ -9265,7 +9268,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9276,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "futures",
  "libc",
@@ -9295,7 +9298,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "chrono",
  "futures",
@@ -9314,7 +9317,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "ansi_term",
  "atty",
@@ -9343,7 +9346,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
@@ -9354,7 +9357,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "futures",
@@ -9380,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "futures",
@@ -9396,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-channel",
  "futures",
@@ -9954,7 +9957,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "hash-db",
  "log",
@@ -9975,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -9989,7 +9992,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "23.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10002,7 +10005,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "16.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.17",
@@ -10016,7 +10019,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -10027,7 +10030,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "futures",
  "log",
@@ -10045,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "futures",
@@ -10060,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10077,7 +10080,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10096,7 +10099,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -10114,7 +10117,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10126,7 +10129,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "21.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "array-bytes 6.2.2",
  "bandersnatch_vrfs",
@@ -10173,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "9.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -10186,7 +10189,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "9.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "quote",
  "sp-core-hashing",
@@ -10196,7 +10199,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -10205,7 +10208,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "8.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10215,7 +10218,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.19.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -10226,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.1.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "serde_json",
  "sp-api",
@@ -10237,7 +10240,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -10251,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "23.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "bytes",
  "ed25519-dalek",
@@ -10275,7 +10278,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "24.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -10286,7 +10289,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.27.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -10298,7 +10301,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -10307,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.1.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -10318,7 +10321,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.1.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10330,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -10340,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "8.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -10350,7 +10353,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -10360,7 +10363,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "24.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -10382,7 +10385,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "17.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -10400,7 +10403,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.1.3",
@@ -10412,7 +10415,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10427,7 +10430,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -10441,7 +10444,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.28.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "hash-db",
  "log",
@@ -10462,7 +10465,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.1",
@@ -10486,12 +10489,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "8.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 
 [[package]]
 name = "sp-storage"
 version = "13.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10504,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10517,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "10.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -10529,7 +10532,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -10538,7 +10541,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10553,7 +10556,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "22.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "ahash 0.8.6",
  "hash-db",
@@ -10577,7 +10580,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "22.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10594,7 +10597,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "8.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -10605,7 +10608,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "14.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -10618,7 +10621,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "20.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11115,12 +11118,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -11139,7 +11142,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "hyper",
  "log",
@@ -11151,7 +11154,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -11808,7 +11811,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
+source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3347,7 +3347,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3370,7 +3370,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3395,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.2",
@@ -3443,7 +3443,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3473,7 +3473,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "futures",
  "indicatif",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "aquamarine",
  "bitflags 1.3.2",
@@ -3534,7 +3534,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.1.3",
@@ -3565,7 +3565,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3575,7 +3575,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "cfg-if",
  "frame-support",
@@ -3594,7 +3594,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3609,7 +3609,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6800,7 +6800,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6817,7 +6817,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6831,7 +6831,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6854,7 +6854,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6927,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8412,7 +8412,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "log",
  "sp-core",
@@ -8423,7 +8423,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8446,7 +8446,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -8462,7 +8462,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -8481,7 +8481,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
@@ -8492,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "array-bytes 6.2.2",
  "chrono",
@@ -8532,7 +8532,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "fnv",
  "futures",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -8585,7 +8585,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "futures",
@@ -8610,7 +8610,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "futures",
@@ -8639,7 +8639,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -8674,7 +8674,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -8687,7 +8687,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "ahash 0.8.6",
  "array-bytes 6.2.2",
@@ -8728,7 +8728,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -8763,7 +8763,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "futures",
@@ -8786,7 +8786,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -8808,7 +8808,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -8820,7 +8820,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8838,7 +8838,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "ansi_term",
  "futures",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "array-bytes 6.2.2",
  "parking_lot 0.12.1",
@@ -8868,7 +8868,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.1.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "array-bytes 4.2.0",
  "arrayvec 0.7.4",
@@ -8896,7 +8896,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel",
@@ -8937,7 +8937,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-channel",
  "cid",
@@ -8957,7 +8957,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -8974,7 +8974,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "ahash 0.8.6",
  "futures",
@@ -8992,7 +8992,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel",
@@ -9013,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel",
@@ -9048,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "array-bytes 6.2.2",
  "futures",
@@ -9066,7 +9066,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "array-bytes 6.2.2",
  "bytes",
@@ -9100,7 +9100,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -9109,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9141,7 +9141,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9161,7 +9161,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -9176,7 +9176,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "array-bytes 6.2.2",
  "futures",
@@ -9204,7 +9204,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "directories",
@@ -9268,7 +9268,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "futures",
  "libc",
@@ -9298,7 +9298,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "chrono",
  "futures",
@@ -9317,7 +9317,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "ansi_term",
  "atty",
@@ -9346,7 +9346,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
@@ -9357,7 +9357,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "futures",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "futures",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-channel",
  "futures",
@@ -9957,7 +9957,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "hash-db",
  "log",
@@ -9978,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -9992,7 +9992,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "23.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10005,7 +10005,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "16.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.17",
@@ -10019,7 +10019,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -10030,7 +10030,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "futures",
  "log",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "futures",
@@ -10063,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10080,7 +10080,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10099,7 +10099,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -10117,7 +10117,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10129,7 +10129,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "21.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "array-bytes 6.2.2",
  "bandersnatch_vrfs",
@@ -10176,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "9.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -10189,7 +10189,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "9.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "quote",
  "sp-core-hashing",
@@ -10199,7 +10199,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -10208,7 +10208,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "8.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10218,7 +10218,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.19.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -10229,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.1.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "serde_json",
  "sp-api",
@@ -10240,7 +10240,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -10254,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "23.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "bytes",
  "ed25519-dalek",
@@ -10278,7 +10278,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "24.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -10289,7 +10289,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.27.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -10301,7 +10301,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.1.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -10321,7 +10321,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.1.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -10343,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "8.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -10353,7 +10353,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -10363,7 +10363,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "24.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -10385,7 +10385,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "17.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -10403,7 +10403,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.1.3",
@@ -10415,7 +10415,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10430,7 +10430,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -10444,7 +10444,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.28.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "hash-db",
  "log",
@@ -10465,7 +10465,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.1",
@@ -10489,12 +10489,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "8.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 
 [[package]]
 name = "sp-storage"
 version = "13.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10507,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "10.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -10532,7 +10532,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -10541,7 +10541,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10556,7 +10556,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "22.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "ahash 0.8.6",
  "hash-db",
@@ -10580,7 +10580,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "22.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10597,7 +10597,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "8.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -10608,7 +10608,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "14.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -10621,7 +10621,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "20.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11118,12 +11118,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -11142,7 +11142,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "hyper",
  "log",
@@ -11154,7 +11154,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -11811,7 +11811,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=features/add_block_builder_extrinsic_getters#8bbd543e77b811e63412d3d6b47dc4d212f5fe77"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3347,7 +3347,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3370,7 +3370,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3395,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.2",
@@ -3443,7 +3443,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3473,7 +3473,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "futures",
  "indicatif",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "aquamarine",
  "bitflags 1.3.2",
@@ -3534,7 +3534,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.1.3",
@@ -3565,7 +3565,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3575,7 +3575,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "cfg-if",
  "frame-support",
@@ -3594,7 +3594,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3609,7 +3609,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6800,7 +6800,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6817,7 +6817,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6831,7 +6831,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6854,7 +6854,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6927,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8412,7 +8412,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "log",
  "sp-core",
@@ -8423,7 +8423,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8446,7 +8446,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -8462,7 +8462,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -8481,7 +8481,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
@@ -8492,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "array-bytes 6.2.2",
  "chrono",
@@ -8532,7 +8532,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "fnv",
  "futures",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -8585,7 +8585,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "futures",
@@ -8610,7 +8610,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "futures",
@@ -8639,7 +8639,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -8674,7 +8674,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -8687,7 +8687,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "ahash 0.8.6",
  "array-bytes 6.2.2",
@@ -8728,7 +8728,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -8763,7 +8763,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "futures",
@@ -8786,7 +8786,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -8808,7 +8808,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -8820,7 +8820,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8838,7 +8838,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "ansi_term",
  "futures",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "array-bytes 6.2.2",
  "parking_lot 0.12.1",
@@ -8868,7 +8868,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.1.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "array-bytes 4.2.0",
  "arrayvec 0.7.4",
@@ -8896,7 +8896,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel",
@@ -8937,7 +8937,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-channel",
  "cid",
@@ -8957,7 +8957,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -8974,7 +8974,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "ahash 0.8.6",
  "futures",
@@ -8992,7 +8992,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel",
@@ -9013,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel",
@@ -9048,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "array-bytes 6.2.2",
  "futures",
@@ -9066,7 +9066,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "array-bytes 6.2.2",
  "bytes",
@@ -9100,7 +9100,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -9109,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9141,7 +9141,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9161,7 +9161,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -9176,7 +9176,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "array-bytes 6.2.2",
  "futures",
@@ -9204,7 +9204,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "directories",
@@ -9268,7 +9268,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "futures",
  "libc",
@@ -9298,7 +9298,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "chrono",
  "futures",
@@ -9317,7 +9317,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -9346,7 +9346,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
@@ -9357,7 +9357,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "futures",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "futures",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-channel",
  "futures",
@@ -9957,7 +9957,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "hash-db",
  "log",
@@ -9978,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -9992,7 +9992,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "23.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10005,7 +10005,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "16.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.17",
@@ -10019,7 +10019,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -10030,7 +10030,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "futures",
  "log",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "futures",
@@ -10063,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10080,7 +10080,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10099,7 +10099,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -10117,7 +10117,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10129,7 +10129,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "21.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "array-bytes 6.2.2",
  "bandersnatch_vrfs",
@@ -10176,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "9.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -10189,7 +10189,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "9.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "quote",
  "sp-core-hashing",
@@ -10199,7 +10199,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -10208,7 +10208,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "8.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10218,7 +10218,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.19.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -10229,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.1.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "serde_json",
  "sp-api",
@@ -10240,7 +10240,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -10254,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "23.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "bytes",
  "ed25519-dalek",
@@ -10278,7 +10278,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "24.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -10289,7 +10289,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.27.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -10301,7 +10301,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.1.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -10321,7 +10321,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.1.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -10343,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "8.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -10353,7 +10353,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -10363,7 +10363,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "24.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -10385,7 +10385,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "17.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -10403,7 +10403,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.1.3",
@@ -10415,7 +10415,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10430,7 +10430,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -10444,7 +10444,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.28.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "hash-db",
  "log",
@@ -10465,7 +10465,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.1",
@@ -10489,12 +10489,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "8.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 
 [[package]]
 name = "sp-storage"
 version = "13.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10507,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "10.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -10532,7 +10532,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -10541,7 +10541,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10556,7 +10556,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "22.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "ahash 0.8.6",
  "hash-db",
@@ -10580,7 +10580,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "22.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10597,7 +10597,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "8.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -10608,7 +10608,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "14.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -10621,7 +10621,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "20.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11118,12 +11118,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -11142,7 +11142,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "hyper",
  "log",
@@ -11154,7 +11154,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -11811,7 +11811,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/massalabs/polkadot-sdk?rev=a06318619a31bb7ff1a74fcba021a584c84c579b#a06318619a31bb7ff1a74fcba021a584c84c579b"
+source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#085c7b6d623984144585b8d730da5b40183dc26c"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,78 +81,78 @@ version = "0.8.0"
 
 [workspace.dependencies]
 # Substrate frame dependencies
-frame-executive = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-frame-support = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-frame-benchmarking = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-frame-benchmarking-cli = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-frame-system = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-frame-system-benchmarking = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-frame-system-rpc-runtime-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-frame-try-runtime = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-substrate-frame-rpc-system = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+frame-executive = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b"  }
+frame-support = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+frame-benchmarking = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+frame-benchmarking-cli = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+frame-system = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+frame-system-benchmarking = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+frame-system-rpc-runtime-api = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+frame-try-runtime = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+substrate-frame-rpc-system = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
 
 # Substrate primitives dependencies
-sp-core = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-std = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-io = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-runtime = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-consensus-aura = { git = "http://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-consensus = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-consensus-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-timestamp = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-inherents = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-keyring = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-blockchain = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-block-builder = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-offchain = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-session = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-transaction-pool = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-version = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-database = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-arithmetic = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-storage = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-state-machine = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-statement-store = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-trie = { version = "22.0.0", git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-tracing = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-core = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-std = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-io = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-runtime = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-consensus-aura = { git = "http://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-consensus = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-consensus-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-timestamp = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-inherents = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-keyring = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-api = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-blockchain = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-block-builder = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-offchain = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-session = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-transaction-pool = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-version = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-database = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-arithmetic = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-storage = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-state-machine = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-statement-store = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-trie = { version = "22.0.0", git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-tracing = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
 
 # Substrate client dependencies
-sc-client-db = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-network = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-network-common = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-network-sync = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-consensus = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-client-db = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-network = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-network-common = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-network-sync = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-consensus = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
 # For integration tests in order to create blocks on demand
-sc-consensus-manual-seal = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-consensus-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-rpc = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-rpc-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-basic-authorship = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-client-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-cli = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-executor = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-service = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-telemetry = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-keystore = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-transaction-pool = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-transaction-pool-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-offchain = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-consensus-aura = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-block-builder = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-proposer-metrics = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-utils = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-substrate-test-runtime-client = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-consensus-manual-seal = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-consensus-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-rpc = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-rpc-api = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-basic-authorship = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-client-api = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-cli = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-executor = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-service = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-telemetry = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-keystore = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-transaction-pool = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-transaction-pool-api = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-offchain = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-consensus-aura = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-block-builder = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-proposer-metrics = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-utils = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+substrate-test-runtime-client = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
 
 
 # Substrate build & tools dependencies
-substrate-build-script-utils = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+substrate-build-script-utils = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
 
 # Substrate Frame pallet
-pallet-aura = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-pallet-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-pallet-timestamp = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+pallet-aura = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+pallet-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+pallet-timestamp = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
 
 # Madara pallets
 pallet-starknet = { path = "crates/pallets/starknet" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,78 +81,78 @@ version = "0.8.0"
 
 [workspace.dependencies]
 # Substrate frame dependencies
-frame-executive = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std"  }
-frame-support = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-frame-benchmarking = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-frame-benchmarking-cli = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-frame-system = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-frame-system-benchmarking = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-frame-system-rpc-runtime-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-frame-try-runtime = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-substrate-frame-rpc-system = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+frame-executive = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters"  }
+frame-support = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+frame-benchmarking = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+frame-benchmarking-cli = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+frame-system = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+frame-system-benchmarking = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+frame-system-rpc-runtime-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+frame-try-runtime = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+substrate-frame-rpc-system = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
 
 # Substrate primitives dependencies
-sp-core = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-std = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-io = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-runtime = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-consensus-aura = { git = "http://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-consensus = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-consensus-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-timestamp = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-inherents = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-keyring = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-blockchain = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-block-builder = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-offchain = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-session = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-transaction-pool = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-version = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-database = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-arithmetic = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-storage = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-state-machine = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-statement-store = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-trie = { version = "22.0.0", git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sp-tracing = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-core = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-std = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-io = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-runtime = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-consensus-aura = { git = "http://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-consensus = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-consensus-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-timestamp = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-inherents = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-keyring = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-blockchain = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-block-builder = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-offchain = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-session = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-transaction-pool = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-version = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-database = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-arithmetic = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-storage = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-state-machine = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-statement-store = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-trie = { version = "22.0.0", git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sp-tracing = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
 
 # Substrate client dependencies
-sc-client-db = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-network = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-network-common = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-network-sync = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-consensus = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-client-db = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-network = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-network-common = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-network-sync = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-consensus = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
 # For integration tests in order to create blocks on demand
-sc-consensus-manual-seal = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-consensus-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-rpc = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-rpc-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-basic-authorship = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-client-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-cli = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-executor = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-service = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-telemetry = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-keystore = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-transaction-pool = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-transaction-pool-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-offchain = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-consensus-aura = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-block-builder = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-proposer-metrics = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-sc-utils = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-substrate-test-runtime-client = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-consensus-manual-seal = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-consensus-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-rpc = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-rpc-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-basic-authorship = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-client-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-cli = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-executor = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-service = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-telemetry = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-keystore = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-transaction-pool = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-transaction-pool-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-offchain = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-consensus-aura = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-block-builder = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-proposer-metrics = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+sc-utils = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+substrate-test-runtime-client = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
 
 
 # Substrate build & tools dependencies
-substrate-build-script-utils = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+substrate-build-script-utils = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
 
 # Substrate Frame pallet
-pallet-aura = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-pallet-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
-pallet-timestamp = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+pallet-aura = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+pallet-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
+pallet-timestamp = { git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
 
 # Madara pallets
 pallet-starknet = { path = "crates/pallets/starknet" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,78 +81,78 @@ version = "0.8.0"
 
 [workspace.dependencies]
 # Substrate frame dependencies
-frame-executive = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b"  }
-frame-support = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-frame-benchmarking = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-frame-benchmarking-cli = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-frame-system = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-frame-system-benchmarking = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-frame-system-rpc-runtime-api = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-frame-try-runtime = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-substrate-frame-rpc-system = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+frame-executive = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std"  }
+frame-support = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+frame-benchmarking = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+frame-benchmarking-cli = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+frame-system = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+frame-system-benchmarking = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+frame-system-rpc-runtime-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+frame-try-runtime = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+substrate-frame-rpc-system = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
 
 # Substrate primitives dependencies
-sp-core = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-std = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-io = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-runtime = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-consensus-aura = { git = "http://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-consensus = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-consensus-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-timestamp = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-inherents = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-keyring = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-api = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-blockchain = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-block-builder = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-offchain = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-session = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-transaction-pool = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-version = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-database = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-arithmetic = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-storage = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-state-machine = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-statement-store = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-trie = { version = "22.0.0", git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sp-tracing = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sp-core = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-std = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-io = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-runtime = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-consensus-aura = { git = "http://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-consensus = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-consensus-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-timestamp = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-inherents = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-keyring = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-blockchain = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-block-builder = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-offchain = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-session = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-transaction-pool = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-version = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-database = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-arithmetic = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-storage = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-state-machine = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-statement-store = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-trie = { version = "22.0.0", git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sp-tracing = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
 
 # Substrate client dependencies
-sc-client-db = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-network = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-network-common = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-network-sync = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-consensus = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-client-db = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-network = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-network-common = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-network-sync = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-consensus = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
 # For integration tests in order to create blocks on demand
-sc-consensus-manual-seal = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-consensus-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-rpc = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-rpc-api = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-basic-authorship = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-client-api = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-cli = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-executor = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-service = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-telemetry = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-keystore = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-transaction-pool = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-transaction-pool-api = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-offchain = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-consensus-aura = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-block-builder = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-proposer-metrics = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-sc-utils = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-substrate-test-runtime-client = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+sc-consensus-manual-seal = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-consensus-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-rpc = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-rpc-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-basic-authorship = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-client-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-cli = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-executor = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-service = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-telemetry = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-keystore = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-transaction-pool = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-transaction-pool-api = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-offchain = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-consensus-aura = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-block-builder = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-proposer-metrics = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+sc-utils = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+substrate-test-runtime-client = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
 
 
 # Substrate build & tools dependencies
-substrate-build-script-utils = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+substrate-build-script-utils = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
 
 # Substrate Frame pallet
-pallet-aura = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-pallet-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
-pallet-timestamp = { git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+pallet-aura = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+pallet-grandpa = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+pallet-timestamp = { git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
 
 # Madara pallets
 pallet-starknet = { path = "crates/pallets/starknet" }

--- a/crates/client/rpc/Cargo.toml
+++ b/crates/client/rpc/Cargo.toml
@@ -22,6 +22,7 @@ mc-genesis-data-provider = { workspace = true }
 mc-rpc-core = { workspace = true }
 mc-storage = { workspace = true }
 pallet-starknet-runtime-api = { workspace = true }
+sc-block-builder = { workspace = true }
 sc-transaction-pool = { workspace = true }
 sc-transaction-pool-api = { workspace = true }
 sp-api = { workspace = true }

--- a/crates/client/rpc/src/madara_routes.rs
+++ b/crates/client/rpc/src/madara_routes.rs
@@ -1,5 +1,6 @@
 use jsonrpsee::core::{async_trait, RpcResult};
 use log::error;
+use sc_block_builder::GetPendingBlockExtrinsics;
 use mc_genesis_data_provider::GenesisProvider;
 pub use mc_rpc_core::{
     Felt, MadaraRpcApiServer, PredeployedAccountWithBalance, StarknetReadRpcApiServer, StarknetTraceRpcApiServer,
@@ -31,6 +32,7 @@ where
     BE: Backend<B> + 'static,
     C: HeaderBackend<B> + BlockBackend<B> + StorageProvider<B, BE> + 'static,
     C: ProvideRuntimeApi<B>,
+    C: GetPendingBlockExtrinsics<B>,
     G: GenesisProvider + Send + Sync + 'static,
     C::Api: StarknetRuntimeApi<B> + ConvertTransactionRuntimeApi<B>,
     P: TransactionPool<Block = B> + 'static,

--- a/crates/client/rpc/src/runtime_api.rs
+++ b/crates/client/rpc/src/runtime_api.rs
@@ -12,6 +12,7 @@ use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
 use mp_simulations::SimulationFlags;
 use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use sc_block_builder::GetPendingBlockExtrinsics;
 use sc_client_api::backend::Backend;
 use sc_transaction_pool::ChainApi;
 use sp_api::{ApiError, ProvideRuntimeApi};
@@ -32,6 +33,7 @@ where
     BE: Backend<B>,
     C: HeaderBackend<B> + 'static,
     C: ProvideRuntimeApi<B>,
+    C: GetPendingBlockExtrinsics<B>,
     C::Api: StarknetRuntimeApi<B> + ConvertTransactionRuntimeApi<B>,
     H: HasherT + Send + Sync + 'static,
 {

--- a/crates/client/rpc/src/starknetrpcwrapper.rs
+++ b/crates/client/rpc/src/starknetrpcwrapper.rs
@@ -9,6 +9,7 @@ pub use mc_rpc_core::{
 use mp_hashers::HasherT;
 use mp_transactions::{BroadcastedDeclareTransactionV0, TransactionStatus};
 use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use sc_block_builder::GetPendingBlockExtrinsics;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sc_transaction_pool::ChainApi;
@@ -44,6 +45,7 @@ where
     BE: Backend<B> + 'static,
     C: HeaderBackend<B> + BlockBackend<B> + StorageProvider<B, BE> + 'static,
     C: ProvideRuntimeApi<B>,
+    C: GetPendingBlockExtrinsics<B>,
     G: GenesisProvider + Send + Sync + 'static,
     C::Api: StarknetRuntimeApi<B> + ConvertTransactionRuntimeApi<B>,
     P: TransactionPool<Block = B> + 'static,
@@ -70,6 +72,7 @@ where
     BE: Backend<B> + 'static,
     C: HeaderBackend<B> + BlockBackend<B> + StorageProvider<B, BE> + 'static,
     C: ProvideRuntimeApi<B>,
+    C: GetPendingBlockExtrinsics<B>,
     C::Api: StarknetRuntimeApi<B> + ConvertTransactionRuntimeApi<B>,
     G: GenesisProvider + Send + Sync + 'static,
     H: HasherT + Send + Sync + 'static,
@@ -547,6 +550,7 @@ where
     BE: Backend<B> + 'static,
     C: HeaderBackend<B> + BlockBackend<B> + StorageProvider<B, BE> + 'static,
     C: ProvideRuntimeApi<B>,
+    C: GetPendingBlockExtrinsics<B>,
     C::Api: StarknetRuntimeApi<B> + ConvertTransactionRuntimeApi<B>,
     G: GenesisProvider + Send + Sync + 'static,
     H: HasherT + Send + Sync + 'static,
@@ -610,6 +614,7 @@ where
     BE: Backend<B> + 'static,
     C: HeaderBackend<B> + BlockBackend<B> + StorageProvider<B, BE> + 'static,
     C: ProvideRuntimeApi<B>,
+    C: GetPendingBlockExtrinsics<B>,
     C::Api: StarknetRuntimeApi<B> + ConvertTransactionRuntimeApi<B>,
     G: GenesisProvider + Send + Sync + 'static,
     H: HasherT + Send + Sync + 'static,

--- a/crates/client/rpc/src/trace_api.rs
+++ b/crates/client/rpc/src/trace_api.rs
@@ -17,6 +17,7 @@ use mp_transactions::from_broadcasted_transactions::{
 };
 use mp_transactions::{get_transaction_hash, TxType};
 use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use sc_block_builder::GetPendingBlockExtrinsics;
 use sc_client_api::{Backend, BlockBackend, StorageProvider};
 use sc_transaction_pool::ChainApi;
 use sc_transaction_pool_api::TransactionPool;
@@ -43,6 +44,7 @@ where
     G: GenesisProvider + Send + Sync + 'static,
     C: HeaderBackend<B> + BlockBackend<B> + StorageProvider<B, BE> + 'static,
     C: ProvideRuntimeApi<B>,
+    C: GetPendingBlockExtrinsics<B>,
     C::Api: StarknetRuntimeApi<B> + ConvertTransactionRuntimeApi<B>,
     P: TransactionPool<Block = B> + 'static,
     H: HasherT + Send + Sync + 'static,

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -102,7 +102,7 @@ blockifier = { workspace = true }
 # CLI-specific dependencies
 reqwest = { workspace = true, features = ["blocking"] }
 serde_json = { workspace = true }
-try-runtime-cli = { optional = true, git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
+try-runtime-cli = { optional = true, git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
 url = { workspace = true }
 
 [build-dependencies]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -102,7 +102,7 @@ blockifier = { workspace = true }
 # CLI-specific dependencies
 reqwest = { workspace = true, features = ["blocking"] }
 serde_json = { workspace = true }
-try-runtime-cli = { optional = true, git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+try-runtime-cli = { optional = true, git = "https://github.com/massalabs/polkadot-sdk", branch = "features/add_block_builder_extrinsic_getters" }
 url = { workspace = true }
 
 [build-dependencies]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -30,6 +30,7 @@ sha3 = { workspace = true }
 
 frame-system = { workspace = true }
 sc-basic-authorship = { workspace = true }
+sc-block-builder = { workspace = true }
 sc-cli = { workspace = true }
 sc-client-api = { workspace = true }
 sc-consensus = { workspace = true }
@@ -101,7 +102,7 @@ blockifier = { workspace = true }
 # CLI-specific dependencies
 reqwest = { workspace = true, features = ["blocking"] }
 serde_json = { workspace = true }
-try-runtime-cli = { optional = true, git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
+try-runtime-cli = { optional = true, git = "https://github.com/massalabs/polkadot-sdk", rev = "a06318619a31bb7ff1a74fcba021a584c84c579b" }
 url = { workspace = true }
 
 [build-dependencies]

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -14,6 +14,7 @@ use madara_runtime::opaque::Block;
 use madara_runtime::{AccountId, Hash, Index, StarknetHasher};
 use mc_genesis_data_provider::GenesisProvider;
 use mc_rpc::starknetrpcwrapper::StarknetRpcWrapper;
+use sc_block_builder::GetPendingBlockExtrinsics;
 use sc_client_api::{Backend, BlockBackend, StorageProvider};
 use sc_consensus_manual_seal::rpc::EngineCommand;
 pub use sc_rpc_api::DenyUnsafe;
@@ -51,6 +52,7 @@ where
         + BlockBackend<Block>
         + HeaderMetadata<Block, Error = BlockChainError>
         + StorageProvider<Block, BE>
+        + GetPendingBlockExtrinsics<Block>
         + 'static,
     C: Send + Sync + 'static,
     C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,


### PR DESCRIPTION
Fix retrieving pending transactions

# Pull Request type

- Bugfix

## What is the current behavior?

When retrieving pending transactions using RPC call, every transactions in transactionPool are retrieved.

Resolves: #NA

## What is the new behavior?

Now, only the transactions added by the BlockBuilder in order to create the next futur bllck are retrieved.

## Does this introduce a breaking change?

No

## Other information

N/A